### PR TITLE
Phase 4: collect TED procurement signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The product is designed to answer:
 
 ## Current implementation status
 
-The repository contains an executable foundation, a durable collection pipeline, and the first live opportunity workflow:
+The repository contains an executable foundation, a durable collection pipeline, real official-source adapters, and the first live opportunity workflow:
 
 - FastAPI application factory, source-governance endpoints, and opportunity list/detail/action APIs;
 - framework-independent domain modules for organizations, evidence, cyber events, raw observations, opportunity scoring, retention, suppression, source accounts, product metrics, collection orchestration, and analyst-reviewed opportunities;
@@ -23,8 +23,10 @@ The repository contains an executable foundation, a durable collection pipeline,
 - executable retention rules;
 - machine-readable source and collection-schedule registries;
 - an official CISA KEV feed adapter with conditional HTTP requests, size/type checks, strict schemas, checkpoints, provenance, and network-free tests;
+- an official anonymous TED Search API adapter for active European SIEM/SOC procurement notices, with selected-field retrieval, local defensive filtering, deterministic buyer/evidence/signal mapping, checkpoints, and direct Opportunity Inbox projection;
 - durable collection jobs with deterministic idempotency keys, leases, retries, bounded exponential backoff, circuit breakers, dead letters, and recovery after interruption;
 - atomic observation/checkpoint/job completion and observation deduplication;
+- transactional commercial projection: a collection job cannot be marked successful if organization, evidence, signal, or opportunity persistence fails;
 - source freshness, queue lag, error, dead-letter, and volume metrics;
 - separate `cip-scheduler` and `cip-worker` process entry points;
 - normalized commercial signals, need hypotheses, evidence links, and persistent opportunity lifecycle;
@@ -38,14 +40,14 @@ The repository contains an executable foundation, a durable collection pipeline,
 
 Not yet implemented:
 
-- production adapters that produce the MVP tender and job-posting commercial signals, such as BOAMP, TED, or authorized careers/ATS sources;
+- BOAMP, DECP, careers/ATS, or other production commercial-signal adapters beyond TED;
 - Chromium/browser workers and download quarantine runtime;
 - named professional-contact enrichment and organization-chart workflows;
 - OpenSearch, Redis, object storage, CRM integration, or autonomous outreach;
 - active LinkedIn collection;
 - any executable BrixHub integration.
 
-The live opportunity pipeline currently consumes normalized commercial signals. It does not claim that BOAMP, TED, job boards, LinkedIn, or other future sources are already connected.
+The live opportunity pipeline can now receive real TED public-tender signals. It does not claim that BOAMP, DECP, job boards, LinkedIn, or other future sources are already connected.
 
 Redis is not required for the current durable queue: PostgreSQL owns scheduling, locking, leases, checkpoints, and recovery. Redis should be introduced only when measured throughput or coordination requirements justify it.
 
@@ -86,7 +88,7 @@ cip-scheduler
 cip-worker
 ```
 
-The scheduler reads `policies/collection_schedules.yml`, synchronizes the authorized source registry, and creates at most one active job per source/adapter. The worker claims jobs with a bounded lease, performs source access outside the database transaction, and commits observations, checkpoint advancement, and job completion atomically.
+The scheduler reads `policies/collection_schedules.yml`, synchronizes the authorized source registry, and creates at most one active job per source/adapter. The worker claims jobs with a bounded lease, performs source access outside the database transaction, and commits observations, checkpoints, job completion, and commercial projections atomically.
 
 Start the UI separately:
 
@@ -97,7 +99,7 @@ npm install
 npm run dev
 ```
 
-The API is available on `http://127.0.0.1:8000` by default. The Next.js server uses `CIP_API_BASE_URL` to load and update the Opportunity Inbox. With no commercial signals in PostgreSQL, the UI displays an explicit empty state rather than synthetic records.
+The API is available on `http://127.0.0.1:8000` by default. The Next.js server uses `CIP_API_BASE_URL` to load and update the Opportunity Inbox. With no matching commercial signals in PostgreSQL, the UI displays an explicit empty state rather than synthetic records.
 
 ## Validation
 
@@ -118,7 +120,7 @@ npm run typecheck
 npm run build
 ```
 
-The live-opportunity phase was independently validated with 256 passing tests and 94.94% combined line-and-branch coverage. Mypy strict passed on 94 source files, migration `0004` passed the PostgreSQL upgrade/downgrade/upgrade cycle, and the Next.js audit, typecheck, and production build passed.
+The TED commercial-adapter phase was independently validated with 275 passing tests and 94.42% combined line-and-branch coverage. Mypy strict passed on 101 source files, the PostgreSQL upgrade/downgrade/upgrade cycle passed, the TED orchestration adapter reached 100% coverage, and the Next.js audit, typecheck, and production build passed.
 
 ## Architecture
 
@@ -144,7 +146,7 @@ policies/
 
 tests/
   unit/                        domain, adapter, governance, persistence, and recovery tests
-  integration/                 persisted signal-to-opportunity workflows
+  integration/                 persisted source-to-opportunity workflows
 ```
 
 ## Durable collection lifecycle
@@ -157,12 +159,12 @@ source registry synchronization
 -> bounded worker lease
 -> policy-checked source collection
 -> validation and raw-observation mapping
--> atomic observation insert + checkpoint advance + job completion
+-> atomic observation + checkpoint + commercial projection + job completion
 -> retry/circuit breaker/dead letter on failure
 -> freshness and queue metrics
 ```
 
-A replayed schedule slot cannot create a duplicate job. A replayed observation cannot create a duplicate raw record. If execution stops before the completion transaction commits, the previous checkpoint remains authoritative. A worker whose lease expired cannot commit a late result.
+A replayed schedule slot cannot create a duplicate job. A replayed observation cannot create a duplicate raw record. If execution stops before the completion transaction commits, the previous checkpoint remains authoritative. A worker whose lease expired cannot commit a late result. A TED job is not successful unless its buyer organization, evidence, commercial signal, and resulting opportunity are also persisted.
 
 ## Opportunity lifecycle
 
@@ -195,7 +197,7 @@ official API
 -> manual import
 ```
 
-The current executable source adapter uses the official CISA KEV JSON feed. Chromium is intentionally deferred until API and static-HTTP acquisition, normalization, provenance, and value metrics are stable.
+The current executable adapters use the official CISA KEV JSON feed and the official TED Search API. Chromium is intentionally deferred until API and static-HTTP acquisition, normalization, provenance, and value metrics are stable.
 
 CAPTCHA, bot challenges, MFA, changed terms, or account-security prompts must produce a safe pause and human task. They are not automatically bypassed. Temporary-account rotation, copied cookies, CAPTCHA-solving services, and access-control circumvention are out of scope.
 
@@ -227,7 +229,7 @@ L7 commercial opportunity
 L8 UI and search read models
 ```
 
-The CISA adapter currently implements L0 through L1. The live SIEM/SOC workflow implements L5 through L8 for normalized commercial signals. Future tender and job adapters must implement L0 through L5 and cannot bypass source governance, evidence provenance, or entity resolution.
+The CISA adapter currently implements L0 through L1. The TED adapter implements L0 through L5 and feeds the live SIEM/SOC workflow, which implements L5 through L8. Future sources cannot bypass source governance, evidence provenance, deterministic identifiers, or entity-resolution controls.
 
 ## Code and test standards
 
@@ -238,7 +240,7 @@ The CISA adapter currently implements L0 through L1. The live SIEM/SOC workflow 
 - source adapters never resolve organizations or calculate opportunities;
 - scores are calculated by the domain and include a reproducible hash;
 - timestamps must be timezone-aware;
-- every adapter requires policy-denial, schema, mapping, checkpoint, and failure tests;
+- every adapter requires policy-denial, schema, mapping, checkpoint, HTTP classification, and failure tests;
 - backend line and branch coverage must remain at least 90%;
 - critical policy and scoring modules target 95%.
 

--- a/policies/collection_schedules.yml
+++ b/policies/collection_schedules.yml
@@ -12,3 +12,15 @@ schedules:
       max_delay_seconds: 900
       circuit_failure_threshold: 3
       circuit_reset_seconds: 900
+
+  - source_id: ted-search
+    adapter_id: ted-search-api
+    enabled: true
+    interval_seconds: 1800
+    lease_seconds: 120
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 60
+      max_delay_seconds: 1800
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 1800

--- a/policies/sources.example.yml
+++ b/policies/sources.example.yml
@@ -1,5 +1,5 @@
 version: 1
-reviewed_at: 2026-08-03
+reviewed_at: 2026-08-04
 
 sources:
   - id: cisa-kev
@@ -42,6 +42,52 @@ sources:
       implementation_cost: low
       maintenance_cost: low
       expected_stability: high
+
+  - id: ted-search
+    name: TED Search API
+    base_url: https://api.ted.europa.eu/v3/notices/search
+    status: enabled
+    source_type: api
+    owner: Publications Office of the European Union
+    terms_url: https://ted.europa.eu/en/legal-notice
+    licence: European Commission reuse policy
+    allowed_data_categories:
+      - public_tender
+      - organization_metadata
+    prohibited_data_categories:
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 2
+    retention_days: 730
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: ted-search-api-public-reuse-2026-08-04
+      reviewed_at: 2026-08-04T09:35:00Z
+      expires_at: null
+      approved_hosts:
+        - api.ted.europa.eu
+      approved_path_prefixes:
+        - /v3/notices/search
+      approved_purposes:
+        - procurement-intelligence
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: high
+    notes: >-
+      Uses the anonymous official Search API with selected metadata fields only.
+      Full notice documents are not stored. Results are re-filtered locally before
+      an evidence-backed commercial signal can be created.
 
   - id: search-manual-review
     name: Search-engine analyst review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cyber-intelligence-platform"
-version = "0.4.0"
+version = "0.5.0"
 description = "Human-operated cyber revenue intelligence and opportunity platform"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"

--- a/src/cip/adapters/sources/ted_search/__init__.py
+++ b/src/cip/adapters/sources/ted_search/__init__.py
@@ -1,0 +1,1 @@
+"""Official TED Search API adapter."""

--- a/src/cip/adapters/sources/ted_search/client.py
+++ b/src/cip/adapters/sources/ted_search/client.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+class TedSourceResponseError(RuntimeError):
+    """TED returned an unsafe or unusable response."""
+
+
+@dataclass(frozen=True, slots=True)
+class TedSearchCheckpoint:
+    latest_publication_number: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TedSearchFetchResult:
+    body: bytes
+
+
+class TedSearchClient:
+    MAX_RESPONSE_BYTES = 5_000_000
+    DEFAULT_LIMIT = 100
+    SEARCH_FIELDS = (
+        "publication-number",
+        "notice-title",
+        "buyer-name",
+        "buyer-country",
+        "publication-date",
+        "deadline-receipt-tender-date-lot",
+        "classification-cpv",
+        "notice-type",
+    )
+    SEARCH_QUERY = (
+        'FT=(siem OR soc OR cybersecurity OR "cyber security" OR cybersecurite '
+        'OR cybersécurité OR xdr OR mdr OR "security operations center")'
+    )
+
+    def __init__(self, client: httpx.Client, *, search_url: str) -> None:
+        self._client = client
+        self._search_url = search_url
+
+    def fetch(self) -> TedSearchFetchResult:
+        response = self._client.post(
+            self._search_url,
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            json={
+                "query": self.SEARCH_QUERY,
+                "fields": list(self.SEARCH_FIELDS),
+                "limit": self.DEFAULT_LIMIT,
+                "scope": "ACTIVE",
+                "checkQuerySyntax": False,
+                "paginationMode": "PAGE_NUMBER",
+                "page": 1,
+                "onlyLatestVersions": True,
+            },
+        )
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return TedSearchFetchResult(body=response.content)
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    if content_type != "application/json":
+        raise TedSourceResponseError(f"unexpected content type: {content_type or 'missing'}")
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise TedSourceResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise TedSourceResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise TedSourceResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/ted_search/collector.py
+++ b/src/cip/adapters/sources/ted_search/collector.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.ted_search.client import (
+    TedSearchCheckpoint,
+    TedSearchClient,
+)
+from cip.adapters.sources.ted_search.mapper import map_ted_notice
+from cip.adapters.sources.ted_search.schemas import TedSearchResponse
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class TedCollectionDeniedError(RuntimeError):
+    """Source governance denied TED collection."""
+
+
+class TedSourceSchemaError(RuntimeError):
+    """TED payload no longer matches the approved selected-field schema."""
+
+
+@dataclass(frozen=True, slots=True)
+class TedCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    projections: tuple[CommercialProjection, ...]
+    checkpoint: TedSearchCheckpoint
+    not_modified: bool
+
+
+def collect_ted_notices(
+    client: TedSearchClient,
+    entry: SourceRegistryEntry,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: TedSearchCheckpoint | None = None,
+) -> TedCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_TENDER,
+            target_url=entry.policy.base_url,
+            purpose="procurement-intelligence",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected,
+    )
+    if not decision.allowed:
+        raise TedCollectionDeniedError(decision.reason.value)
+    try:
+        response = TedSearchResponse.model_validate_json(client.fetch().body)
+    except ValidationError as exc:
+        raise TedSourceSchemaError("TED search schema validation failed") from exc
+
+    latest = response.notices[0].publication_number if response.notices else None
+    observations: list[RawObservation] = []
+    projections: list[CommercialProjection] = []
+    previous = checkpoint.latest_publication_number if checkpoint else None
+    for notice in response.notices:
+        if previous is not None and notice.publication_number == previous:
+            break
+        mapped = map_ted_notice(
+            notice,
+            collection_job_id=collection_job_id,
+            collected_at=collected,
+            retention_until=retention_until,
+        )
+        if mapped is not None:
+            observation, projection = mapped
+            observations.append(observation)
+            projections.append(projection)
+    next_checkpoint = TedSearchCheckpoint(
+        latest_publication_number=latest or previous,
+    )
+    not_modified = bool(previous is not None and latest == previous)
+    return TedCollectionBatch(
+        observations=tuple(observations),
+        projections=tuple(projections),
+        checkpoint=next_checkpoint,
+        not_modified=not_modified,
+    )

--- a/src/cip/adapters/sources/ted_search/mapper.py
+++ b/src/cip/adapters/sources/ted_search/mapper.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from hashlib import sha256
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from cip.adapters.sources.ted_search.schemas import TedNotice
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.evidence.domain.entities import Evidence
+from cip.modules.opportunities.domain.entities import CommercialSignal, SignalType
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.shared.kernel.time import require_aware_utc
+
+ADAPTER_ID = "ted-search-api"
+ADAPTER_VERSION = "1.0.0"
+SOURCE_ID = "ted-search"
+SIGNAL_TERMS = (
+    "siem",
+    "soc",
+    "security operations center",
+    "cybersecurity",
+    "cyber security",
+    "cybersécurité",
+    "cybersecurite",
+    "managed detection and response",
+    "mdr",
+    "xdr",
+    "security monitoring",
+)
+COUNTRY_CODES = {
+    "AUT": "AT", "BEL": "BE", "BGR": "BG", "HRV": "HR", "CYP": "CY",
+    "CZE": "CZ", "DNK": "DK", "EST": "EE", "FIN": "FI", "FRA": "FR",
+    "DEU": "DE", "GRC": "GR", "HUN": "HU", "IRL": "IE", "ITA": "IT",
+    "LVA": "LV", "LTU": "LT", "LUX": "LU", "MLT": "MT", "NLD": "NL",
+    "POL": "PL", "PRT": "PT", "ROU": "RO", "SVK": "SK", "SVN": "SI",
+    "ESP": "ES", "SWE": "SE", "NOR": "NO", "ISL": "IS", "CHE": "CH",
+}
+
+
+def map_ted_notice(
+    notice: TedNotice,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> tuple[RawObservation, CommercialProjection] | None:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    title = notice.title()
+    matched_terms = _matched_terms(title)
+    if not matched_terms:
+        return None
+    buyer = notice.buyer()
+    country = COUNTRY_CODES.get(notice.country() or "")
+    notice_url = f"https://ted.europa.eu/en/notice/{notice.publication_number}/html"
+    payload = notice.model_dump(mode="json", by_alias=True)
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    payload_hash = sha256(payload_bytes).hexdigest()
+    published_at = _aware(notice.publication_timestamp())
+    deadline = _aware(notice.deadline_timestamp())
+    usable_deadline = deadline if deadline is not None and deadline > collected else None
+    organization_id = uuid5(
+        NAMESPACE_URL,
+        f"ted:buyer:{country or 'unknown'}:{' '.join(buyer.casefold().split())}",
+    )
+    evidence_id = uuid5(NAMESPACE_URL, f"ted:notice:{notice.publication_number}")
+    summary = _summary(title, buyer, usable_deadline)
+    organization = Organization(
+        id=organization_id,
+        canonical_name=buyer,
+        legal_name=buyer,
+        country_code=country,
+        created_at=collected,
+        updated_at=collected,
+    )
+    evidence = Evidence(
+        id=evidence_id,
+        source_id=SOURCE_ID,
+        source_record_key=notice.publication_number,
+        source_url=notice_url,
+        summary=summary,
+        confidence=0.9,
+        collected_at=collected,
+        published_at=published_at,
+        content_hash_sha256=payload_hash,
+        raw_storage_permitted=False,
+        retention_until=retention_until,
+    )
+    signal = CommercialSignal(
+        id=uuid5(NAMESPACE_URL, f"ted:signal:{notice.publication_number}"),
+        organization_id=organization_id,
+        evidence_id=evidence_id,
+        signal_type=SignalType.PUBLIC_TENDER,
+        title=title,
+        summary=summary,
+        confidence=0.9,
+        matched_terms=matched_terms,
+        published_at=published_at,
+        collected_at=collected,
+        expires_at=usable_deadline,
+        created_at=collected,
+    )
+    observation = RawObservation(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        collection_job_id=collection_job_id,
+        source_record_type="procurement_notice",
+        source_record_key=notice.publication_number,
+        source_url=notice_url,
+        payload_hash_sha256=payload_hash,
+        data_categories=frozenset({DataCategory.PUBLIC_TENDER}),
+        collected_at=collected,
+        published_at=published_at,
+        schema_fingerprint="ted-search-v3-selected-fields-1",
+        classification="internal",
+        retention_until=retention_until,
+    )
+    return observation, CommercialProjection(organization, evidence, signal)
+
+
+def _matched_terms(title: str) -> tuple[str, ...]:
+    normalized = title.casefold()
+    return tuple(term for term in SIGNAL_TERMS if term in normalized)
+
+
+def _summary(title: str, buyer: str, deadline: datetime | None) -> str:
+    result = f"TED public procurement notice from {buyer}: {title}."
+    if deadline is not None:
+        result += f" Response deadline: {deadline.isoformat()}."
+    return result
+
+
+def _aware(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/src/cip/adapters/sources/ted_search/mapper.py
+++ b/src/cip/adapters/sources/ted_search/mapper.py
@@ -31,12 +31,36 @@ SIGNAL_TERMS = (
     "security monitoring",
 )
 COUNTRY_CODES = {
-    "AUT": "AT", "BEL": "BE", "BGR": "BG", "HRV": "HR", "CYP": "CY",
-    "CZE": "CZ", "DNK": "DK", "EST": "EE", "FIN": "FI", "FRA": "FR",
-    "DEU": "DE", "GRC": "GR", "HUN": "HU", "IRL": "IE", "ITA": "IT",
-    "LVA": "LV", "LTU": "LT", "LUX": "LU", "MLT": "MT", "NLD": "NL",
-    "POL": "PL", "PRT": "PT", "ROU": "RO", "SVK": "SK", "SVN": "SI",
-    "ESP": "ES", "SWE": "SE", "NOR": "NO", "ISL": "IS", "CHE": "CH",
+    "AUT": "AT",
+    "BEL": "BE",
+    "BGR": "BG",
+    "CHE": "CH",
+    "CYP": "CY",
+    "CZE": "CZ",
+    "DEU": "DE",
+    "DNK": "DK",
+    "ESP": "ES",
+    "EST": "EE",
+    "FIN": "FI",
+    "FRA": "FR",
+    "GRC": "GR",
+    "HRV": "HR",
+    "HUN": "HU",
+    "IRL": "IE",
+    "ISL": "IS",
+    "ITA": "IT",
+    "LTU": "LT",
+    "LUX": "LU",
+    "LVA": "LV",
+    "MLT": "MT",
+    "NLD": "NL",
+    "NOR": "NO",
+    "POL": "PL",
+    "PRT": "PT",
+    "ROU": "RO",
+    "SVK": "SK",
+    "SVN": "SI",
+    "SWE": "SE",
 }
 
 
@@ -56,7 +80,11 @@ def map_ted_notice(
     country = COUNTRY_CODES.get(notice.country() or "")
     notice_url = f"https://ted.europa.eu/en/notice/{notice.publication_number}/html"
     payload = notice.model_dump(mode="json", by_alias=True)
-    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    payload_bytes = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
     payload_hash = sha256(payload_bytes).hexdigest()
     published_at = _aware(notice.publication_timestamp())
     deadline = _aware(notice.deadline_timestamp())

--- a/src/cip/adapters/sources/ted_search/schemas.py
+++ b/src/cip/adapters/sources/ted_search/schemas.py
@@ -77,20 +77,20 @@ def _flatten_text(value: object) -> list[str]:
         stripped = value.strip()
         return [stripped] if stripped else []
     if isinstance(value, list):
-        result: list[str] = []
+        list_values: list[str] = []
         for item in value:
-            result.extend(_flatten_text(item))
-        return result
+            list_values.extend(_flatten_text(item))
+        return list_values
     if isinstance(value, dict):
         preferred = ("eng", "en", "fra", "fr")
-        result: list[str] = []
+        localized_values: list[str] = []
         for key in preferred:
             if key in value:
-                result.extend(_flatten_text(value[key]))
+                localized_values.extend(_flatten_text(value[key]))
         for key, item in value.items():
             if key not in preferred:
-                result.extend(_flatten_text(item))
-        return result
+                localized_values.extend(_flatten_text(item))
+        return localized_values
     return []
 
 

--- a/src/cip/adapters/sources/ted_search/schemas.py
+++ b/src/cip/adapters/sources/ted_search/schemas.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class TedNotice(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    publication_number: str = Field(alias="publication-number", min_length=1, max_length=64)
+    notice_title: object = Field(alias="notice-title")
+    buyer_name: object = Field(alias="buyer-name")
+    buyer_country: object | None = Field(default=None, alias="buyer-country")
+    publication_date: date | datetime | str | None = Field(
+        default=None,
+        alias="publication-date",
+    )
+    deadline: object | None = Field(
+        default=None,
+        alias="deadline-receipt-tender-date-lot",
+    )
+    classification_cpv: list[str] = Field(
+        default_factory=list,
+        alias="classification-cpv",
+    )
+    notice_type: object | None = Field(default=None, alias="notice-type")
+
+    @field_validator("notice_title", "buyer_name")
+    @classmethod
+    def require_textual_value(cls, value: object) -> object:
+        if not _flatten_text(value):
+            raise ValueError("localized field must contain text")
+        return value
+
+    def title(self) -> str:
+        return _first_text(self.notice_title)
+
+    def buyer(self) -> str:
+        return _first_text(self.buyer_name)
+
+    def country(self) -> str | None:
+        values = _flatten_text(self.buyer_country)
+        if not values:
+            return None
+        country = values[0].upper()
+        return country if len(country) == 3 else None
+
+    def publication_timestamp(self) -> datetime | None:
+        return _parse_datetime(self.publication_date)
+
+    def deadline_timestamp(self) -> datetime | None:
+        candidates = (_parse_datetime(value) for value in _flatten_text(self.deadline))
+        return next((value for value in candidates if value is not None), None)
+
+
+class TedSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    notices: list[TedNotice] = Field(default_factory=list)
+    iteration_next_token: str | None = Field(default=None, alias="iterationNextToken")
+    total_notice_count: int | None = Field(default=None, alias="totalNoticeCount", ge=0)
+
+
+def _first_text(value: object) -> str:
+    values = _flatten_text(value)
+    if not values:
+        raise ValueError("localized field contains no text")
+    return values[0]
+
+
+def _flatten_text(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    if isinstance(value, list):
+        result: list[str] = []
+        for item in value:
+            result.extend(_flatten_text(item))
+        return result
+    if isinstance(value, dict):
+        preferred = ("eng", "en", "fra", "fr")
+        result: list[str] = []
+        for key in preferred:
+            if key in value:
+                result.extend(_flatten_text(value[key]))
+        for key, item in value.items():
+            if key not in preferred:
+                result.extend(_flatten_text(item))
+        return result
+    return []
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time())
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    if not normalized:
+        return None
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        try:
+            return datetime.strptime(normalized, "%Y%m%d")
+        except ValueError:
+            return None

--- a/src/cip/main.py
+++ b/src/cip/main.py
@@ -9,7 +9,7 @@ from cip.modules.source_governance.api.routes import router as source_governance
 def create_app() -> FastAPI:
     application = FastAPI(
         title="Cyber Intelligence Platform",
-        version="0.4.0",
+        version="0.5.0",
         description=(
             "Human-operated cyber revenue intelligence API with explicit source governance, "
             "provenance, and evidence-backed opportunity discovery."

--- a/src/cip/modules/collection_orchestration/application/ports.py
+++ b/src/cip/modules/collection_orchestration/application/ports.py
@@ -6,6 +6,9 @@ from datetime import datetime
 from typing import Protocol
 from uuid import UUID
 
+from cip.modules.evidence.domain.entities import Evidence
+from cip.modules.opportunities.domain.entities import CommercialSignal
+from cip.modules.organizations.domain.entities import Organization
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import DataCategory
 
@@ -18,10 +21,24 @@ class AdapterExecutionError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class CommercialProjection:
+    organization: Organization
+    evidence: Evidence
+    signal: CommercialSignal
+
+    def __post_init__(self) -> None:
+        if self.signal.organization_id != self.organization.id:
+            raise ValueError("signal organization must match projected organization")
+        if self.signal.evidence_id != self.evidence.id:
+            raise ValueError("signal evidence must match projected evidence")
+
+
+@dataclass(frozen=True, slots=True)
 class AdapterCollectionBatch:
     observations: tuple[RawObservation, ...]
     checkpoint_payload: Mapping[str, object]
     not_modified: bool
+    commercial_projections: tuple[CommercialProjection, ...] = ()
 
 
 class CollectionAdapter(Protocol):

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from cip.modules.collection_orchestration.application.adapters import CisaKevAdapter
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.collection_orchestration.application.scheduler import schedule_due_jobs
+from cip.modules.collection_orchestration.application.ted_adapter import TedSearchAdapter
 from cip.modules.collection_orchestration.application.worker import (
     WorkerOutcome,
     WorkerStatus,
@@ -25,7 +26,10 @@ from cip.modules.collection_orchestration.infrastructure.schedule_loader import 
 from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.data_governance.infrastructure.retention_loader import load_retention_policy
 from cip.modules.source_governance.infrastructure.persistence import sync_source_registry
-from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
 from cip.shared.config.settings import Settings
 from cip.shared.kernel.time import utc_now
 from cip.shared.persistence.session import (
@@ -51,15 +55,10 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
     entries = load_source_registry(settings.source_registry_path)
     with session_scope(factory) as session:
         sync_source_registry(session, entries)
-    entries_by_id = {entry.policy.id: entry for entry in entries}
-    adapters: dict[tuple[str, str], CollectionAdapter] = {}
-    cisa_entry = entries_by_id.get(CisaKevAdapter.source_id)
-    if cisa_entry is not None:
-        adapter = CisaKevAdapter(
-            cisa_entry,
-            timeout_seconds=settings.source_http_timeout_seconds,
-        )
-        adapters[(adapter.source_id, adapter.adapter_id)] = adapter
+    adapters = _build_adapters(
+        entries,
+        timeout_seconds=settings.source_http_timeout_seconds,
+    )
     schedules = load_collection_schedules(settings.collection_schedule_path)
     _validate_registered_schedules(schedules, adapters)
     return CollectionRuntime(
@@ -68,6 +67,29 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         adapters=adapters,
         retention_policy=load_retention_policy(settings.retention_policy_path),
     )
+
+
+def _build_adapters(
+    entries: tuple[SourceRegistryEntry, ...],
+    *,
+    timeout_seconds: float,
+) -> dict[tuple[str, str], CollectionAdapter]:
+    entries_by_id = {entry.policy.id: entry for entry in entries}
+    adapters: dict[tuple[str, str], CollectionAdapter] = {}
+    cisa_entry = entries_by_id.get(CisaKevAdapter.source_id)
+    if cisa_entry is not None:
+        _register(adapters, CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds))
+    ted_entry = entries_by_id.get(TedSearchAdapter.source_id)
+    if ted_entry is not None:
+        _register(adapters, TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds))
+    return adapters
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    adapters[(adapter.source_id, adapter.adapter_id)] = adapter
 
 
 def run_scheduler_once(runtime: CollectionRuntime, *, now: datetime | None = None) -> int:

--- a/src/cip/modules/collection_orchestration/application/ted_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/ted_adapter.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.ted_search.client import (
+    TedSearchCheckpoint,
+    TedSearchClient,
+    TedSourceResponseError,
+)
+from cip.adapters.sources.ted_search.collector import (
+    TedCollectionDeniedError,
+    TedSourceSchemaError,
+    collect_ted_notices,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class TedSearchAdapter:
+    source_id = "ted-search"
+    adapter_id = "ted-search-api"
+    data_category = DataCategory.PUBLIC_TENDER
+
+    def __init__(self, entry: SourceRegistryEntry, *, timeout_seconds: float = 30.0) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("TED adapter requires the ted-search source policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_ted_notices(
+                    TedSearchClient(http_client, search_url=self._entry.policy.base_url),
+                    self._entry,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except TedCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except TedSourceSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except TedSourceResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"TED Search returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={
+                "latest_publication_number": batch.checkpoint.latest_publication_number,
+            },
+            not_modified=batch.not_modified,
+            commercial_projections=batch.projections,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> TedSearchCheckpoint | None:
+    if payload is None:
+        return None
+    value = payload.get("latest_publication_number")
+    if value is not None and not isinstance(value, str):
+        raise AdapterExecutionError(
+            "checkpoint field latest_publication_number must be a string or null",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    return TedSearchCheckpoint(latest_publication_number=value)
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/collection_orchestration/application/worker.py
+++ b/src/cip/modules/collection_orchestration/application/worker.py
@@ -21,6 +21,9 @@ from cip.modules.collection_orchestration.infrastructure.repository import (
     fail_job,
 )
 from cip.modules.data_governance.domain.retention import RetentionPolicy
+from cip.modules.opportunities.infrastructure.projections import (
+    persist_commercial_projections,
+)
 from cip.shared.kernel.time import require_aware_utc, utc_now
 from cip.shared.persistence.session import session_scope
 
@@ -99,11 +102,17 @@ def run_worker_once(
 
     try:
         with session_scope(factory) as session:
+            completion_time = _read_clock(clock)
             written = complete_job(
                 session,
                 claimed,
                 batch,
-                now=_read_clock(clock),
+                now=completion_time,
+            )
+            persist_commercial_projections(
+                session,
+                batch.commercial_projections,
+                now=completion_time,
             )
     except LeaseLostError:
         return WorkerOutcome(

--- a/src/cip/modules/opportunities/infrastructure/projections.py
+++ b/src/cip/modules/opportunities/infrastructure/projections.py
@@ -9,7 +9,9 @@ from sqlalchemy.orm import Session
 from cip.modules.collection_orchestration.application.ports import CommercialProjection
 from cip.modules.evidence.domain.entities import Evidence
 from cip.modules.evidence.infrastructure.models import EvidenceRecord
-from cip.modules.opportunities.infrastructure.generation import generate_siem_soc_opportunity
+from cip.modules.opportunities.infrastructure.generation import (
+    generate_siem_soc_opportunity,
+)
 from cip.modules.opportunities.infrastructure.signals import store_commercial_signal
 from cip.modules.organizations.domain.entities import Organization
 from cip.modules.organizations.infrastructure.models import OrganizationRecord
@@ -61,7 +63,7 @@ def _upsert_organization(session: Session, organization: Organization) -> None:
     record.canonical_name = organization.canonical_name
     record.legal_name = organization.legal_name
     record.country_code = organization.country_code
-    record.updated_at = max(record.updated_at, organization.updated_at)
+    record.updated_at = organization.updated_at
 
 
 def _upsert_evidence(session: Session, evidence: Evidence) -> None:

--- a/src/cip/modules/opportunities/infrastructure/projections.py
+++ b/src/cip/modules/opportunities/infrastructure/projections.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.evidence.domain.entities import Evidence
+from cip.modules.evidence.infrastructure.models import EvidenceRecord
+from cip.modules.opportunities.infrastructure.generation import generate_siem_soc_opportunity
+from cip.modules.opportunities.infrastructure.signals import store_commercial_signal
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.organizations.infrastructure.models import OrganizationRecord
+from cip.shared.kernel.time import require_aware_utc
+
+
+def persist_commercial_projections(
+    session: Session,
+    projections: Sequence[CommercialProjection],
+    *,
+    now: datetime,
+) -> tuple[UUID, ...]:
+    evaluated_at = require_aware_utc(now, field_name="now")
+    organization_ids: list[UUID] = []
+    for projection in projections:
+        _upsert_organization(session, projection.organization)
+        _upsert_evidence(session, projection.evidence)
+        store_commercial_signal(session, projection.signal)
+        organization_ids.append(projection.organization.id)
+    opportunity_ids: list[UUID] = []
+    for organization_id in dict.fromkeys(organization_ids):
+        opportunity_id = generate_siem_soc_opportunity(
+            session,
+            organization_id,
+            now=evaluated_at,
+        )
+        if opportunity_id is not None:
+            opportunity_ids.append(opportunity_id)
+    return tuple(opportunity_ids)
+
+
+def _upsert_organization(session: Session, organization: Organization) -> None:
+    record = session.get(OrganizationRecord, organization.id)
+    if record is None:
+        session.add(
+            OrganizationRecord(
+                id=organization.id,
+                canonical_name=organization.canonical_name,
+                legal_name=organization.legal_name,
+                country_code=organization.country_code,
+                website_url=organization.website_url,
+                registration_ids=list(organization.registration_ids),
+                created_at=organization.created_at,
+                updated_at=organization.updated_at,
+            )
+        )
+        session.flush()
+        return
+    record.canonical_name = organization.canonical_name
+    record.legal_name = organization.legal_name
+    record.country_code = organization.country_code
+    record.updated_at = max(record.updated_at, organization.updated_at)
+
+
+def _upsert_evidence(session: Session, evidence: Evidence) -> None:
+    record = session.get(EvidenceRecord, evidence.id)
+    if record is None:
+        session.add(
+            EvidenceRecord(
+                id=evidence.id,
+                source_id=evidence.source_id,
+                source_record_key=evidence.source_record_key,
+                source_url=evidence.source_url,
+                summary=evidence.summary,
+                confidence=evidence.confidence,
+                collected_at=evidence.collected_at,
+                published_at=evidence.published_at,
+                observed_at=evidence.observed_at,
+                content_hash_sha256=evidence.content_hash_sha256,
+                raw_storage_uri=evidence.raw_storage_uri,
+                raw_storage_permitted=evidence.raw_storage_permitted,
+                retention_until=evidence.retention_until,
+            )
+        )
+        session.flush()
+        return
+    record.source_url = evidence.source_url
+    record.summary = evidence.summary
+    record.confidence = evidence.confidence
+    record.collected_at = evidence.collected_at
+    record.published_at = evidence.published_at
+    record.content_hash_sha256 = evidence.content_hash_sha256
+    record.retention_until = evidence.retention_until

--- a/tests/integration/test_ted_commercial_projection.py
+++ b/tests/integration/test_ted_commercial_projection.py
@@ -45,9 +45,9 @@ def test_ted_projection_is_idempotent_and_visible_in_inbox() -> None:
         assert first_ids == second_ids
         assert len(first_ids) == 1
         detail = get_opportunity_detail(session, first_ids[0])
-        assert detail.organization.canonical_name == "Ville Exemple"
+        assert detail.opportunity.organization == "Ville Exemple"
         assert detail.opportunity.evidence_count == 1
-        assert detail.opportunity.trigger_summary.startswith("1 public tender")
+        assert detail.opportunity.trigger.startswith("1 public tender")
         assert detail.evidence[0].source_id == "ted-search"
         assert detail.evidence[0].source_url.endswith("987654-2026/html")
 

--- a/tests/integration/test_ted_commercial_projection.py
+++ b/tests/integration/test_ted_commercial_projection.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from cip.adapters.sources.ted_search.mapper import map_ted_notice
+from cip.adapters.sources.ted_search.schemas import TedNotice
+from cip.modules.evidence.infrastructure.models import EvidenceRecord
+from cip.modules.opportunities.infrastructure.models import (
+    CommercialSignalRecord,
+    OpportunityRecord,
+)
+from cip.modules.opportunities.infrastructure.projections import (
+    persist_commercial_projections,
+)
+from cip.modules.opportunities.infrastructure.queries import get_opportunity_detail
+from cip.modules.organizations.infrastructure.models import OrganizationRecord
+from cip.shared.persistence.metadata import get_metadata
+from cip.shared.persistence.session import create_database_engine, create_session_factory
+
+NOW = datetime(2026, 8, 4, 10, 0, tzinfo=UTC)
+
+
+def test_ted_projection_is_idempotent_and_visible_in_inbox() -> None:
+    engine = create_database_engine("sqlite+pysqlite:///:memory:")
+    get_metadata().create_all(engine)
+    factory = create_session_factory(engine)
+    mapped = map_ted_notice(
+        TedNotice.model_validate(_notice()),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=730),
+    )
+    assert mapped is not None
+    _, projection = mapped
+
+    with factory() as session:
+        first_ids = persist_commercial_projections(session, (projection,), now=NOW)
+        second_ids = persist_commercial_projections(session, (projection,), now=NOW)
+        session.commit()
+        _assert_counts(session)
+        assert first_ids == second_ids
+        assert len(first_ids) == 1
+        detail = get_opportunity_detail(session, first_ids[0])
+        assert detail.organization.canonical_name == "Ville Exemple"
+        assert detail.opportunity.evidence_count == 1
+        assert detail.opportunity.trigger_summary.startswith("1 public tender")
+        assert detail.evidence[0].source_id == "ted-search"
+        assert detail.evidence[0].source_url.endswith("987654-2026/html")
+
+
+def _assert_counts(session: Session) -> None:
+    assert session.scalar(select(func.count()).select_from(OrganizationRecord)) == 1
+    assert session.scalar(select(func.count()).select_from(EvidenceRecord)) == 1
+    assert session.scalar(select(func.count()).select_from(CommercialSignalRecord)) == 1
+    assert session.scalar(select(func.count()).select_from(OpportunityRecord)) == 1
+
+
+def _notice() -> dict[str, object]:
+    return {
+        "publication-number": "987654-2026",
+        "notice-title": {"fra": "Service SIEM et centre opérationnel SOC"},
+        "buyer-name": {"fra": ["Ville Exemple"]},
+        "buyer-country": ["FRA"],
+        "publication-date": "2026-08-04",
+        "deadline-receipt-tender-date-lot": ["2026-08-30T12:00:00Z"],
+        "classification-cpv": ["72000000"],
+        "notice-type": ["cn-standard"],
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,14 +61,14 @@ def test_health() -> None:
     response = client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "version": "0.4.0"}
+    assert response.json() == {"status": "ok", "version": "0.5.0"}
 
 
 def test_application_factory_builds_independent_app() -> None:
     application = create_app()
 
     assert application is not app
-    assert application.version == "0.4.0"
+    assert application.version == "0.5.0"
 
 
 def test_validate_source_policy() -> None:

--- a/tests/test_opportunity_api.py
+++ b/tests/test_opportunity_api.py
@@ -49,7 +49,7 @@ def test_health_reports_phase_version(client_and_session: tuple[TestClient, Sess
     response = client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "version": "0.4.0"}
+    assert response.json() == {"status": "ok", "version": "0.5.0"}
 
 
 def test_empty_opportunity_list(client_and_session: tuple[TestClient, Session]) -> None:

--- a/tests/unit/adapters/ted_search/test_collector.py
+++ b/tests/unit/adapters/ted_search/test_collector.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from cip.adapters.sources.ted_search.client import (
+    TedSearchCheckpoint,
+    TedSearchClient,
+    TedSearchFetchResult,
+)
+from cip.adapters.sources.ted_search.collector import (
+    TedSourceSchemaError,
+    collect_ted_notices,
+)
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 4, 10, 0, tzinfo=UTC)
+
+
+class StubTedClient(TedSearchClient):
+    def __init__(self, payload: object) -> None:
+        self._body = json.dumps(payload).encode()
+
+    def fetch(self) -> TedSearchFetchResult:
+        return TedSearchFetchResult(body=self._body)
+
+
+def test_collector_maps_only_new_relevant_notices() -> None:
+    client = StubTedClient(
+        {
+            "notices": [
+                _notice("300-2026", "SIEM managed service"),
+                _notice("200-2026", "Office furniture"),
+                _notice("100-2026", "SOC monitoring platform"),
+            ],
+            "totalNoticeCount": 3,
+        }
+    )
+
+    batch = collect_ted_notices(
+        client,
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=730),
+        checkpoint=TedSearchCheckpoint(latest_publication_number="100-2026"),
+    )
+
+    assert batch.not_modified is False
+    assert batch.checkpoint.latest_publication_number == "300-2026"
+    assert len(batch.observations) == 1
+    assert len(batch.projections) == 1
+    assert batch.projections[0].signal.title == "SIEM managed service"
+
+
+def test_collector_marks_unchanged_first_page() -> None:
+    batch = collect_ted_notices(
+        StubTedClient({"notices": [_notice("300-2026", "SIEM managed service")]}),
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=730),
+        checkpoint=TedSearchCheckpoint(latest_publication_number="300-2026"),
+    )
+
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert batch.projections == ()
+
+
+def test_collector_rejects_schema_drift() -> None:
+    with pytest.raises(TedSourceSchemaError, match="schema validation"):
+        collect_ted_notices(
+            StubTedClient({"notices": [{"publication-number": "missing-fields"}]}),
+            _entry(),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=730),
+        )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.example.yml"))
+        if entry.policy.id == "ted-search"
+    )
+
+
+def _notice(number: str, title: str) -> dict[str, object]:
+    return {
+        "publication-number": number,
+        "notice-title": {"eng": title},
+        "buyer-name": {"eng": ["Public Buyer"]},
+        "buyer-country": ["FRA"],
+        "publication-date": "2026-08-04",
+        "deadline-receipt-tender-date-lot": ["2026-08-20T12:00:00Z"],
+        "classification-cpv": ["72000000"],
+        "notice-type": ["cn-standard"],
+    }

--- a/tests/unit/adapters/ted_search/test_ted_search.py
+++ b/tests/unit/adapters/ted_search/test_ted_search.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.ted_search.client import (
+    TedSearchClient,
+    TedSourceResponseError,
+)
+from cip.adapters.sources.ted_search.mapper import map_ted_notice
+from cip.adapters.sources.ted_search.schemas import TedNotice, TedSearchResponse
+from cip.modules.opportunities.domain.entities import SignalType
+
+NOW = datetime(2026, 8, 4, 10, 0, tzinfo=UTC)
+
+
+def test_client_posts_bounded_active_search() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["body"] = request.read().decode()
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"notices": []},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        result = TedSearchClient(
+            http_client,
+            search_url="https://api.ted.europa.eu/v3/notices/search",
+        ).fetch()
+
+    assert captured["method"] == "POST"
+    assert '"scope":"ACTIVE"' in str(captured["body"])
+    assert '"limit":100' in str(captured["body"])
+    assert TedSearchResponse.model_validate_json(result.body).notices == []
+
+
+def test_client_rejects_non_json_and_oversized_responses() -> None:
+    def wrong_type(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/html"}, text="no")
+
+    with httpx.Client(transport=httpx.MockTransport(wrong_type)) as http_client:
+        with pytest.raises(TedSourceResponseError, match="content type"):
+            TedSearchClient(http_client, search_url="https://example.test/search").fetch()
+
+    def oversized(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "application/json",
+                "content-length": str(TedSearchClient.MAX_RESPONSE_BYTES + 1),
+            },
+            content=b"{}",
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(oversized)) as http_client:
+        with pytest.raises(TedSourceResponseError, match="size limit"):
+            TedSearchClient(http_client, search_url="https://example.test/search").fetch()
+
+
+def test_schema_normalizes_localized_fields_and_dates() -> None:
+    notice = TedNotice.model_validate(
+        _notice_payload(
+            **{
+                "notice-title": {"fra": "Supervision SIEM"},
+                "buyer-name": {"eng": ["Public Buyer"]},
+                "publication-date": "20260804",
+                "deadline-receipt-tender-date-lot": ["2026-08-20T12:00:00Z"],
+            }
+        )
+    )
+
+    assert notice.title() == "Supervision SIEM"
+    assert notice.buyer() == "Public Buyer"
+    assert notice.country() == "FRA"
+    assert notice.publication_timestamp() == datetime(2026, 8, 4)
+    assert notice.deadline_timestamp() == datetime(2026, 8, 20, 12, tzinfo=UTC)
+
+
+def test_mapper_creates_deterministic_evidence_backed_projection() -> None:
+    notice = TedNotice.model_validate(_notice_payload())
+    retention = NOW + timedelta(days=730)
+
+    first = map_ted_notice(
+        notice,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=retention,
+    )
+    second = map_ted_notice(
+        notice,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=retention,
+    )
+
+    assert first is not None and second is not None
+    observation, projection = first
+    assert projection.organization.id == second[1].organization.id
+    assert projection.evidence.id == second[1].evidence.id
+    assert projection.signal.id == second[1].signal.id
+    assert projection.organization.country_code == "FR"
+    assert projection.signal.signal_type is SignalType.PUBLIC_TENDER
+    assert projection.signal.matched_terms == ("siem", "soc")
+    assert projection.signal.evidence_id == projection.evidence.id
+    assert observation.source_url.endswith("123456-2026/html")
+    assert observation.payload_hash_sha256 == projection.evidence.content_hash_sha256
+
+
+def test_mapper_drops_false_positive_returned_by_remote_search() -> None:
+    notice = TedNotice.model_validate(
+        _notice_payload(**{"notice-title": {"eng": "Office furniture supply"}})
+    )
+
+    assert (
+        map_ted_notice(
+            notice,
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=30),
+        )
+        is None
+    )
+
+
+def _notice_payload(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "publication-number": "123456-2026",
+        "notice-title": {"eng": "SIEM and SOC managed security service"},
+        "buyer-name": {"eng": ["Ville Exemple"]},
+        "buyer-country": ["FRA"],
+        "publication-date": "2026-08-04",
+        "deadline-receipt-tender-date-lot": ["2026-08-20T12:00:00Z"],
+        "classification-cpv": ["72000000"],
+        "notice-type": ["cn-standard"],
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/adapters/ted_search/test_ted_search.py
+++ b/tests/unit/adapters/ted_search/test_ted_search.py
@@ -45,9 +45,11 @@ def test_client_rejects_non_json_and_oversized_responses() -> None:
     def wrong_type(_: httpx.Request) -> httpx.Response:
         return httpx.Response(200, headers={"content-type": "text/html"}, text="no")
 
-    with httpx.Client(transport=httpx.MockTransport(wrong_type)) as http_client:
-        with pytest.raises(TedSourceResponseError, match="content type"):
-            TedSearchClient(http_client, search_url="https://example.test/search").fetch()
+    with (
+        httpx.Client(transport=httpx.MockTransport(wrong_type)) as http_client,
+        pytest.raises(TedSourceResponseError, match="content type"),
+    ):
+        TedSearchClient(http_client, search_url="https://example.test/search").fetch()
 
     def oversized(_: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -59,9 +61,11 @@ def test_client_rejects_non_json_and_oversized_responses() -> None:
             content=b"{}",
         )
 
-    with httpx.Client(transport=httpx.MockTransport(oversized)) as http_client:
-        with pytest.raises(TedSourceResponseError, match="size limit"):
-            TedSearchClient(http_client, search_url="https://example.test/search").fetch()
+    with (
+        httpx.Client(transport=httpx.MockTransport(oversized)) as http_client,
+        pytest.raises(TedSourceResponseError, match="size limit"),
+    ):
+        TedSearchClient(http_client, search_url="https://example.test/search").fetch()
 
 
 def test_schema_normalizes_localized_fields_and_dates() -> None:

--- a/tests/unit/collection_orchestration/test_domain_and_schedule.py
+++ b/tests/unit/collection_orchestration/test_domain_and_schedule.py
@@ -98,12 +98,20 @@ def test_checkpoint_is_immutable_and_requires_aware_dates() -> None:
 
 def test_repository_collection_schedule_loads() -> None:
     schedules = load_collection_schedules(Path("policies/collection_schedules.yml"))
+    schedules_by_identity = {
+        (schedule.source_id, schedule.adapter_id): schedule for schedule in schedules
+    }
 
-    assert len(schedules) == 1
-    schedule = schedules[0]
-    assert schedule.source_id == "cisa-kev"
-    assert schedule.interval_seconds == 900
-    assert schedule.retry_policy.max_attempts == 4
+    assert set(schedules_by_identity) == {
+        ("cisa-kev", "cisa-kev-feed"),
+        ("ted-search", "ted-search-api"),
+    }
+    cisa = schedules_by_identity[("cisa-kev", "cisa-kev-feed")]
+    ted = schedules_by_identity[("ted-search", "ted-search-api")]
+    assert cisa.interval_seconds == 900
+    assert cisa.retry_policy.max_attempts == 4
+    assert ted.interval_seconds == 1800
+    assert ted.retry_policy.base_delay_seconds == 60
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/collection_orchestration/test_runtime_and_metrics.py
+++ b/tests/unit/collection_orchestration/test_runtime_and_metrics.py
@@ -65,15 +65,19 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
     get_metadata().create_all(create_database_engine(settings.database_url))
 
     runtime = build_collection_runtime(settings)
-    assert run_scheduler_once(runtime, now=NOW) == 1
+    assert run_scheduler_once(runtime, now=NOW) == 2
     assert run_scheduler_once(runtime, now=NOW) == 0
 
     with session_scope(runtime.factory) as session:
-        source = session.get(SourceRecord, "cisa-kev")
-        job = session.scalar(select(CollectionJobRecord))
-    assert source is not None
-    assert source.automated_collection_allowed is True
-    assert job is not None
+        cisa = session.get(SourceRecord, "cisa-kev")
+        ted = session.get(SourceRecord, "ted-search")
+        jobs = tuple(session.scalars(select(CollectionJobRecord)))
+    assert cisa is not None and cisa.automated_collection_allowed is True
+    assert ted is not None and ted.automated_collection_allowed is True
+    assert {(job.source_id, job.adapter_id) for job in jobs} == {
+        ("cisa-kev", "cisa-kev-feed"),
+        ("ted-search", "ted-search-api"),
+    }
 
 
 def test_source_registry_sync_inserts_updates_and_then_stabilizes(tmp_path: Path) -> None:

--- a/tests/unit/collection_orchestration/test_ted_adapter.py
+++ b/tests/unit/collection_orchestration/test_ted_adapter.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.ted_search.client import (
+    TedSearchCheckpoint,
+    TedSourceResponseError,
+)
+from cip.adapters.sources.ted_search.collector import (
+    TedCollectionBatch,
+    TedCollectionDeniedError,
+    TedSourceSchemaError,
+)
+from cip.modules.collection_orchestration.application import ted_adapter as ted_adapter_module
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.collection_orchestration.application.ted_adapter import TedSearchAdapter
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 4, 10, 0, tzinfo=UTC)
+
+
+def _entry(source_id: str = "ted-search") -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.example.yml"))
+        if entry.policy.id == source_id
+    )
+
+
+def test_ted_adapter_maps_checkpoint_and_collection_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_collect(client: object, entry: object, **kwargs: object) -> TedCollectionBatch:
+        del client, entry
+        captured.update(kwargs)
+        return TedCollectionBatch(
+            observations=(),
+            projections=(),
+            checkpoint=TedSearchCheckpoint(latest_publication_number="300-2026"),
+            not_modified=True,
+        )
+
+    monkeypatch.setattr(ted_adapter_module, "collect_ted_notices", fake_collect)
+    adapter = TedSearchAdapter(_entry())
+
+    batch = adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload={"latest_publication_number": "200-2026"},
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=730),
+    )
+
+    checkpoint = captured["checkpoint"]
+    assert isinstance(checkpoint, TedSearchCheckpoint)
+    assert checkpoint.latest_publication_number == "200-2026"
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert batch.commercial_projections == ()
+    assert batch.checkpoint_payload == {"latest_publication_number": "300-2026"}
+
+
+def test_ted_adapter_accepts_missing_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_collect(client: object, entry: object, **kwargs: object) -> TedCollectionBatch:
+        del client, entry
+        captured.update(kwargs)
+        return TedCollectionBatch(
+            observations=(),
+            projections=(),
+            checkpoint=TedSearchCheckpoint(),
+            not_modified=False,
+        )
+
+    monkeypatch.setattr(ted_adapter_module, "collect_ted_notices", fake_collect)
+
+    TedSearchAdapter(_entry()).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=730),
+    )
+
+    assert captured["checkpoint"] is None
+
+
+def test_ted_adapter_validates_constructor_and_checkpoint() -> None:
+    with pytest.raises(ValueError, match="ted-search"):
+        TedSearchAdapter(_entry("cisa-kev"))
+    with pytest.raises(ValueError, match="timeout"):
+        TedSearchAdapter(_entry(), timeout_seconds=0)
+
+    with pytest.raises(AdapterExecutionError, match="latest_publication_number") as error:
+        TedSearchAdapter(_entry()).collect(
+            collection_job_id=uuid4(),
+            checkpoint_payload={"latest_publication_number": 42},
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=730),
+        )
+
+    assert error.value.error_code == "invalid_checkpoint"
+    assert error.value.retryable is False
+
+
+@pytest.mark.parametrize(
+    ("exception", "error_code", "retryable"),
+    [
+        (TedCollectionDeniedError("blocked"), "source_policy_denied", False),
+        (TedSourceSchemaError("drift"), "source_schema_drift", False),
+        (TedSourceResponseError("unsafe"), "unsafe_source_response", True),
+        (httpx.ReadTimeout("timeout"), "source_transport_error", True),
+    ],
+)
+def test_ted_adapter_normalizes_source_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    exception: Exception,
+    error_code: str,
+    retryable: bool,
+) -> None:
+    monkeypatch.setattr(
+        ted_adapter_module,
+        "collect_ted_notices",
+        lambda *args, **kwargs: (_ for _ in ()).throw(exception),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        TedSearchAdapter(_entry()).collect(
+            collection_job_id=uuid4(),
+            checkpoint_payload=None,
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=730),
+        )
+
+    assert error.value.error_code == error_code
+    assert error.value.retryable is retryable
+
+
+@pytest.mark.parametrize(
+    ("status", "retryable"),
+    [(404, False), (429, True), (503, True)],
+)
+def test_ted_adapter_classifies_http_status(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    retryable: bool,
+) -> None:
+    request = httpx.Request("POST", "https://api.ted.europa.eu/v3/notices/search")
+    response = httpx.Response(status, request=request)
+    exception = httpx.HTTPStatusError("failure", request=request, response=response)
+    monkeypatch.setattr(
+        ted_adapter_module,
+        "collect_ted_notices",
+        lambda *args, **kwargs: (_ for _ in ()).throw(exception),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        TedSearchAdapter(_entry()).collect(
+            collection_job_id=uuid4(),
+            checkpoint_payload=None,
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=730),
+        )
+
+    assert error.value.error_code == f"http_{status}"
+    assert error.value.retryable is retryable

--- a/tests/unit/source_governance/test_registry.py
+++ b/tests/unit/source_governance/test_registry.py
@@ -28,8 +28,13 @@ def test_repository_source_registry_loads() -> None:
         "linkedin-authorized-browser",
         "linkedin-official-api",
         "search-manual-review",
+        "ted-search",
     }
     assert entries_by_id["cisa-kev"].policy.status is SourceStatus.ENABLED
+    assert entries_by_id["ted-search"].policy.status is SourceStatus.ENABLED
+    assert entries_by_id["ted-search"].policy.allowed_data_categories == frozenset(
+        {DataCategory.PUBLIC_TENDER, DataCategory.ORGANIZATION_METADATA}
+    )
     assert entries_by_id["brixhub"].policy.status is SourceStatus.QUARANTINED
     assert entries_by_id["brixhub"].policy.allowed_data_categories == frozenset()
 


### PR DESCRIPTION
Closes #17

## Objectif

Ajouter le premier adaptateur commercial réel afin d’alimenter automatiquement l’Opportunity Inbox à partir d’avis de marchés publics officiels.

## Source

- API officielle TED Search v3 ;
- accès anonyme ;
- requête POST bornée sur les avis actifs ;
- champs sélectionnés uniquement ;
- aucun scraping de page ni stockage du document intégral.

## Changements

- client HTTP TED avec limites de contenu et validation du type MIME ;
- schémas Pydantic pour les champs sélectionnés ;
- requête cyber/SIEM/SOC et filtre local défensif ;
- checkpoint sur le dernier numéro de publication observé ;
- mapping déterministe vers observation, organisation, preuve et signal `public_tender` ;
- projection commerciale persistée dans la transaction de fin de job ;
- recalcul automatique de l’opportunité SIEM/SOC ;
- enregistrement du nouvel adaptateur dans le runtime ;
- politique source et planification toutes les 30 minutes ;
- version applicative `0.5.0` ;
- tests séparés pour client, schémas, collecte, mapping, orchestration, erreurs HTTP et intégration Inbox ;
- documentation mise à jour sans revendiquer BOAMP, DECP ou les offres d’emploi comme déjà connectés.

## Garanties

- aucune donnée personnelle privée ;
- aucun contenu d’avis complet stocké ;
- provenance TED et URL de preuve conservées ;
- identifiants déterministes et ingestion idempotente ;
- une réponse distante non pertinente ne devient pas un signal ;
- l’échec de projection annule aussi la réussite de collecte ;
- fichiers applicatifs TED segmentés, le plus grand faisant 169 lignes ;
- aucune définition de fonction dupliquée introduite.

## Validation obtenue

CI #99 sur le head final `1039dcf8362ee6a8f1e8eb2c61d1e2e105782dfd` : succès complet.

Backend :
- `pip check` : PASS ;
- `pip-audit --skip-editable` : aucune vulnérabilité connue ;
- Ruff : PASS ;
- Mypy strict : PASS sur 101 fichiers source ;
- Alembic PostgreSQL `upgrade -> downgrade -> upgrade` : PASS ;
- 275 tests : PASS ;
- couverture lignes et branches : 94,42 %, seuil de 90 % respecté ;
- orchestration `TedSearchAdapter` : 100 % de couverture.

Frontend :
- audit npm : PASS ;
- TypeScript : PASS ;
- build Next.js : PASS.

## Périmètre suivant

- prochain adaptateur commercial officiel, avec priorité au marché public français ;
- garde-fous automatisés de structure et découpage du dépôt ;
- Chromium et quarantaine restent suivis séparément dans #3.