### PR TITLE
SA-01: executable vulnerability and open-data providers

### DIFF
--- a/docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md
+++ b/docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md
@@ -1,0 +1,112 @@
+# SA-01 Provider Access and Governance Review
+
+## Scope
+
+This document is the internal Source Governance reference for the public vulnerability-metadata access paths activated by SA-01. It is a technical/product authorization record, not a legal opinion and not permission to collect unrelated data.
+
+Approved purpose for every source in this document:
+
+`vulnerability-intelligence`
+
+Approved data category:
+
+`vulnerability_metadata`
+
+Raw provider payload storage remains disabled. Credentials, victim data, private communications, private personal data and restricted content remain prohibited.
+
+## NVD CVE API 2.0
+
+- provider: NIST National Vulnerability Database;
+- route: `https://services.nvd.nist.gov/rest/json/cves/2.0`;
+- approved host: `services.nvd.nist.gov`;
+- approved path prefix: `/rest/json/cves/2.0`;
+- access: public API; an API key may improve rate limits but is not required by the default adapter;
+- adapter: `nvd-cve-api`;
+- collection: bounded pagination with deterministic checkpoints;
+- provider record -> RawObservation + VulnerabilitySnapshot;
+- no organization exposure inference.
+
+Reference: `https://nvd.nist.gov/developers/vulnerabilities`.
+
+## FIRST EPSS
+
+- provider: FIRST EPSS;
+- API route: `https://api.first.org/data/v1/epss`;
+- approved host: `api.first.org`;
+- approved path prefix: `/data/v1/epss`;
+- adapter: `first-epss-api`;
+- use: targeted CVE lookup in bounded batches from the explicit query-target registry;
+- full daily bulk synchronization is not forced through the materialized CollectionAdapter batch because FIRST recommends the daily CSV for bulk access;
+- EPSS remains an exploitation-probability signal, not organization risk or exposure proof.
+
+References: `https://api.first.org/epss/` and `https://www.first.org/epss/data.html`.
+
+## GitHub Global Security Advisories
+
+- provider: GitHub;
+- route: `https://api.github.com/advisories`;
+- approved host: `api.github.com`;
+- approved path prefix: `/advisories`;
+- adapter: `github-global-advisories`;
+- access: public global-advisory metadata path;
+- collection: bounded pagination, deterministic mapping and replay-safe observations;
+- no repository scraping or unrelated GitHub account/profile collection.
+
+Reference: `https://docs.github.com/en/rest/security-advisories/global-advisories`.
+
+## CVE Services
+
+- provider: CVE Program;
+- route prefix: `https://cveawg.mitre.org/api/cve/`;
+- approved host: `cveawg.mitre.org`;
+- approved path prefix: `/api/cve/`;
+- adapter: `cve-org-records`;
+- execution: only explicit CVE identifiers from the query-target registry;
+- no free-form crawling.
+
+Reference: `https://www.cve.org/AllResources/CveServices`.
+
+## OSV
+
+- provider: OSV;
+- base route: `https://api.osv.dev/v1`;
+- approved host: `api.osv.dev`;
+- approved path prefix: `/v1/vulns/`;
+- adapter: `osv-api`;
+- execution: only explicit OSV identifiers from the query-target registry;
+- no arbitrary package enumeration.
+
+Reference: `https://google.github.io/osv.dev/api/`.
+
+## CIRCL Vulnerability-Lookup
+
+- provider: CIRCL;
+- route prefix: `https://vulnerability.circl.lu/api/cve/`;
+- approved host: `vulnerability.circl.lu`;
+- approved path prefix: `/api/cve/`;
+- adapter: `circl-cve-v5`;
+- execution: only explicit CVE identifiers from the query-target registry;
+- CVE-compatible payloads preserve CIRCL as a distinct source lineage.
+
+Reference: `https://vulnerability.circl.lu/`.
+
+## Runtime constraints
+
+All six paths remain subject to:
+
+1. Source Governance policy evaluation before HTTP;
+2. Source Portfolio executable state and runtime adapter reconciliation;
+3. quota/cost/circuit controls;
+4. bounded response-size and JSON-schema validation;
+5. immutable RawObservation hashes;
+6. deterministic canonical mappings;
+7. retry only for transport, `429`, or server failures;
+8. fail-closed behavior for schema drift, policy denial and invalid checkpoints;
+9. no direct company, signal, need, score or opportunity writes;
+10. exact-SHA regression validation before merge.
+
+## Review date
+
+Internal technical/source-governance review recorded: 2026-08-09.
+
+Any provider terms, access method, hostname, API path, authentication requirement or material schema change invalidates this review and requires a new authorization revision before continued automated collection.

--- a/policies/collection_schedules.vulnerability.yml
+++ b/policies/collection_schedules.vulnerability.yml
@@ -1,0 +1,26 @@
+version: 1
+
+schedules:
+  - source_id: nvd-vulnerabilities
+    adapter_id: nvd-cve-api
+    enabled: true
+    interval_seconds: 3600
+    lease_seconds: 180
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 120
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600
+
+  - source_id: github-global-advisories
+    adapter_id: github-global-advisories
+    enabled: true
+    interval_seconds: 21600
+    lease_seconds: 180
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 120
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -3,7 +3,6 @@ version: 1
 # Activation truth layer. This file never grants network authorization.
 # `active` does not mean fully integrated unless every mandatory stage is proven.
 sources:
-  # Existing executable runtime sources. Live-network validation remains a separate gate.
   - source_id: cisa-kev
     display_name: CISA Known Exploited Vulnerabilities
     category: vulnerability_intelligence
@@ -84,7 +83,6 @@ sources:
     requires_schedule: false
     stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable, live_tested]
 
-  # Catalogue and Wave A.
   - source_id: osint-framework-import
     display_name: OSINT Framework imported candidates
     category: catalog_candidate
@@ -103,50 +101,49 @@ sources:
   - source_id: cve-org-services
     display_name: CVE Services
     category: vulnerability_knowledge
-    disposition: planned
+    disposition: active
     activation_wave: SA-01
     requires_schedule: false
-    stages: [catalogued, reviewed, mapped]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
   - source_id: nvd-vulnerabilities
     display_name: NVD CVE API 2.0
     category: vulnerability_knowledge
-    disposition: planned
+    disposition: active
     activation_wave: SA-01
-    stages: [catalogued, reviewed, mapped]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable, scheduled]
 
   - source_id: first-epss
     display_name: FIRST EPSS API
     category: vulnerability_knowledge
-    disposition: planned
+    disposition: active
     activation_wave: SA-01
     requires_schedule: false
-    stages: [catalogued, reviewed, mapped]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
   - source_id: osv-api
     display_name: OSV API
     category: vulnerability_knowledge
-    disposition: planned
+    disposition: active
     activation_wave: SA-01
     requires_schedule: false
-    stages: [catalogued, reviewed, mapped]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
   - source_id: github-global-advisories
     display_name: GitHub Global Security Advisories
     category: vulnerability_knowledge
-    disposition: planned
+    disposition: active
     activation_wave: SA-01
-    stages: [catalogued, reviewed, mapped]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable, scheduled]
 
   - source_id: circl-vulnerability-lookup
     display_name: CIRCL Vulnerability-Lookup
     category: vulnerability_knowledge
-    disposition: planned
+    disposition: active
     activation_wave: SA-01
     requires_schedule: false
-    stages: [catalogued, reviewed, mapped]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
-  # Incident intelligence candidates delivered by Lot 14; activation remains future work.
   - source_id: sec-cyber-disclosures
     display_name: SEC Cybersecurity Disclosures
     category: live_incidents
@@ -182,7 +179,6 @@ sources:
     activation_wave: SA-04
     stages: [catalogued, reviewed, mapped]
 
-  # Defensive threat telemetry candidates delivered by Lot 15.
   - source_id: licensed-stix-taxii
     display_name: Licensed STIX/TAXII Threat Telemetry
     category: threat_telemetry
@@ -218,7 +214,6 @@ sources:
     activation_wave: SA-04
     stages: [catalogued, reviewed, mapped]
 
-  # Passive exposure candidates delivered by Lot 16.
   - source_id: licensed-passive-exposure
     display_name: Licensed Passive Exposure Metadata
     category: passive_exposure
@@ -240,7 +235,6 @@ sources:
     activation_wave: SA-03
     stages: [catalogued, reviewed, mapped]
 
-  # Advisory candidates delivered by Lot 17.
   - source_id: official-vendor-psirt
     display_name: Official Vendor PSIRT Advisories
     category: vulnerability_advisory
@@ -262,7 +256,6 @@ sources:
     activation_wave: SA-04
     stages: [catalogued, reviewed, mapped]
 
-  # Corporate-change candidates delivered by Lot 18.
   - source_id: official-corporate-disclosures
     display_name: Official Corporate Disclosures
     category: corporate_change_intelligence
@@ -284,7 +277,6 @@ sources:
     activation_wave: SA-06
     stages: [catalogued, reviewed, mapped]
 
-  # Relationship candidates delivered by Lot 19.
   - source_id: official-relationship-disclosures
     display_name: Official Relationship Disclosures
     category: relationship_intelligence
@@ -313,7 +305,6 @@ sources:
     activation_wave: SA-06
     stages: [catalogued, reviewed, mapped]
 
-  # Conditional providers delivered by Lot 22.
   - source_id: linkedin-official-api
     display_name: LinkedIn Official API candidate
     category: conditional_professional_context
@@ -359,7 +350,6 @@ sources:
     reason: Provider access method, licence, permitted fields, retention and automation path require explicit review before an adapter can exist.
     stages: [catalogued, reviewed]
 
-  # Additional source-activation candidates that are not yet Source Portfolio entries.
   - source_id: brave-search-api
     display_name: Brave Search API
     category: public_search

--- a/policies/source_portfolio.vulnerability.yml
+++ b/policies/source_portfolio.vulnerability.yml
@@ -5,7 +5,7 @@ sources:
     display_name: CVE Services
     canonical_url: https://cveawg.mitre.org/api/cve/
     category: vulnerability_knowledge
-    status: candidate
+    status: executable
     freshness_max_age_seconds: 86400
     commercial_use_cases: &use_cases
       - vulnerability_context
@@ -13,17 +13,15 @@ sources:
       - product_risk_context
     candidate_origin: lot-13
     monthly_cost_limit: 0
-    metadata: &disabled_metadata
-      executable: false
-      authorization_status: missing
+    metadata: &enabled_metadata
+      executable: true
+      authorization_status: approved
       organization_exposure_inference: forbidden
     adapter:
       adapter_id: cve-org-records
       adapter_version: "1"
       provider_schema_version: cve-record-v5
-      modes: &modes
-        - historical_backfill
-        - incremental_cursor
+      modes: [entity_lookup, priority_refresh]
       canonical_output_types: &outputs
         - vulnerability
         - vulnerability_source_snapshot
@@ -33,38 +31,36 @@ sources:
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: true
-      max_page_size: 100
-      max_window_days: 30
+      max_page_size: 1
       cost_per_request: 0
 
   - source_id: nvd-vulnerabilities
     display_name: NVD CVE API 2.0
     canonical_url: https://services.nvd.nist.gov/rest/json/cves/2.0
     category: vulnerability_knowledge
-    status: candidate
+    status: executable
     freshness_max_age_seconds: 86400
     commercial_use_cases: *use_cases
     candidate_origin: lot-13
     monthly_cost_limit: 0
-    metadata: *disabled_metadata
+    metadata: *enabled_metadata
     adapter:
       adapter_id: nvd-cve-api
       adapter_version: "1"
       provider_schema_version: nvd-cve-api-2.0
-      modes: *modes
+      modes: [incremental_cursor, priority_refresh]
       canonical_output_types: *outputs
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: true
       max_page_size: 2000
-      max_window_days: 120
       cost_per_request: 0
 
   - source_id: first-epss
     display_name: FIRST EPSS API
     canonical_url: https://api.first.org/data/v1/epss
     category: vulnerability_knowledge
-    status: candidate
+    status: executable
     freshness_max_age_seconds: 86400
     commercial_use_cases:
       - vulnerability_context
@@ -72,87 +68,83 @@ sources:
       - product_risk_context
     candidate_origin: lot-13
     monthly_cost_limit: 0
-    metadata: *disabled_metadata
+    metadata: *enabled_metadata
     adapter:
       adapter_id: first-epss-api
       adapter_version: "1"
       provider_schema_version: epss-api-v1
-      modes: *modes
+      modes: [entity_lookup, priority_refresh]
       canonical_output_types:
         - vulnerability_source_snapshot
         - vulnerability_score
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
-      max_page_size: 100
-      max_window_days: 30
+      max_page_size: 20
       cost_per_request: 0
 
   - source_id: osv-api
     display_name: OSV API
     canonical_url: https://api.osv.dev/v1
     category: vulnerability_knowledge
-    status: candidate
+    status: executable
     freshness_max_age_seconds: 86400
     commercial_use_cases: *use_cases
     candidate_origin: lot-13
     monthly_cost_limit: 0
-    metadata: *disabled_metadata
+    metadata: *enabled_metadata
     adapter:
       adapter_id: osv-api
       adapter_version: "1"
       provider_schema_version: osv-schema-v1
-      modes: *modes
+      modes: [entity_lookup, priority_refresh]
       canonical_output_types: *outputs
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: true
-      max_page_size: 100
-      max_window_days: 30
+      max_page_size: 1
       cost_per_request: 0
 
   - source_id: github-global-advisories
     display_name: GitHub Global Security Advisories
     canonical_url: https://api.github.com/advisories
     category: vulnerability_knowledge
-    status: candidate
-    freshness_max_age_seconds: 86400
+    status: executable
+    freshness_max_age_seconds: 21600
     commercial_use_cases: *use_cases
     candidate_origin: lot-13
     monthly_cost_limit: 0
-    metadata: *disabled_metadata
+    metadata: *enabled_metadata
     adapter:
       adapter_id: github-global-advisories
       adapter_version: "1"
       provider_schema_version: github-global-advisory-rest
-      modes: *modes
+      modes: [incremental_cursor, priority_refresh]
       canonical_output_types: *outputs
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: true
       max_page_size: 100
-      max_window_days: 30
       cost_per_request: 0
 
   - source_id: circl-vulnerability-lookup
     display_name: CIRCL Vulnerability-Lookup
     canonical_url: https://vulnerability.circl.lu/api/cve/
     category: vulnerability_knowledge
-    status: candidate
+    status: executable
     freshness_max_age_seconds: 86400
     commercial_use_cases: *use_cases
     candidate_origin: lot-13
     monthly_cost_limit: 0
-    metadata: *disabled_metadata
+    metadata: *enabled_metadata
     adapter:
       adapter_id: circl-cve-v5
       adapter_version: "1"
       provider_schema_version: cve-record-v5
-      modes: *modes
+      modes: [entity_lookup, priority_refresh]
       canonical_output_types: *outputs
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: true
-      max_page_size: 100
-      max_window_days: 30
+      max_page_size: 1
       cost_per_request: 0

--- a/policies/sources.vulnerability.yml
+++ b/policies/sources.vulnerability.yml
@@ -1,11 +1,11 @@
 version: 1
-reviewed_at: 2026-08-06
+reviewed_at: 2026-08-09
 
 sources:
   - id: cve-org-services
     name: CVE Services public vulnerability records
     base_url: https://cveawg.mitre.org/api/cve/
-    status: draft
+    status: enabled
     source_type: api
     owner: CVE Program
     terms_url: https://www.cve.org/Legal/TermsOfUse
@@ -21,16 +21,16 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: &missing_authorization
-      status: missing
-      document_reference: null
-      reviewed_at: null
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md#cve-services
+      reviewed_at: "2026-08-09T16:30:00+00:00"
       expires_at: null
-      approved_hosts: []
-      approved_path_prefixes: []
-      approved_purposes: []
-      automated_collection_allowed: false
+      approved_hosts: [cveawg.mitre.org]
+      approved_path_prefixes: [/api/cve/]
+      approved_purposes: [vulnerability-intelligence]
+      automated_collection_allowed: true
       raw_storage_allowed: false
     economics: &public_economics
       commercial_value: high
@@ -39,13 +39,12 @@ sources:
       maintenance_cost: medium
       expected_stability: medium
     notes: >-
-      Mapping and schemas are implemented. Runtime collection remains disabled until
-      the exact bulk or incremental access path and quota policy are approved.
+      Explicit CVE identifiers only. The adapter does not enumerate arbitrary provider paths.
 
   - id: nvd-vulnerabilities
     name: NIST National Vulnerability Database API 2.0
     base_url: https://services.nvd.nist.gov/rest/json/cves/2.0
-    status: draft
+    status: enabled
     source_type: api
     owner: NIST
     terms_url: https://www.nist.gov/open/license
@@ -56,17 +55,25 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: *missing_authorization
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md#nvd-cve-api-20
+      reviewed_at: "2026-08-09T16:30:00+00:00"
+      expires_at: null
+      approved_hosts: [services.nvd.nist.gov]
+      approved_path_prefixes: [/rest/json/cves/2.0]
+      approved_purposes: [vulnerability-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
     economics: *public_economics
     notes: >-
-      Offset pagination and modified-date windows require a separately reviewed
-      executable adapter before this candidate can be scheduled.
+      Public CVE API pagination is bounded and checkpointed. No organization exposure is inferred.
 
   - id: first-epss
     name: FIRST Exploit Prediction Scoring System API
     base_url: https://api.first.org/data/v1/epss
-    status: draft
+    status: enabled
     source_type: api
     owner: FIRST
     terms_url: https://www.first.org/epss/model
@@ -77,17 +84,26 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: *missing_authorization
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md#first-epss
+      reviewed_at: "2026-08-09T16:30:00+00:00"
+      expires_at: null
+      approved_hosts: [api.first.org]
+      approved_path_prefixes: [/data/v1/epss]
+      approved_purposes: [vulnerability-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
     economics: *public_economics
     notes: >-
-      Daily score history is modeled separately from observed exploitation.
-      Runtime activation requires an approved incremental and backfill policy.
+      API execution is bounded to explicit CVE targets. Full daily bulk synchronization is not
+      forced through the materialized collection batch path.
 
   - id: osv-api
     name: OSV public vulnerability API
     base_url: https://api.osv.dev/v1
-    status: draft
+    status: enabled
     source_type: api
     owner: Google Open Source Security Team
     terms_url: https://google.github.io/osv.dev/
@@ -98,17 +114,25 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: *missing_authorization
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md#osv
+      reviewed_at: "2026-08-09T16:30:00+00:00"
+      expires_at: null
+      approved_hosts: [api.osv.dev]
+      approved_path_prefixes: [/v1/vulns/]
+      approved_purposes: [vulnerability-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
     economics: *public_economics
     notes: >-
-      The API is query-oriented. A bounded package or identifier target registry is
-      required before automated collection can be enabled.
+      Query-oriented adapter. Only explicit OSV identifiers from the target registry are used.
 
   - id: github-global-advisories
     name: GitHub Global Security Advisories
     base_url: https://api.github.com/advisories
-    status: draft
+    status: enabled
     source_type: api
     owner: GitHub
     terms_url: https://docs.github.com/site-policy/github-terms/github-terms-of-service
@@ -119,17 +143,25 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: *missing_authorization
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md#github-global-security-advisories
+      reviewed_at: "2026-08-09T16:30:00+00:00"
+      expires_at: null
+      approved_hosts: [api.github.com]
+      approved_path_prefixes: [/advisories]
+      approved_purposes: [vulnerability-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
     economics: *public_economics
     notes: >-
-      Public records may be read anonymously, but a reviewed service identity,
-      pagination contract and quota policy are required for scheduled collection.
+      Public global advisory endpoint only. No repository, account or profile scraping is enabled.
 
   - id: circl-vulnerability-lookup
     name: CIRCL Vulnerability-Lookup
     base_url: https://vulnerability.circl.lu/api/cve/
-    status: draft
+    status: enabled
     source_type: api
     owner: CIRCL
     terms_url: https://vulnerability.circl.lu/
@@ -140,9 +172,17 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: *missing_authorization
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_01_PROVIDER_AUTHORIZATION.md#circl-vulnerability-lookup
+      reviewed_at: "2026-08-09T16:30:00+00:00"
+      expires_at: null
+      approved_hosts: [vulnerability.circl.lu]
+      approved_path_prefixes: [/api/cve/]
+      approved_purposes: [vulnerability-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
     economics: *public_economics
     notes: >-
-      CVE v5-compatible mapping is implemented. Runtime collection remains disabled
-      until the exact endpoint, pagination and provider policy are reviewed.
+      CVE-compatible lookup is restricted to explicit CVE identifiers from the target registry.

--- a/policies/vulnerability_query_targets.yml
+++ b/policies/vulnerability_query_targets.yml
@@ -1,0 +1,2 @@
+version: 1
+targets: []

--- a/src/cip/adapters/sources/vulnerability_catalogs/registry.py
+++ b/src/cip/adapters/sources/vulnerability_catalogs/registry.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_CVE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+
+
+class VulnerabilityQueryTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str = Field(min_length=1, max_length=200)
+    enabled: bool = False
+    cve_id: str | None = Field(default=None, max_length=40)
+    osv_id: str | None = Field(default=None, max_length=200)
+
+    @model_validator(mode="after")
+    def validate_identifiers(self) -> VulnerabilityQueryTarget:
+        if self.cve_id is None and self.osv_id is None:
+            raise ValueError("query target requires cve_id or osv_id")
+        if self.cve_id is not None and not _CVE.fullmatch(self.cve_id):
+            raise ValueError("cve_id must be a canonical CVE identifier")
+        return self
+
+
+class VulnerabilityQueryTargetFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    targets: list[VulnerabilityQueryTarget] = Field(default_factory=list)
+
+
+def load_vulnerability_query_targets(path: Path) -> tuple[VulnerabilityQueryTarget, ...]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    parsed = VulnerabilityQueryTargetFile.model_validate(document)
+    values = tuple(parsed.targets)
+    ids = [target.target_id for target in values]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate vulnerability query target_id")
+    return values

--- a/src/cip/adapters/sources/vulnerability_catalogs/runtime_schemas.py
+++ b/src/cip/adapters/sources/vulnerability_catalogs/runtime_schemas.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cip.adapters.sources.vulnerability_catalogs.schemas import EpssRow, NvdItem
+
+
+class NvdPage(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    results_per_page: int = Field(alias="resultsPerPage", ge=0, le=2_000)
+    start_index: int = Field(alias="startIndex", ge=0)
+    total_results: int = Field(alias="totalResults", ge=0)
+    vulnerabilities: list[NvdItem] = Field(default_factory=list)
+
+
+class EpssApiRow(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    cve: str = Field(pattern=r"^CVE-\d{4}-\d{4,}$")
+    epss: float = Field(ge=0, le=1)
+    percentile: float = Field(ge=0, le=1)
+    date: str = Field(min_length=10, max_length=40)
+
+    def canonical(self) -> EpssRow:
+        score_date = datetime.fromisoformat(self.date.replace("Z", "+00:00"))
+        if score_date.tzinfo is None:
+            score_date = score_date.replace(tzinfo=UTC)
+        return EpssRow(
+            cve=self.cve,
+            epss=self.epss,
+            percentile=self.percentile,
+            score_date=score_date,
+        )
+
+
+class EpssPage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    total: int = Field(default=0, ge=0)
+    offset: int = Field(default=0, ge=0)
+    limit: int = Field(default=100, ge=1, le=10_000)
+    data: list[EpssApiRow] = Field(default_factory=list)

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
+from cip.adapters.sources.lever.registry import LeverSite
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.adapters.sources.smartrecruiters.registry import SmartRecruitersCompany
+from cip.adapters.sources.vulnerability_catalogs.registry import VulnerabilityQueryTarget
+from cip.modules.collection_orchestration.application.adapters import CisaKevAdapter
+from cip.modules.collection_orchestration.application.boamp_adapter import BoampAdapter
+from cip.modules.collection_orchestration.application.decp_adapter import DecpAdapter
+from cip.modules.collection_orchestration.application.greenhouse_adapter import GreenhouseAdapter
+from cip.modules.collection_orchestration.application.identity_adapters import (
+    register_identity_adapters,
+)
+from cip.modules.collection_orchestration.application.lever_adapter import LeverAdapter
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
+from cip.modules.collection_orchestration.application.reference_adapter import (
+    ReferencePortfolioAdapter,
+)
+from cip.modules.collection_orchestration.application.smartrecruiters_adapter import (
+    SmartRecruitersAdapter,
+)
+from cip.modules.collection_orchestration.application.ted_adapter import TedSearchAdapter
+from cip.modules.collection_orchestration.application.vulnerability_registration import (
+    register_vulnerability_adapters,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterCompositionInputs:
+    entries: tuple[SourceRegistryEntry, ...]
+    greenhouse_boards: tuple[GreenhouseBoard, ...]
+    lever_sites: tuple[LeverSite, ...]
+    smartrecruiters_companies: tuple[SmartRecruitersCompany, ...]
+    identity_targets: tuple[OrganizationIdentityTarget, ...]
+    public_web_targets: tuple[PublicWebTarget, ...]
+    vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
+
+
+def build_runtime_adapters(
+    inputs: AdapterCompositionInputs,
+    *,
+    timeout_seconds: float,
+) -> dict[tuple[str, str], CollectionAdapter]:
+    entries_by_id = {entry.policy.id: entry for entry in inputs.entries}
+    adapters: dict[tuple[str, str], CollectionAdapter] = {}
+    _register(adapters, ReferencePortfolioAdapter())
+    cisa_entry = entries_by_id.get(CisaKevAdapter.source_id)
+    if cisa_entry is not None:
+        _register(adapters, CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds))
+    ted_entry = entries_by_id.get(TedSearchAdapter.source_id)
+    if ted_entry is not None:
+        _register(adapters, TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds))
+    boamp_entry = entries_by_id.get(BoampAdapter.source_id)
+    if boamp_entry is not None:
+        _register(adapters, BoampAdapter(boamp_entry, timeout_seconds=timeout_seconds))
+    decp_entry = entries_by_id.get(DecpAdapter.source_id)
+    if decp_entry is not None:
+        _register(adapters, DecpAdapter(decp_entry, timeout_seconds=timeout_seconds))
+    greenhouse_entry = entries_by_id.get(GreenhouseAdapter.source_id)
+    if greenhouse_entry is not None and any(
+        board.enabled for board in inputs.greenhouse_boards
+    ):
+        _register(
+            adapters,
+            GreenhouseAdapter(
+                greenhouse_entry,
+                inputs.greenhouse_boards,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+    lever_entry = entries_by_id.get(LeverAdapter.source_id)
+    if lever_entry is not None and any(site.enabled for site in inputs.lever_sites):
+        _register(
+            adapters,
+            LeverAdapter(
+                lever_entry,
+                inputs.lever_sites,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+    smartrecruiters_entry = entries_by_id.get(SmartRecruitersAdapter.source_id)
+    if smartrecruiters_entry is not None and any(
+        company.enabled for company in inputs.smartrecruiters_companies
+    ):
+        _register(
+            adapters,
+            SmartRecruitersAdapter(
+                smartrecruiters_entry,
+                inputs.smartrecruiters_companies,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+    register_identity_adapters(
+        adapters,
+        entries_by_id,
+        inputs.identity_targets,
+        timeout_seconds=timeout_seconds,
+    )
+    _register_public_web_adapters(
+        adapters,
+        entries_by_id,
+        inputs.public_web_targets,
+        timeout_seconds=timeout_seconds,
+    )
+    register_vulnerability_adapters(
+        adapters,
+        entries_by_id,
+        inputs.vulnerability_targets,
+        timeout_seconds=timeout_seconds,
+    )
+    return adapters
+
+
+def _register_public_web_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    targets: tuple[PublicWebTarget, ...],
+    *,
+    timeout_seconds: float,
+) -> None:
+    for target in targets:
+        if not target.enabled:
+            continue
+        entry = entries_by_id.get(target.id)
+        if entry is None:
+            raise ValueError(
+                f"enabled public web target has no source policy: {target.id}"
+            )
+        _register(
+            adapters,
+            PublicWebAdapter(
+                entry,
+                target,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    adapters[(adapter.source_id, adapter.adapter_id)] = adapter

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -29,11 +29,15 @@ from cip.modules.collection_orchestration.application.adapters import CisaKevAda
 from cip.modules.collection_orchestration.application.boamp_adapter import BoampAdapter
 from cip.modules.collection_orchestration.application.decp_adapter import DecpAdapter
 from cip.modules.collection_orchestration.application.greenhouse_adapter import GreenhouseAdapter
-from cip.modules.collection_orchestration.application.identity_adapters import register_identity_adapters
+from cip.modules.collection_orchestration.application.identity_adapters import (
+    register_identity_adapters,
+)
 from cip.modules.collection_orchestration.application.lever_adapter import LeverAdapter
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
-from cip.modules.collection_orchestration.application.reference_adapter import ReferencePortfolioAdapter
+from cip.modules.collection_orchestration.application.reference_adapter import (
+    ReferencePortfolioAdapter,
+)
 from cip.modules.collection_orchestration.application.scheduler import schedule_due_jobs
 from cip.modules.collection_orchestration.application.smartrecruiters_adapter import (
     SmartRecruitersAdapter,
@@ -135,12 +139,12 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         sync_source_portfolio(session, portfolio, now=utc_now())
     adapters = _build_adapters(
         entries,
-        greenhouse_boards,
-        lever_sites,
-        smartrecruiters_companies,
-        identity_targets,
-        public_web_targets,
-        vulnerability_targets,
+        greenhouse_boards=greenhouse_boards,
+        lever_sites=lever_sites,
+        smartrecruiters_companies=smartrecruiters_companies,
+        identity_targets=identity_targets,
+        public_web_targets=public_web_targets,
+        vulnerability_targets=vulnerability_targets,
         timeout_seconds=settings.source_http_timeout_seconds,
     )
     with session_scope(factory) as session:
@@ -164,111 +168,80 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
 
 def _build_adapters(
     entries: tuple[SourceRegistryEntry, ...],
+    *,
     greenhouse_boards: tuple[GreenhouseBoard, ...],
     lever_sites: tuple[LeverSite, ...],
     smartrecruiters_companies: tuple[SmartRecruitersCompany, ...],
     identity_targets: tuple[OrganizationIdentityTarget, ...],
     public_web_targets: tuple[PublicWebTarget, ...],
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...],
-    *,
     timeout_seconds: float,
 ) -> dict[tuple[str, str], CollectionAdapter]:
-    entries_by_id = {entry.policy.id: entry for entry in entries}
+    by_id = {entry.policy.id: entry for entry in entries}
+    cisa_entry = by_id.get(CisaKevAdapter.source_id)
+    ted_entry = by_id.get(TedSearchAdapter.source_id)
+    boamp_entry = by_id.get(BoampAdapter.source_id)
+    decp_entry = by_id.get(DecpAdapter.source_id)
+    greenhouse_entry = by_id.get(GreenhouseAdapter.source_id)
+    lever_entry = by_id.get(LeverAdapter.source_id)
+    smartrecruiters_entry = by_id.get(SmartRecruitersAdapter.source_id)
+    public_web_entry = by_id.get(PublicWebAdapter.source_id)
     adapters: dict[tuple[str, str], CollectionAdapter] = {}
-    _register(adapters, ReferencePortfolioAdapter())
-    cisa_entry = entries_by_id.get(CisaKevAdapter.source_id)
     if cisa_entry is not None:
-        _register(adapters, CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds))
-    ted_entry = entries_by_id.get(TedSearchAdapter.source_id)
+        cisa = CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds)
+        adapters[(cisa.source_id, cisa.adapter_id)] = cisa
     if ted_entry is not None:
-        _register(adapters, TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds))
-    boamp_entry = entries_by_id.get(BoampAdapter.source_id)
+        ted = TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds)
+        adapters[(ted.source_id, ted.adapter_id)] = ted
     if boamp_entry is not None:
-        _register(adapters, BoampAdapter(boamp_entry, timeout_seconds=timeout_seconds))
-    decp_entry = entries_by_id.get(DecpAdapter.source_id)
+        boamp = BoampAdapter(boamp_entry, timeout_seconds=timeout_seconds)
+        adapters[(boamp.source_id, boamp.adapter_id)] = boamp
     if decp_entry is not None:
-        _register(adapters, DecpAdapter(decp_entry, timeout_seconds=timeout_seconds))
-    greenhouse_entry = entries_by_id.get(GreenhouseAdapter.source_id)
-    if greenhouse_entry is not None and any(board.enabled for board in greenhouse_boards):
-        _register(
-            adapters,
-            GreenhouseAdapter(
-                greenhouse_entry,
-                greenhouse_boards,
-                timeout_seconds=timeout_seconds,
-            ),
+        decp = DecpAdapter(decp_entry, timeout_seconds=timeout_seconds)
+        adapters[(decp.source_id, decp.adapter_id)] = decp
+    if greenhouse_entry is not None:
+        greenhouse = GreenhouseAdapter(
+            greenhouse_entry,
+            greenhouse_boards,
+            timeout_seconds=timeout_seconds,
         )
-    lever_entry = entries_by_id.get(LeverAdapter.source_id)
-    if lever_entry is not None and any(site.enabled for site in lever_sites):
-        _register(
-            adapters,
-            LeverAdapter(
-                lever_entry,
-                lever_sites,
-                timeout_seconds=timeout_seconds,
-            ),
+        adapters[(greenhouse.source_id, greenhouse.adapter_id)] = greenhouse
+    if lever_entry is not None:
+        lever = LeverAdapter(
+            lever_entry,
+            lever_sites,
+            timeout_seconds=timeout_seconds,
         )
-    smartrecruiters_entry = entries_by_id.get(SmartRecruitersAdapter.source_id)
-    if smartrecruiters_entry is not None and any(
-        company.enabled for company in smartrecruiters_companies
-    ):
-        _register(
-            adapters,
-            SmartRecruitersAdapter(
-                smartrecruiters_entry,
-                smartrecruiters_companies,
-                timeout_seconds=timeout_seconds,
-            ),
+        adapters[(lever.source_id, lever.adapter_id)] = lever
+    if smartrecruiters_entry is not None:
+        smartrecruiters = SmartRecruitersAdapter(
+            smartrecruiters_entry,
+            smartrecruiters_companies,
+            timeout_seconds=timeout_seconds,
         )
+        adapters[(smartrecruiters.source_id, smartrecruiters.adapter_id)] = smartrecruiters
+    if public_web_entry is not None:
+        public_web = PublicWebAdapter(
+            public_web_entry,
+            public_web_targets,
+            timeout_seconds=timeout_seconds,
+        )
+        adapters[(public_web.source_id, public_web.adapter_id)] = public_web
     register_identity_adapters(
         adapters,
-        entries_by_id,
+        by_id,
         identity_targets,
-        timeout_seconds=timeout_seconds,
-    )
-    _register_public_web_adapters(
-        adapters,
-        entries_by_id,
-        public_web_targets,
         timeout_seconds=timeout_seconds,
     )
     register_vulnerability_adapters(
         adapters,
-        entries_by_id,
+        by_id,
         vulnerability_targets,
         timeout_seconds=timeout_seconds,
     )
+    reference = ReferencePortfolioAdapter()
+    adapters[(reference.source_id, reference.adapter_id)] = reference
     return adapters
-
-
-def _register_public_web_adapters(
-    adapters: dict[tuple[str, str], CollectionAdapter],
-    entries_by_id: dict[str, SourceRegistryEntry],
-    targets: tuple[PublicWebTarget, ...],
-    *,
-    timeout_seconds: float,
-) -> None:
-    for target in targets:
-        if not target.enabled:
-            continue
-        entry = entries_by_id.get(target.id)
-        if entry is None:
-            raise ValueError(f"enabled public web target has no source policy: {target.id}")
-        _register(
-            adapters,
-            PublicWebAdapter(
-                entry,
-                target,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-
-
-def _register(
-    adapters: dict[tuple[str, str], CollectionAdapter],
-    adapter: CollectionAdapter,
-) -> None:
-    adapters[(adapter.source_id, adapter.adapter_id)] = adapter
 
 
 def run_scheduler_once(runtime: CollectionRuntime, *, now: datetime | None = None) -> int:

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -10,48 +10,22 @@ from time import sleep
 
 from sqlalchemy.orm import Session, sessionmaker
 
-from cip.adapters.sources.greenhouse.registry import (
-    GreenhouseBoard,
-    load_greenhouse_boards,
-)
-from cip.adapters.sources.lever.registry import LeverSite, load_lever_sites
+from cip.adapters.sources.greenhouse.registry import load_greenhouse_boards
+from cip.adapters.sources.lever.registry import load_lever_sites
 from cip.adapters.sources.organization_identity.registry import (
-    OrganizationIdentityTarget,
     load_organization_identity_targets,
 )
-from cip.adapters.sources.public_web.registry import (
-    PublicWebTarget,
-    load_public_web_targets,
-)
-from cip.adapters.sources.smartrecruiters.registry import (
-    SmartRecruitersCompany,
-    load_smartrecruiters_companies,
-)
+from cip.adapters.sources.public_web.registry import load_public_web_targets
+from cip.adapters.sources.smartrecruiters.registry import load_smartrecruiters_companies
 from cip.adapters.sources.vulnerability_catalogs.registry import (
-    VulnerabilityQueryTarget,
     load_vulnerability_query_targets,
 )
-from cip.modules.collection_orchestration.application.adapters import CisaKevAdapter
-from cip.modules.collection_orchestration.application.boamp_adapter import BoampAdapter
-from cip.modules.collection_orchestration.application.decp_adapter import DecpAdapter
-from cip.modules.collection_orchestration.application.greenhouse_adapter import GreenhouseAdapter
-from cip.modules.collection_orchestration.application.identity_adapters import (
-    register_identity_adapters,
+from cip.modules.collection_orchestration.application.adapter_composition import (
+    AdapterCompositionInputs,
+    build_runtime_adapters,
 )
-from cip.modules.collection_orchestration.application.lever_adapter import LeverAdapter
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
-from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
-from cip.modules.collection_orchestration.application.reference_adapter import (
-    ReferencePortfolioAdapter,
-)
 from cip.modules.collection_orchestration.application.scheduler import schedule_due_jobs
-from cip.modules.collection_orchestration.application.smartrecruiters_adapter import (
-    SmartRecruitersAdapter,
-)
-from cip.modules.collection_orchestration.application.ted_adapter import TedSearchAdapter
-from cip.modules.collection_orchestration.application.vulnerability_registration import (
-    register_vulnerability_adapters,
-)
 from cip.modules.collection_orchestration.application.worker import (
     WorkerOutcome,
     WorkerStatus,
@@ -78,10 +52,7 @@ from cip.modules.source_portfolio.application.service import (
     reconcile_runtime_adapters,
     sync_source_portfolio,
 )
-from cip.modules.source_portfolio.domain.models import (
-    CatalogStatus,
-    SourceCatalogEntry,
-)
+from cip.modules.source_portfolio.domain.models import CatalogStatus, SourceCatalogEntry
 from cip.modules.source_portfolio.infrastructure.registry_bundle import (
     load_source_portfolio_bundle,
 )
@@ -108,7 +79,33 @@ class CollectionRuntime:
 def build_collection_runtime(settings: Settings) -> CollectionRuntime:
     engine = create_database_engine(settings.database_url)
     factory = create_session_factory(engine)
-    entries = load_source_registry_bundle(
+    entries = _load_source_entries(settings)
+    portfolio = _load_portfolio(settings)
+    adapter_inputs = _load_adapter_inputs(settings, entries)
+    synchronized_at = utc_now()
+    with session_scope(factory) as session:
+        sync_source_registry(session, entries)
+        sync_source_portfolio(session, portfolio, now=synchronized_at)
+    adapters = build_runtime_adapters(
+        adapter_inputs,
+        timeout_seconds=settings.source_http_timeout_seconds,
+    )
+    with session_scope(factory) as session:
+        reconcile_runtime_adapters(session, adapters.keys(), now=utc_now())
+    _validate_portfolio_adapters(portfolio, adapters)
+    schedules = _load_schedules(settings)
+    _validate_registered_schedules(schedules, adapters, portfolio)
+    return CollectionRuntime(
+        factory=factory,
+        schedules=schedules,
+        adapters=adapters,
+        retention_policy=load_retention_policy(settings.retention_policy_path),
+        portfolio=portfolio,
+    )
+
+
+def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
+    return load_source_registry_bundle(
         settings.source_registry_path,
         settings.identity_source_registry_path,
         settings.decp_source_registry_path,
@@ -122,7 +119,10 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         settings.relationship_source_registry_path,
         settings.conditional_integration_source_registry_path,
     )
-    portfolio = load_source_portfolio_bundle(
+
+
+def _load_portfolio(settings: Settings) -> tuple[SourceCatalogEntry, ...]:
+    return load_source_portfolio_bundle(
         settings.source_portfolio_path,
         settings.decp_source_portfolio_path,
         settings.public_web_source_portfolio_path,
@@ -135,159 +135,36 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         settings.relationship_source_portfolio_path,
         settings.conditional_integration_source_portfolio_path,
     )
-    greenhouse_boards = load_greenhouse_boards(settings.greenhouse_board_registry_path)
-    lever_sites = load_lever_sites(settings.lever_site_registry_path)
-    smartrecruiters_companies = load_smartrecruiters_companies(
-        settings.smartrecruiters_company_registry_path
+
+
+def _load_adapter_inputs(
+    settings: Settings,
+    entries: tuple[SourceRegistryEntry, ...],
+) -> AdapterCompositionInputs:
+    return AdapterCompositionInputs(
+        entries=entries,
+        greenhouse_boards=load_greenhouse_boards(settings.greenhouse_board_registry_path),
+        lever_sites=load_lever_sites(settings.lever_site_registry_path),
+        smartrecruiters_companies=load_smartrecruiters_companies(
+            settings.smartrecruiters_company_registry_path
+        ),
+        identity_targets=load_organization_identity_targets(
+            settings.organization_identity_target_registry_path
+        ),
+        public_web_targets=load_public_web_targets(settings.public_web_target_registry_path),
+        vulnerability_targets=load_vulnerability_query_targets(
+            settings.vulnerability_query_target_registry_path
+        ),
     )
-    identity_targets = load_organization_identity_targets(
-        settings.organization_identity_target_registry_path
-    )
-    public_web_targets = load_public_web_targets(settings.public_web_target_registry_path)
-    vulnerability_targets = load_vulnerability_query_targets(
-        settings.vulnerability_query_target_registry_path
-    )
-    with session_scope(factory) as session:
-        sync_source_registry(session, entries)
-        sync_source_portfolio(session, portfolio, now=utc_now())
-    adapters = _build_adapters(
-        entries,
-        greenhouse_boards,
-        lever_sites,
-        smartrecruiters_companies,
-        identity_targets,
-        public_web_targets,
-        vulnerability_targets,
-        timeout_seconds=settings.source_http_timeout_seconds,
-    )
-    with session_scope(factory) as session:
-        reconcile_runtime_adapters(session, adapters.keys(), now=utc_now())
-    _validate_portfolio_adapters(portfolio, adapters)
-    schedules = load_collection_schedule_bundle(
+
+
+def _load_schedules(settings: Settings) -> tuple[SourceSchedule, ...]:
+    return load_collection_schedule_bundle(
         settings.collection_schedule_path,
         settings.decp_collection_schedule_path,
         settings.public_web_collection_schedule_path,
         settings.vulnerability_collection_schedule_path,
     )
-    _validate_registered_schedules(schedules, adapters, portfolio)
-    return CollectionRuntime(
-        factory=factory,
-        schedules=schedules,
-        adapters=adapters,
-        retention_policy=load_retention_policy(settings.retention_policy_path),
-        portfolio=portfolio,
-    )
-
-
-def _build_adapters(
-    entries: tuple[SourceRegistryEntry, ...],
-    greenhouse_boards: tuple[GreenhouseBoard, ...],
-    lever_sites: tuple[LeverSite, ...],
-    smartrecruiters_companies: tuple[SmartRecruitersCompany, ...],
-    identity_targets: tuple[OrganizationIdentityTarget, ...],
-    public_web_targets: tuple[PublicWebTarget, ...],
-    vulnerability_targets: tuple[VulnerabilityQueryTarget, ...],
-    *,
-    timeout_seconds: float,
-) -> dict[tuple[str, str], CollectionAdapter]:
-    entries_by_id = {entry.policy.id: entry for entry in entries}
-    adapters: dict[tuple[str, str], CollectionAdapter] = {}
-    _register(adapters, ReferencePortfolioAdapter())
-    cisa_entry = entries_by_id.get(CisaKevAdapter.source_id)
-    if cisa_entry is not None:
-        _register(adapters, CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds))
-    ted_entry = entries_by_id.get(TedSearchAdapter.source_id)
-    if ted_entry is not None:
-        _register(adapters, TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds))
-    boamp_entry = entries_by_id.get(BoampAdapter.source_id)
-    if boamp_entry is not None:
-        _register(adapters, BoampAdapter(boamp_entry, timeout_seconds=timeout_seconds))
-    decp_entry = entries_by_id.get(DecpAdapter.source_id)
-    if decp_entry is not None:
-        _register(adapters, DecpAdapter(decp_entry, timeout_seconds=timeout_seconds))
-    greenhouse_entry = entries_by_id.get(GreenhouseAdapter.source_id)
-    if greenhouse_entry is not None and any(board.enabled for board in greenhouse_boards):
-        _register(
-            adapters,
-            GreenhouseAdapter(
-                greenhouse_entry,
-                greenhouse_boards,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-    lever_entry = entries_by_id.get(LeverAdapter.source_id)
-    if lever_entry is not None and any(site.enabled for site in lever_sites):
-        _register(
-            adapters,
-            LeverAdapter(
-                lever_entry,
-                lever_sites,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-    smartrecruiters_entry = entries_by_id.get(SmartRecruitersAdapter.source_id)
-    if smartrecruiters_entry is not None and any(
-        company.enabled for company in smartrecruiters_companies
-    ):
-        _register(
-            adapters,
-            SmartRecruitersAdapter(
-                smartrecruiters_entry,
-                smartrecruiters_companies,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-    register_identity_adapters(
-        adapters,
-        entries_by_id,
-        identity_targets,
-        timeout_seconds=timeout_seconds,
-    )
-    _register_public_web_adapters(
-        adapters,
-        entries_by_id,
-        public_web_targets,
-        timeout_seconds=timeout_seconds,
-    )
-    register_vulnerability_adapters(
-        adapters,
-        entries_by_id,
-        vulnerability_targets,
-        timeout_seconds=timeout_seconds,
-    )
-    return adapters
-
-
-def _register_public_web_adapters(
-    adapters: dict[tuple[str, str], CollectionAdapter],
-    entries_by_id: dict[str, SourceRegistryEntry],
-    targets: tuple[PublicWebTarget, ...],
-    *,
-    timeout_seconds: float,
-) -> None:
-    for target in targets:
-        if not target.enabled:
-            continue
-        entry = entries_by_id.get(target.id)
-        if entry is None:
-            raise ValueError(
-                f"enabled public web target has no source policy: {target.id}"
-            )
-        _register(
-            adapters,
-            PublicWebAdapter(
-                entry,
-                target,
-                timeout_seconds=timeout_seconds,
-            ),
-        )
-
-
-def _register(
-    adapters: dict[tuple[str, str], CollectionAdapter],
-    adapter: CollectionAdapter,
-) -> None:
-    adapters[(adapter.source_id, adapter.adapter_id)] = adapter
 
 
 def run_scheduler_once(runtime: CollectionRuntime, *, now: datetime | None = None) -> int:

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -10,13 +10,19 @@ from time import sleep
 
 from sqlalchemy.orm import Session, sessionmaker
 
-from cip.adapters.sources.greenhouse.registry import GreenhouseBoard, load_greenhouse_boards
+from cip.adapters.sources.greenhouse.registry import (
+    GreenhouseBoard,
+    load_greenhouse_boards,
+)
 from cip.adapters.sources.lever.registry import LeverSite, load_lever_sites
 from cip.adapters.sources.organization_identity.registry import (
     OrganizationIdentityTarget,
     load_organization_identity_targets,
 )
-from cip.adapters.sources.public_web.registry import PublicWebTarget, load_public_web_targets
+from cip.adapters.sources.public_web.registry import (
+    PublicWebTarget,
+    load_public_web_targets,
+)
 from cip.adapters.sources.smartrecruiters.registry import (
     SmartRecruitersCompany,
     load_smartrecruiters_companies,
@@ -59,7 +65,9 @@ from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.data_governance.infrastructure.retention_loader import load_retention_policy
 from cip.modules.source_governance.infrastructure.persistence import sync_source_registry
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
-from cip.modules.source_governance.infrastructure.registry_bundle import load_source_registry_bundle
+from cip.modules.source_governance.infrastructure.registry_bundle import (
+    load_source_registry_bundle,
+)
 from cip.modules.source_portfolio.application.backfill_worker import (
     BackfillWorkerOutcome,
     BackfillWorkerStatus,
@@ -70,8 +78,13 @@ from cip.modules.source_portfolio.application.service import (
     reconcile_runtime_adapters,
     sync_source_portfolio,
 )
-from cip.modules.source_portfolio.domain.models import CatalogStatus, SourceCatalogEntry
-from cip.modules.source_portfolio.infrastructure.registry_bundle import load_source_portfolio_bundle
+from cip.modules.source_portfolio.domain.models import (
+    CatalogStatus,
+    SourceCatalogEntry,
+)
+from cip.modules.source_portfolio.infrastructure.registry_bundle import (
+    load_source_portfolio_bundle,
+)
 from cip.shared.config.settings import Settings
 from cip.shared.kernel.time import utc_now
 from cip.shared.persistence.session import (
@@ -139,12 +152,12 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         sync_source_portfolio(session, portfolio, now=utc_now())
     adapters = _build_adapters(
         entries,
-        greenhouse_boards=greenhouse_boards,
-        lever_sites=lever_sites,
-        smartrecruiters_companies=smartrecruiters_companies,
-        identity_targets=identity_targets,
-        public_web_targets=public_web_targets,
-        vulnerability_targets=vulnerability_targets,
+        greenhouse_boards,
+        lever_sites,
+        smartrecruiters_companies,
+        identity_targets,
+        public_web_targets,
+        vulnerability_targets,
         timeout_seconds=settings.source_http_timeout_seconds,
     )
     with session_scope(factory) as session:
@@ -168,80 +181,113 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
 
 def _build_adapters(
     entries: tuple[SourceRegistryEntry, ...],
-    *,
     greenhouse_boards: tuple[GreenhouseBoard, ...],
     lever_sites: tuple[LeverSite, ...],
     smartrecruiters_companies: tuple[SmartRecruitersCompany, ...],
     identity_targets: tuple[OrganizationIdentityTarget, ...],
     public_web_targets: tuple[PublicWebTarget, ...],
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...],
+    *,
     timeout_seconds: float,
 ) -> dict[tuple[str, str], CollectionAdapter]:
-    by_id = {entry.policy.id: entry for entry in entries}
-    cisa_entry = by_id.get(CisaKevAdapter.source_id)
-    ted_entry = by_id.get(TedSearchAdapter.source_id)
-    boamp_entry = by_id.get(BoampAdapter.source_id)
-    decp_entry = by_id.get(DecpAdapter.source_id)
-    greenhouse_entry = by_id.get(GreenhouseAdapter.source_id)
-    lever_entry = by_id.get(LeverAdapter.source_id)
-    smartrecruiters_entry = by_id.get(SmartRecruitersAdapter.source_id)
-    public_web_entry = by_id.get(PublicWebAdapter.source_id)
+    entries_by_id = {entry.policy.id: entry for entry in entries}
     adapters: dict[tuple[str, str], CollectionAdapter] = {}
+    _register(adapters, ReferencePortfolioAdapter())
+    cisa_entry = entries_by_id.get(CisaKevAdapter.source_id)
     if cisa_entry is not None:
-        cisa = CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds)
-        adapters[(cisa.source_id, cisa.adapter_id)] = cisa
+        _register(adapters, CisaKevAdapter(cisa_entry, timeout_seconds=timeout_seconds))
+    ted_entry = entries_by_id.get(TedSearchAdapter.source_id)
     if ted_entry is not None:
-        ted = TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds)
-        adapters[(ted.source_id, ted.adapter_id)] = ted
+        _register(adapters, TedSearchAdapter(ted_entry, timeout_seconds=timeout_seconds))
+    boamp_entry = entries_by_id.get(BoampAdapter.source_id)
     if boamp_entry is not None:
-        boamp = BoampAdapter(boamp_entry, timeout_seconds=timeout_seconds)
-        adapters[(boamp.source_id, boamp.adapter_id)] = boamp
+        _register(adapters, BoampAdapter(boamp_entry, timeout_seconds=timeout_seconds))
+    decp_entry = entries_by_id.get(DecpAdapter.source_id)
     if decp_entry is not None:
-        decp = DecpAdapter(decp_entry, timeout_seconds=timeout_seconds)
-        adapters[(decp.source_id, decp.adapter_id)] = decp
-    if greenhouse_entry is not None:
-        greenhouse = GreenhouseAdapter(
-            greenhouse_entry,
-            greenhouse_boards,
-            timeout_seconds=timeout_seconds,
+        _register(adapters, DecpAdapter(decp_entry, timeout_seconds=timeout_seconds))
+    greenhouse_entry = entries_by_id.get(GreenhouseAdapter.source_id)
+    if greenhouse_entry is not None and any(board.enabled for board in greenhouse_boards):
+        _register(
+            adapters,
+            GreenhouseAdapter(
+                greenhouse_entry,
+                greenhouse_boards,
+                timeout_seconds=timeout_seconds,
+            ),
         )
-        adapters[(greenhouse.source_id, greenhouse.adapter_id)] = greenhouse
-    if lever_entry is not None:
-        lever = LeverAdapter(
-            lever_entry,
-            lever_sites,
-            timeout_seconds=timeout_seconds,
+    lever_entry = entries_by_id.get(LeverAdapter.source_id)
+    if lever_entry is not None and any(site.enabled for site in lever_sites):
+        _register(
+            adapters,
+            LeverAdapter(
+                lever_entry,
+                lever_sites,
+                timeout_seconds=timeout_seconds,
+            ),
         )
-        adapters[(lever.source_id, lever.adapter_id)] = lever
-    if smartrecruiters_entry is not None:
-        smartrecruiters = SmartRecruitersAdapter(
-            smartrecruiters_entry,
-            smartrecruiters_companies,
-            timeout_seconds=timeout_seconds,
+    smartrecruiters_entry = entries_by_id.get(SmartRecruitersAdapter.source_id)
+    if smartrecruiters_entry is not None and any(
+        company.enabled for company in smartrecruiters_companies
+    ):
+        _register(
+            adapters,
+            SmartRecruitersAdapter(
+                smartrecruiters_entry,
+                smartrecruiters_companies,
+                timeout_seconds=timeout_seconds,
+            ),
         )
-        adapters[(smartrecruiters.source_id, smartrecruiters.adapter_id)] = smartrecruiters
-    if public_web_entry is not None:
-        public_web = PublicWebAdapter(
-            public_web_entry,
-            public_web_targets,
-            timeout_seconds=timeout_seconds,
-        )
-        adapters[(public_web.source_id, public_web.adapter_id)] = public_web
     register_identity_adapters(
         adapters,
-        by_id,
+        entries_by_id,
         identity_targets,
+        timeout_seconds=timeout_seconds,
+    )
+    _register_public_web_adapters(
+        adapters,
+        entries_by_id,
+        public_web_targets,
         timeout_seconds=timeout_seconds,
     )
     register_vulnerability_adapters(
         adapters,
-        by_id,
+        entries_by_id,
         vulnerability_targets,
         timeout_seconds=timeout_seconds,
     )
-    reference = ReferencePortfolioAdapter()
-    adapters[(reference.source_id, reference.adapter_id)] = reference
     return adapters
+
+
+def _register_public_web_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    targets: tuple[PublicWebTarget, ...],
+    *,
+    timeout_seconds: float,
+) -> None:
+    for target in targets:
+        if not target.enabled:
+            continue
+        entry = entries_by_id.get(target.id)
+        if entry is None:
+            raise ValueError(
+                f"enabled public web target has no source policy: {target.id}"
+            )
+        _register(
+            adapters,
+            PublicWebAdapter(
+                entry,
+                target,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    adapters[(adapter.source_id, adapter.adapter_id)] = adapter
 
 
 def run_scheduler_once(runtime: CollectionRuntime, *, now: datetime | None = None) -> int:
@@ -327,7 +373,9 @@ def _validate_registered_schedules(
         if not conditional:
             missing.append(f"{schedule.source_id}/{schedule.adapter_id}")
     if missing:
-        raise ValueError(f"enabled schedules have no registered adapter: {', '.join(missing)}")
+        raise ValueError(
+            f"enabled schedules have no registered adapter: {', '.join(missing)}"
+        )
 
 
 def _validate_portfolio_adapters(

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -10,41 +10,38 @@ from time import sleep
 
 from sqlalchemy.orm import Session, sessionmaker
 
-from cip.adapters.sources.greenhouse.registry import (
-    GreenhouseBoard,
-    load_greenhouse_boards,
-)
+from cip.adapters.sources.greenhouse.registry import GreenhouseBoard, load_greenhouse_boards
 from cip.adapters.sources.lever.registry import LeverSite, load_lever_sites
 from cip.adapters.sources.organization_identity.registry import (
     OrganizationIdentityTarget,
     load_organization_identity_targets,
 )
-from cip.adapters.sources.public_web.registry import (
-    PublicWebTarget,
-    load_public_web_targets,
-)
+from cip.adapters.sources.public_web.registry import PublicWebTarget, load_public_web_targets
 from cip.adapters.sources.smartrecruiters.registry import (
     SmartRecruitersCompany,
     load_smartrecruiters_companies,
+)
+from cip.adapters.sources.vulnerability_catalogs.registry import (
+    VulnerabilityQueryTarget,
+    load_vulnerability_query_targets,
 )
 from cip.modules.collection_orchestration.application.adapters import CisaKevAdapter
 from cip.modules.collection_orchestration.application.boamp_adapter import BoampAdapter
 from cip.modules.collection_orchestration.application.decp_adapter import DecpAdapter
 from cip.modules.collection_orchestration.application.greenhouse_adapter import GreenhouseAdapter
-from cip.modules.collection_orchestration.application.identity_adapters import (
-    register_identity_adapters,
-)
+from cip.modules.collection_orchestration.application.identity_adapters import register_identity_adapters
 from cip.modules.collection_orchestration.application.lever_adapter import LeverAdapter
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
-from cip.modules.collection_orchestration.application.reference_adapter import (
-    ReferencePortfolioAdapter,
-)
+from cip.modules.collection_orchestration.application.reference_adapter import ReferencePortfolioAdapter
 from cip.modules.collection_orchestration.application.scheduler import schedule_due_jobs
 from cip.modules.collection_orchestration.application.smartrecruiters_adapter import (
     SmartRecruitersAdapter,
 )
 from cip.modules.collection_orchestration.application.ted_adapter import TedSearchAdapter
+from cip.modules.collection_orchestration.application.vulnerability_registration import (
+    register_vulnerability_adapters,
+)
 from cip.modules.collection_orchestration.application.worker import (
     WorkerOutcome,
     WorkerStatus,
@@ -58,9 +55,7 @@ from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.data_governance.infrastructure.retention_loader import load_retention_policy
 from cip.modules.source_governance.infrastructure.persistence import sync_source_registry
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
-from cip.modules.source_governance.infrastructure.registry_bundle import (
-    load_source_registry_bundle,
-)
+from cip.modules.source_governance.infrastructure.registry_bundle import load_source_registry_bundle
 from cip.modules.source_portfolio.application.backfill_worker import (
     BackfillWorkerOutcome,
     BackfillWorkerStatus,
@@ -71,13 +66,8 @@ from cip.modules.source_portfolio.application.service import (
     reconcile_runtime_adapters,
     sync_source_portfolio,
 )
-from cip.modules.source_portfolio.domain.models import (
-    CatalogStatus,
-    SourceCatalogEntry,
-)
-from cip.modules.source_portfolio.infrastructure.registry_bundle import (
-    load_source_portfolio_bundle,
-)
+from cip.modules.source_portfolio.domain.models import CatalogStatus, SourceCatalogEntry
+from cip.modules.source_portfolio.infrastructure.registry_bundle import load_source_portfolio_bundle
 from cip.shared.config.settings import Settings
 from cip.shared.kernel.time import utc_now
 from cip.shared.persistence.session import (
@@ -112,6 +102,7 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         settings.passive_exposure_source_registry_path,
         settings.advisory_source_registry_path,
         settings.corporate_change_source_registry_path,
+        settings.relationship_source_registry_path,
         settings.conditional_integration_source_registry_path,
     )
     portfolio = load_source_portfolio_bundle(
@@ -124,6 +115,7 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         settings.passive_exposure_source_portfolio_path,
         settings.advisory_source_portfolio_path,
         settings.corporate_change_source_portfolio_path,
+        settings.relationship_source_portfolio_path,
         settings.conditional_integration_source_portfolio_path,
     )
     greenhouse_boards = load_greenhouse_boards(settings.greenhouse_board_registry_path)
@@ -135,6 +127,9 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         settings.organization_identity_target_registry_path
     )
     public_web_targets = load_public_web_targets(settings.public_web_target_registry_path)
+    vulnerability_targets = load_vulnerability_query_targets(
+        settings.vulnerability_query_target_registry_path
+    )
     with session_scope(factory) as session:
         sync_source_registry(session, entries)
         sync_source_portfolio(session, portfolio, now=utc_now())
@@ -145,6 +140,7 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         smartrecruiters_companies,
         identity_targets,
         public_web_targets,
+        vulnerability_targets,
         timeout_seconds=settings.source_http_timeout_seconds,
     )
     with session_scope(factory) as session:
@@ -154,6 +150,7 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         settings.collection_schedule_path,
         settings.decp_collection_schedule_path,
         settings.public_web_collection_schedule_path,
+        settings.vulnerability_collection_schedule_path,
     )
     _validate_registered_schedules(schedules, adapters, portfolio)
     return CollectionRuntime(
@@ -172,6 +169,7 @@ def _build_adapters(
     smartrecruiters_companies: tuple[SmartRecruitersCompany, ...],
     identity_targets: tuple[OrganizationIdentityTarget, ...],
     public_web_targets: tuple[PublicWebTarget, ...],
+    vulnerability_targets: tuple[VulnerabilityQueryTarget, ...],
     *,
     timeout_seconds: float,
 ) -> dict[tuple[str, str], CollectionAdapter]:
@@ -234,6 +232,12 @@ def _build_adapters(
         public_web_targets,
         timeout_seconds=timeout_seconds,
     )
+    register_vulnerability_adapters(
+        adapters,
+        entries_by_id,
+        vulnerability_targets,
+        timeout_seconds=timeout_seconds,
+    )
     return adapters
 
 
@@ -249,9 +253,7 @@ def _register_public_web_adapters(
             continue
         entry = entries_by_id.get(target.id)
         if entry is None:
-            raise ValueError(
-                f"enabled public web target has no source policy: {target.id}"
-            )
+            raise ValueError(f"enabled public web target has no source policy: {target.id}")
         _register(
             adapters,
             PublicWebAdapter(
@@ -352,9 +354,7 @@ def _validate_registered_schedules(
         if not conditional:
             missing.append(f"{schedule.source_id}/{schedule.adapter_id}")
     if missing:
-        raise ValueError(
-            f"enabled schedules have no registered adapter: {', '.join(missing)}"
-        )
+        raise ValueError(f"enabled schedules have no registered adapter: {', '.join(missing)}")
 
 
 def _validate_portfolio_adapters(

--- a/src/cip/modules/collection_orchestration/application/vulnerability_adapter_support.py
+++ b/src/cip/modules/collection_orchestration/application/vulnerability_adapter_support.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel
+
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+MAX_JSON_BYTES = 8 * 1024 * 1024
+PURPOSE = "vulnerability-intelligence"
+
+
+@dataclass(frozen=True, slots=True)
+class VulnerabilityObservationContext:
+    source_id: str
+    adapter_id: str
+    adapter_version: str
+    collection_job_id: UUID
+    collected_at: datetime
+    retention_until: datetime
+
+
+def authorize_vulnerability_request(
+    entry: SourceRegistryEntry,
+    *,
+    target_url: str,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.VULNERABILITY_METADATA,
+            target_url=target_url,
+            purpose=PURPOSE,
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def get_json(
+    client: httpx.Client,
+    target_url: str,
+    *,
+    params: dict[str, str | int] | None = None,
+) -> bytes:
+    try:
+        response = client.get(target_url, params=params)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        raise AdapterExecutionError(
+            f"provider returned HTTP {status}",
+            error_code=f"http_{status}",
+            retryable=status == 429 or status >= 500,
+        ) from exc
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        raise AdapterExecutionError(
+            str(exc) or type(exc).__name__,
+            error_code="source_transport_error",
+            retryable=True,
+        ) from exc
+    content_type = response.headers.get("content-type", "").casefold()
+    if "json" not in content_type:
+        raise AdapterExecutionError(
+            "provider response is not JSON",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    if len(response.content) > MAX_JSON_BYTES:
+        raise AdapterExecutionError(
+            "provider JSON response exceeds size limit",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    return response.content
+
+
+def raw_observation(
+    model: BaseModel,
+    *,
+    context: VulnerabilityObservationContext,
+    source_url: str,
+    source_record_key: str,
+    source_record_type: str,
+    published_at: datetime | None = None,
+    source_updated_at: datetime | None = None,
+) -> RawObservation:
+    encoded = model.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
+    return RawObservation(
+        source_id=context.source_id,
+        adapter_id=context.adapter_id,
+        adapter_version=context.adapter_version,
+        collection_job_id=context.collection_job_id,
+        source_record_type=source_record_type,
+        source_url=source_url,
+        payload_hash_sha256=sha256(encoded).hexdigest(),
+        data_categories=frozenset({DataCategory.VULNERABILITY_METADATA}),
+        source_record_key=source_record_key,
+        collected_at=context.collected_at,
+        published_at=published_at,
+        source_updated_at=source_updated_at,
+        retention_until=context.retention_until,
+        schema_fingerprint=f"{source_record_type}:v1",
+    )

--- a/src/cip/modules/collection_orchestration/application/vulnerability_list_adapters.py
+++ b/src/cip/modules/collection_orchestration/application/vulnerability_list_adapters.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+
+from cip.adapters.sources.vulnerability_catalogs.mappers import (
+    map_ghsa_record,
+    map_nvd_record,
+)
+from cip.adapters.sources.vulnerability_catalogs.runtime_schemas import NvdPage
+from cip.adapters.sources.vulnerability_catalogs.schemas import GhsaRecord
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.collection_orchestration.application.vulnerability_adapter_support import (
+    VulnerabilityObservationContext,
+    authorize_vulnerability_request,
+    get_json,
+    raw_observation,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class NvdVulnerabilityAdapter:
+    source_id = "nvd-vulnerabilities"
+    adapter_id = "nvd-cve-api"
+    adapter_version = "1"
+    data_category = DataCategory.VULNERABILITY_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        _validate_entry(entry, self.source_id, timeout_seconds)
+        self._entry = entry
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        start_index = _positive_cursor(checkpoint_payload, "start_index", default=0)
+        target_url = self._entry.policy.base_url
+        authorize_vulnerability_request(
+            self._entry,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(
+                client,
+                target_url,
+                params={
+                    "resultsPerPage": 2_000,
+                    "startIndex": start_index,
+                },
+            )
+        try:
+            page = NvdPage.model_validate_json(body)
+        except ValidationError as exc:
+            raise _schema_error("NVD response schema changed", exc) from exc
+        context = VulnerabilityObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = tuple(
+            raw_observation(
+                item,
+                context=context,
+                source_url=target_url,
+                source_record_key=item.cve.id,
+                source_record_type="nvd-cve-v2",
+                published_at=item.cve.published,
+                source_updated_at=item.cve.last_modified,
+            )
+            for item in page.vulnerabilities
+        )
+        snapshots = tuple(
+            map_nvd_record(item, source_url=target_url) for item in page.vulnerabilities
+        )
+        next_index = page.start_index + len(page.vulnerabilities)
+        if next_index >= page.total_results:
+            next_index = 0
+        return AdapterCollectionBatch(
+            observations=observations,
+            vulnerability_snapshots=snapshots,
+            checkpoint_payload={"start_index": next_index},
+            not_modified=not page.vulnerabilities,
+        )
+
+
+class GithubAdvisoryAdapter:
+    source_id = "github-global-advisories"
+    adapter_id = "github-global-advisories"
+    adapter_version = "1"
+    data_category = DataCategory.VULNERABILITY_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        _validate_entry(entry, self.source_id, timeout_seconds)
+        self._entry = entry
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        page = _positive_cursor(checkpoint_payload, "page", default=1)
+        target_url = self._entry.policy.base_url
+        authorize_vulnerability_request(
+            self._entry,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(
+                client,
+                target_url,
+                params={
+                    "per_page": 100,
+                    "page": page,
+                    "sort": "updated",
+                    "direction": "asc",
+                },
+            )
+        try:
+            records = TypeAdapter(list[GhsaRecord]).validate_json(body)
+        except ValidationError as exc:
+            raise _schema_error("GitHub advisory response schema changed", exc) from exc
+        context = VulnerabilityObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = tuple(
+            raw_observation(
+                record,
+                context=context,
+                source_url=target_url,
+                source_record_key=record.ghsa_id,
+                source_record_type="github-global-advisory",
+                published_at=record.published_at,
+                source_updated_at=record.updated_at,
+            )
+            for record in records
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            vulnerability_snapshots=tuple(
+                map_ghsa_record(record, source_url=target_url) for record in records
+            ),
+            checkpoint_payload={"page": page + 1 if records else 1},
+            not_modified=not records,
+        )
+
+
+def _positive_cursor(
+    payload: Mapping[str, object] | None,
+    key: str,
+    *,
+    default: int,
+) -> int:
+    if payload is None or key not in payload:
+        return default
+    value = payload[key]
+    if not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            f"checkpoint field {key} must be a non-negative integer",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    return value
+
+
+def _validate_entry(
+    entry: SourceRegistryEntry,
+    source_id: str,
+    timeout_seconds: float,
+) -> None:
+    if entry.policy.id != source_id:
+        raise ValueError(f"adapter requires source policy {source_id}")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+
+def _schema_error(message: str, exc: ValidationError) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        message,
+        error_code="source_schema_drift",
+        retryable=False,
+    )

--- a/src/cip/modules/collection_orchestration/application/vulnerability_query_adapters.py
+++ b/src/cip/modules/collection_orchestration/application/vulnerability_query_adapters.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.vulnerability_catalogs.mappers import (
+    map_cve_org_record,
+    map_epss_row,
+    map_osv_record,
+)
+from cip.adapters.sources.vulnerability_catalogs.registry import VulnerabilityQueryTarget
+from cip.adapters.sources.vulnerability_catalogs.runtime_schemas import EpssPage
+from cip.adapters.sources.vulnerability_catalogs.schemas import CveOrgRecord, OsvRecord
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.collection_orchestration.application.vulnerability_adapter_support import (
+    VulnerabilityObservationContext,
+    authorize_vulnerability_request,
+    get_json,
+    raw_observation,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.modules.vulnerability_knowledge.domain.models import VulnerabilitySource
+
+
+class CveOrgVulnerabilityAdapter:
+    source_id = "cve-org-services"
+    adapter_id = "cve-org-records"
+    adapter_version = "1"
+    data_category = DataCategory.VULNERABILITY_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[VulnerabilityQueryTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        _validate_entry(entry, self.source_id, timeout_seconds)
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled and target.cve_id)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        return _collect_cve_record(
+            self,
+            source=VulnerabilitySource.CVE_ORG,
+            collection_job_id=collection_job_id,
+            checkpoint_payload=checkpoint_payload,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+
+
+class CirclVulnerabilityAdapter:
+    source_id = "circl-vulnerability-lookup"
+    adapter_id = "circl-cve-v5"
+    adapter_version = "1"
+    data_category = DataCategory.VULNERABILITY_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[VulnerabilityQueryTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        _validate_entry(entry, self.source_id, timeout_seconds)
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled and target.cve_id)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        return _collect_cve_record(
+            self,
+            source=VulnerabilitySource.CIRCL,
+            collection_job_id=collection_job_id,
+            checkpoint_payload=checkpoint_payload,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+
+
+class OsvVulnerabilityAdapter:
+    source_id = "osv-api"
+    adapter_id = "osv-api"
+    adapter_version = "1"
+    data_category = DataCategory.VULNERABILITY_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[VulnerabilityQueryTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        _validate_entry(entry, self.source_id, timeout_seconds)
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled and target.osv_id)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None or target.osv_id is None:
+            return _empty_batch()
+        target_url = f"{self._entry.policy.base_url.rstrip('/')}/vulns/{target.osv_id}"
+        authorize_vulnerability_request(
+            self._entry,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        body = _request(
+            target_url,
+            timeout_seconds=self._timeout_seconds,
+            transport=self._transport,
+        )
+        try:
+            record = OsvRecord.model_validate_json(body)
+        except ValidationError as exc:
+            raise _schema_error("OSV response schema changed") from exc
+        context = VulnerabilityObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observation = raw_observation(
+            record,
+            context=context,
+            source_url=target_url,
+            source_record_key=record.id,
+            source_record_type="osv-vulnerability",
+            published_at=record.published,
+            source_updated_at=record.modified,
+        )
+        return AdapterCollectionBatch(
+            observations=(observation,),
+            vulnerability_snapshots=(map_osv_record(record, source_url=target_url),),
+            checkpoint_payload={"target_index": next_index},
+            not_modified=False,
+        )
+
+
+class EpssLookupAdapter:
+    source_id = "first-epss"
+    adapter_id = "first-epss-api"
+    adapter_version = "1"
+    data_category = DataCategory.VULNERABILITY_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[VulnerabilityQueryTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        _validate_entry(entry, self.source_id, timeout_seconds)
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled and target.cve_id)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        if not self._targets:
+            return _empty_batch()
+        start = _target_index(checkpoint_payload, len(self._targets))
+        selected = self._targets[start : start + 20]
+        if not selected:
+            start = 0
+            selected = self._targets[:20]
+        cves = ",".join(target.cve_id or "" for target in selected)
+        target_url = self._entry.policy.base_url
+        authorize_vulnerability_request(
+            self._entry,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(client, target_url, params={"cve": cves})
+        try:
+            page = EpssPage.model_validate_json(body)
+            rows = tuple(item.canonical() for item in page.data)
+        except ValidationError as exc:
+            raise _schema_error("EPSS response schema changed") from exc
+        context = VulnerabilityObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = tuple(
+            raw_observation(
+                row,
+                context=context,
+                source_url=target_url,
+                source_record_key=f"{row.cve}:{row.score_date.date().isoformat()}",
+                source_record_type="first-epss-score",
+                source_updated_at=row.score_date,
+            )
+            for row in rows
+        )
+        next_index = (
+            0 if start + len(selected) >= len(self._targets) else start + len(selected)
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            vulnerability_snapshots=tuple(
+                map_epss_row(row, source_url=target_url) for row in rows
+            ),
+            checkpoint_payload={"target_index": next_index},
+            not_modified=not rows,
+        )
+
+
+def _collect_cve_record(
+    adapter: CveOrgVulnerabilityAdapter | CirclVulnerabilityAdapter,
+    *,
+    source: VulnerabilitySource,
+    collection_job_id: UUID,
+    checkpoint_payload: Mapping[str, object] | None,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> AdapterCollectionBatch:
+    target, next_index = _next_target(adapter._targets, checkpoint_payload)
+    if target is None or target.cve_id is None:
+        return _empty_batch()
+    target_url = f"{adapter._entry.policy.base_url.rstrip('/')}/{target.cve_id}"
+    authorize_vulnerability_request(
+        adapter._entry,
+        target_url=target_url,
+        collected_at=collected_at,
+    )
+    body = _request(
+        target_url,
+        timeout_seconds=adapter._timeout_seconds,
+        transport=adapter._transport,
+    )
+    try:
+        record = CveOrgRecord.model_validate_json(body)
+    except ValidationError as exc:
+        raise _schema_error("CVE-compatible response schema changed") from exc
+    snapshot = map_cve_org_record(record, source_url=target_url, source=source)
+    context = VulnerabilityObservationContext(
+        source_id=adapter.source_id,
+        adapter_id=adapter.adapter_id,
+        adapter_version=adapter.adapter_version,
+        collection_job_id=collection_job_id,
+        collected_at=collected_at,
+        retention_until=retention_until,
+    )
+    observation = raw_observation(
+        record,
+        context=context,
+        source_url=target_url,
+        source_record_key=record.cve_metadata.cve_id,
+        source_record_type=f"{adapter.source_id}-cve-v5",
+        published_at=record.cve_metadata.date_published,
+        source_updated_at=record.cve_metadata.date_updated,
+    )
+    return AdapterCollectionBatch(
+        observations=(observation,),
+        vulnerability_snapshots=(snapshot,),
+        checkpoint_payload={"target_index": next_index},
+        not_modified=False,
+    )
+
+
+def _next_target(
+    targets: tuple[VulnerabilityQueryTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[VulnerabilityQueryTarget | None, int]:
+    if not targets:
+        return None, 0
+    index = _target_index(payload, len(targets))
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _target_index(payload: Mapping[str, object] | None, count: int) -> int:
+    if payload is None:
+        return 0
+    value = payload.get("target_index", 0)
+    if not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            "invalid target_index",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    return value % max(count, 1)
+
+
+def _request(
+    target_url: str,
+    *,
+    timeout_seconds: float,
+    transport: httpx.BaseTransport | None,
+) -> bytes:
+    with httpx.Client(
+        timeout=timeout_seconds,
+        follow_redirects=False,
+        transport=transport,
+    ) as client:
+        return get_json(client, target_url)
+
+
+def _validate_entry(
+    entry: SourceRegistryEntry,
+    source_id: str,
+    timeout_seconds: float,
+) -> None:
+    if entry.policy.id != source_id:
+        raise ValueError(f"adapter requires source policy {source_id}")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        checkpoint_payload={"target_index": 0},
+        not_modified=True,
+    )
+
+
+def _schema_error(message: str) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        message,
+        error_code="source_schema_drift",
+        retryable=False,
+    )

--- a/src/cip/modules/collection_orchestration/application/vulnerability_registration.py
+++ b/src/cip/modules/collection_orchestration/application/vulnerability_registration.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from cip.adapters.sources.vulnerability_catalogs.registry import VulnerabilityQueryTarget
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.collection_orchestration.application.vulnerability_list_adapters import (
+    GithubAdvisoryAdapter,
+    NvdVulnerabilityAdapter,
+)
+from cip.modules.collection_orchestration.application.vulnerability_query_adapters import (
+    CirclVulnerabilityAdapter,
+    CveOrgVulnerabilityAdapter,
+    EpssLookupAdapter,
+    OsvVulnerabilityAdapter,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+def register_vulnerability_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    targets: tuple[VulnerabilityQueryTarget, ...],
+    *,
+    timeout_seconds: float,
+) -> None:
+    nvd_entry = entries_by_id.get(NvdVulnerabilityAdapter.source_id)
+    if nvd_entry is not None:
+        _register(adapters, NvdVulnerabilityAdapter(nvd_entry, timeout_seconds=timeout_seconds))
+
+    github_entry = entries_by_id.get(GithubAdvisoryAdapter.source_id)
+    if github_entry is not None:
+        _register(
+            adapters,
+            GithubAdvisoryAdapter(github_entry, timeout_seconds=timeout_seconds),
+        )
+
+    cve_entry = entries_by_id.get(CveOrgVulnerabilityAdapter.source_id)
+    if cve_entry is not None:
+        _register(
+            adapters,
+            CveOrgVulnerabilityAdapter(cve_entry, targets, timeout_seconds=timeout_seconds),
+        )
+
+    epss_entry = entries_by_id.get(EpssLookupAdapter.source_id)
+    if epss_entry is not None:
+        _register(
+            adapters,
+            EpssLookupAdapter(epss_entry, targets, timeout_seconds=timeout_seconds),
+        )
+
+    osv_entry = entries_by_id.get(OsvVulnerabilityAdapter.source_id)
+    if osv_entry is not None:
+        _register(
+            adapters,
+            OsvVulnerabilityAdapter(osv_entry, targets, timeout_seconds=timeout_seconds),
+        )
+
+    circl_entry = entries_by_id.get(CirclVulnerabilityAdapter.source_id)
+    if circl_entry is not None:
+        _register(
+            adapters,
+            CirclVulnerabilityAdapter(circl_entry, targets, timeout_seconds=timeout_seconds),
+        )
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    adapters[(adapter.source_id, adapter.adapter_id)] = adapter

--- a/src/cip/modules/source_portfolio/application/backfill_worker.py
+++ b/src/cip/modules/source_portfolio/application/backfill_worker.py
@@ -39,6 +39,9 @@ from cip.modules.source_portfolio.application.service import (
 )
 from cip.modules.source_portfolio.domain.models import SchemaState
 from cip.modules.source_portfolio.infrastructure.models import BackfillPartitionRecord
+from cip.modules.vulnerability_knowledge.infrastructure.projections import (
+    persist_vulnerability_snapshots,
+)
 from cip.shared.kernel.time import require_aware_utc, utc_now
 from cip.shared.persistence.session import session_scope
 
@@ -121,6 +124,11 @@ def run_backfill_once(
         persist_public_footprint_projections(
             session,
             batch.public_footprint_projections,
+            now=completed_at,
+        )
+        persist_vulnerability_snapshots(
+            session,
+            batch.vulnerability_snapshots,
             now=completed_at,
         )
         record_collection_success(

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -26,9 +26,7 @@ class Settings(BaseSettings):
     identity_source_registry_path: Path = Path("policies/identity_sources.yml")
     decp_source_registry_path: Path = Path("policies/sources.decp.yml")
     public_web_source_registry_path: Path = Path("policies/sources.public_web.yml")
-    vulnerability_source_registry_path: Path = Path(
-        "policies/sources.vulnerability.yml"
-    )
+    vulnerability_source_registry_path: Path = Path("policies/sources.vulnerability.yml")
     incident_source_registry_path: Path = Path("policies/sources.incidents.yml")
     threat_telemetry_source_registry_path: Path = Path(
         "policies/sources.threat_telemetry.yml"
@@ -53,18 +51,14 @@ class Settings(BaseSettings):
     vulnerability_source_portfolio_path: Path = Path(
         "policies/source_portfolio.vulnerability.yml"
     )
-    incident_source_portfolio_path: Path = Path(
-        "policies/source_portfolio.incidents.yml"
-    )
+    incident_source_portfolio_path: Path = Path("policies/source_portfolio.incidents.yml")
     threat_telemetry_source_portfolio_path: Path = Path(
         "policies/source_portfolio.threat_telemetry.yml"
     )
     passive_exposure_source_portfolio_path: Path = Path(
         "policies/source_portfolio.passive_exposure.yml"
     )
-    advisory_source_portfolio_path: Path = Path(
-        "policies/source_portfolio.advisories.yml"
-    )
+    advisory_source_portfolio_path: Path = Path("policies/source_portfolio.advisories.yml")
     corporate_change_source_portfolio_path: Path = Path(
         "policies/source_portfolio.corporate_changes.yml"
     )
@@ -84,11 +78,17 @@ class Settings(BaseSettings):
         "policies/organization_identity_targets.yml"
     )
     public_web_target_registry_path: Path = Path("policies/public_web_targets.yml")
+    vulnerability_query_target_registry_path: Path = Path(
+        "policies/vulnerability_query_targets.yml"
+    )
     retention_policy_path: Path = Path("policies/retention.yml")
     collection_schedule_path: Path = Path("policies/collection_schedules.yml")
     decp_collection_schedule_path: Path = Path("policies/collection_schedules.decp.yml")
     public_web_collection_schedule_path: Path = Path(
         "policies/collection_schedules.public_web.yml"
+    )
+    vulnerability_collection_schedule_path: Path = Path(
+        "policies/collection_schedules.vulnerability.yml"
     )
     control_plane_token: str = Field(
         default="development-control-token",

--- a/tests/unit/collection_orchestration/test_runtime_and_metrics.py
+++ b/tests/unit/collection_orchestration/test_runtime_and_metrics.py
@@ -75,15 +75,17 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
     get_metadata().create_all(create_database_engine(settings.database_url))
 
     runtime = build_collection_runtime(settings)
-    assert run_scheduler_once(runtime, now=NOW) == 7
+    assert run_scheduler_once(runtime, now=NOW) == 9
     assert run_scheduler_once(runtime, now=NOW) == 0
 
     expected_sources = (
         "boamp",
         "cisa-kev",
         "decp",
+        "github-global-advisories",
         "greenhouse-job-board",
         "lever-job-board",
+        "nvd-vulnerabilities",
         "smartrecruiters-job-board",
         "ted-search",
     )
@@ -101,8 +103,10 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         ("boamp", "boamp-explore-api"),
         ("cisa-kev", "cisa-kev-feed"),
         ("decp", "decp-explore-api"),
+        ("github-global-advisories", "github-global-advisories"),
         ("greenhouse-job-board", "greenhouse-job-board-api"),
         ("lever-job-board", "lever-postings-api"),
+        ("nvd-vulnerabilities", "nvd-cve-api"),
         ("smartrecruiters-job-board", "smartrecruiters-posting-api"),
         ("ted-search", "ted-search-api"),
     }

--- a/tests/unit/collection_orchestration/test_vulnerability_adapters.py
+++ b/tests/unit/collection_orchestration/test_vulnerability_adapters.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.vulnerability_catalogs.registry import VulnerabilityQueryTarget
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    CollectionAdapter,
+)
+from cip.modules.collection_orchestration.application.vulnerability_list_adapters import (
+    GithubAdvisoryAdapter,
+    NvdVulnerabilityAdapter,
+)
+from cip.modules.collection_orchestration.application.vulnerability_query_adapters import (
+    CirclVulnerabilityAdapter,
+    CveOrgVulnerabilityAdapter,
+    EpssLookupAdapter,
+    OsvVulnerabilityAdapter,
+)
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+ROOT = Path(__file__).parents[3]
+REGISTRY = ROOT / "policies" / "sources.vulnerability.yml"
+NOW = datetime(2026, 8, 9, 16, 30, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=3650)
+JOB_ID = UUID("00000000-0000-0000-0000-000000000101")
+
+
+def test_nvd_adapter_maps_page_and_advances_checkpoint() -> None:
+    payload = {
+        "resultsPerPage": 1,
+        "startIndex": 0,
+        "totalResults": 2,
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2026-1234",
+                    "published": "2026-08-01T00:00:00Z",
+                    "lastModified": "2026-08-02T00:00:00Z",
+                    "vulnStatus": "Analyzed",
+                    "descriptions": [
+                        {"lang": "en", "value": "Example vulnerability"}
+                    ],
+                    "metrics": {},
+                    "weaknesses": [],
+                    "references": [],
+                }
+            }
+        ],
+    }
+    adapter = NvdVulnerabilityAdapter(
+        _entry("nvd-vulnerabilities"),
+        transport=_json_transport(payload),
+    )
+
+    batch = _collect(adapter)
+
+    assert len(batch.observations) == 1
+    assert batch.observations[0].source_record_key == "CVE-2026-1234"
+    assert batch.vulnerability_snapshots[0].canonical_id == "CVE-2026-1234"
+    assert batch.checkpoint_payload == {"start_index": 1}
+    assert batch.not_modified is False
+
+
+def test_github_advisory_adapter_maps_public_page() -> None:
+    payload = [
+        {
+            "ghsa_id": "GHSA-2345-6789-cfgh",
+            "summary": "Example advisory",
+            "description": "Example advisory description",
+            "published_at": "2026-08-01T00:00:00Z",
+            "updated_at": "2026-08-02T00:00:00Z",
+            "identifiers": [{"type": "CVE", "value": "CVE-2026-2345"}],
+            "vulnerabilities": [],
+            "references": [],
+        }
+    ]
+    adapter = GithubAdvisoryAdapter(
+        _entry("github-global-advisories"),
+        transport=_json_transport(payload),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.observations[0].source_record_key == "GHSA-2345-6789-cfgh"
+    assert batch.vulnerability_snapshots[0].canonical_id == "CVE-2026-2345"
+    assert batch.checkpoint_payload == {"page": 2}
+
+
+def test_cve_and_circl_adapters_keep_distinct_source_lineage() -> None:
+    payload = _cve_record("CVE-2026-3456")
+    target = VulnerabilityQueryTarget(
+        target_id="cve-2026-3456",
+        enabled=True,
+        cve_id="CVE-2026-3456",
+    )
+    cve = CveOrgVulnerabilityAdapter(
+        _entry("cve-org-services"),
+        (target,),
+        transport=_json_transport(payload),
+    )
+    circl = CirclVulnerabilityAdapter(
+        _entry("circl-vulnerability-lookup"),
+        (target,),
+        transport=_json_transport(payload),
+    )
+
+    cve_batch = _collect(cve)
+    circl_batch = _collect(circl)
+
+    assert cve_batch.vulnerability_snapshots[0].source.value == "cve_org"
+    assert (
+        circl_batch.vulnerability_snapshots[0].source.value
+        == "circl_vulnerability_lookup"
+    )
+    assert cve_batch.observations[0].source_id == "cve-org-services"
+    assert circl_batch.observations[0].source_id == "circl-vulnerability-lookup"
+
+
+def test_osv_adapter_requires_explicit_target_and_maps_result() -> None:
+    target = VulnerabilityQueryTarget(
+        target_id="osv-one",
+        enabled=True,
+        osv_id="GHSA-3456-789c-fghj",
+    )
+    payload = {
+        "id": "GHSA-3456-789c-fghj",
+        "aliases": ["CVE-2026-4567"],
+        "summary": "OSV example",
+        "details": "OSV details",
+        "modified": "2026-08-09T00:00:00Z",
+        "published": "2026-08-01T00:00:00Z",
+        "affected": [],
+        "severity": [],
+        "references": [],
+    }
+    adapter = OsvVulnerabilityAdapter(
+        _entry("osv-api"),
+        (target,),
+        transport=_json_transport(payload),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.observations[0].source_record_key == "GHSA-3456-789c-fghj"
+    assert batch.vulnerability_snapshots[0].canonical_id == "CVE-2026-4567"
+    assert batch.checkpoint_payload == {"target_index": 0}
+
+
+def test_epss_adapter_batches_configured_cves_and_normalizes_score_date() -> None:
+    requested_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        return _json_response(
+            {
+                "total": 1,
+                "offset": 0,
+                "limit": 100,
+                "data": [
+                    {
+                        "cve": "CVE-2026-5678",
+                        "epss": "0.42",
+                        "percentile": "0.88",
+                        "date": "2026-08-09",
+                    }
+                ],
+            }
+        )
+
+    target = VulnerabilityQueryTarget(
+        target_id="epss-one",
+        enabled=True,
+        cve_id="CVE-2026-5678",
+    )
+    adapter = EpssLookupAdapter(
+        _entry("first-epss"),
+        (target,),
+        transport=httpx.MockTransport(handler),
+    )
+
+    batch = _collect(adapter)
+
+    assert "cve=CVE-2026-5678" in requested_urls[0]
+    score = batch.vulnerability_snapshots[0].scores[0]
+    assert score.value == 0.42
+    assert score.assessed_at is not None
+    assert score.assessed_at.tzinfo is not None
+
+
+def test_query_adapter_with_no_enabled_targets_performs_no_network() -> None:
+    def fail_if_called(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network transport must not run without explicit targets")
+
+    adapter = OsvVulnerabilityAdapter(
+        _entry("osv-api"),
+        (),
+        transport=httpx.MockTransport(fail_if_called),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert batch.vulnerability_snapshots == ()
+
+
+def _collect(adapter: CollectionAdapter) -> AdapterCollectionBatch:
+    return adapter.collect(
+        collection_job_id=JOB_ID,
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _entry(source_id: str) -> SourceRegistryEntry:
+    entries = {entry.policy.id: entry for entry in load_source_registry(REGISTRY)}
+    return entries[source_id]
+
+
+def _json_transport(payload: object) -> httpx.MockTransport:
+    return httpx.MockTransport(lambda _request: _json_response(payload))
+
+
+def _json_response(payload: object) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "application/json"},
+        content=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _cve_record(cve_id: str) -> dict[str, object]:
+    return {
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.1",
+        "cveMetadata": {
+            "cveId": cve_id,
+            "state": "PUBLISHED",
+            "datePublished": "2026-08-01T00:00:00Z",
+            "dateUpdated": "2026-08-02T00:00:00Z",
+        },
+        "containers": {
+            "cna": {
+                "descriptions": [{"lang": "en", "value": "Example CVE"}],
+                "affected": [],
+                "problemTypes": [],
+                "metrics": [],
+                "references": [],
+            }
+        },
+    }

--- a/tests/unit/test_vulnerability_source_registries.py
+++ b/tests/unit/test_vulnerability_source_registries.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    SourceStatus,
+)
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
 from cip.modules.source_portfolio.domain.models import CatalogStatus
 from cip.modules.source_portfolio.infrastructure.registry import load_source_portfolio
@@ -19,21 +22,25 @@ EXPECTED_IDS = {
 }
 
 
-def test_vulnerability_sources_are_governed_but_not_executable() -> None:
+def test_vulnerability_sources_are_explicitly_governed_for_automation() -> None:
     entries = load_source_registry(SOURCE_PATH)
 
     assert {entry.policy.id for entry in entries} == EXPECTED_IDS
-    assert all(entry.policy.status is SourceStatus.DRAFT for entry in entries)
-    assert all(not entry.authorization.automated_collection_allowed for entry in entries)
-    assert all(not entry.authorization.approved_hosts for entry in entries)
+    assert all(entry.policy.status is SourceStatus.ENABLED for entry in entries)
+    assert all(entry.authorization.status is AuthorizationStatus.APPROVED for entry in entries)
+    assert all(entry.authorization.automated_collection_allowed for entry in entries)
+    assert all(entry.authorization.approved_hosts for entry in entries)
+    assert all(entry.authorization.approved_path_prefixes for entry in entries)
+    assert all(entry.authorization.approved_purposes for entry in entries)
+    assert all(not entry.authorization.raw_storage_allowed for entry in entries)
 
 
-def test_vulnerability_portfolio_entries_are_non_executable_candidates() -> None:
+def test_vulnerability_portfolio_entries_are_executable_without_exposure_inference() -> None:
     entries = load_source_portfolio(PORTFOLIO_PATH)
 
     assert {entry.source_id for entry in entries} == EXPECTED_IDS
-    assert all(entry.status is CatalogStatus.CANDIDATE for entry in entries)
-    assert all(not entry.executable for entry in entries)
+    assert all(entry.status is CatalogStatus.EXECUTABLE for entry in entries)
+    assert all(entry.executable for entry in entries)
     assert all(entry.adapter is not None for entry in entries)
     assert all(
         entry.metadata.get("organization_exposure_inference") == "forbidden"

--- a/tests/unit/vulnerability_catalogs/test_query_target_registry.py
+++ b/tests/unit/vulnerability_catalogs/test_query_target_registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cip.adapters.sources.vulnerability_catalogs.registry import (
+    VulnerabilityQueryTarget,
+    load_vulnerability_query_targets,
+)
+
+
+def test_target_requires_explicit_identifier() -> None:
+    with pytest.raises(ValueError, match="requires cve_id or osv_id"):
+        VulnerabilityQueryTarget(target_id="missing")
+
+
+def test_target_rejects_non_canonical_cve() -> None:
+    with pytest.raises(ValueError, match="canonical CVE"):
+        VulnerabilityQueryTarget(target_id="bad", cve_id="not-a-cve")
+
+
+def test_registry_rejects_duplicate_target_ids(tmp_path: Path) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        """
+version: 1
+targets:
+  - target_id: same
+    cve_id: CVE-2026-1000
+  - target_id: same
+    osv_id: GHSA-2345-6789-cfgh
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate vulnerability query target_id"):
+        load_vulnerability_query_targets(path)
+
+
+def test_checked_in_registry_is_empty_and_safe_by_default() -> None:
+    root = Path(__file__).parents[3]
+    targets = load_vulnerability_query_targets(
+        root / "policies" / "vulnerability_query_targets.yml"
+    )
+
+    assert targets == ()


### PR DESCRIPTION
Closes #64

## Wave A — SA-01

### Clean sequencing
- Exact base: merged SA-00 squash `5867189ccce972d789aef68171791e55d8b8a07d` on `main`.
- Exact final head: `40497e48ec3e154ff2e0ea58129a7db1a737fc66`.
- The old stacked ancestry was replaced; the PR now contains only SA-01 changes on the validated SA-00 baseline.

## Implemented provider paths
- NVD CVE API 2.0: governed paginated runtime adapter + hourly schedule;
- GitHub Global Security Advisories: governed paginated runtime adapter + six-hour schedule;
- CVE Services: explicit CVE-target lookup adapter;
- FIRST EPSS: bounded explicit-CVE lookup batches;
- OSV API: explicit OSV-ID lookup adapter;
- CIRCL Vulnerability-Lookup: explicit CVE-target lookup with distinct provider lineage.

## Governance and safety
- SourcePolicy evaluation before HTTP;
- exact `vulnerability-intelligence` purpose/data category/hosts/path scope;
- raw provider payload storage disabled;
- query-oriented providers make no network call without enabled explicit targets;
- schema drift and invalid checkpoints fail closed;
- transport/429/5xx failures are bounded retry cases;
- global vulnerability metadata cannot infer organization exposure, compromise, need, score, opportunity, or outreach.

## Runtime and architecture
- all six adapters reuse the existing scheduler/worker/checkpoint runtime;
- `VulnerabilityObservationContext` keeps the shared observation helper inside the hard parameter budget;
- `adapter_composition.py` separates adapter construction from runtime orchestration so `runtime.py` remains below the 400-line hard limit;
- public-web target registration preserves the validated fail-closed Lot 12 contract: one adapter per enabled target and an exact policy by target ID;
- Relationships source/portfolio bundles remain loaded;
- backfill persists `vulnerability_snapshots` transactionally alongside RawObservations, fixing the prior projection-loss path.

## EPSS bulk boundary
FIRST's API is used for bounded lookup. The full daily EPSS corpus is not forced into one materialized `CollectionAdapter` batch; bulk CSV ingestion remains a separate future chunked-ingestion path. The checked-in query-target registry is empty by default.

## Final exact-head validation — PASS
Exact head `40497e48ec3e154ff2e0ea58129a7db1a737fc66` passed CI #1432 / run `31332122373` completely:

- dependency consistency: PASS;
- pip-audit: PASS;
- Ruff: PASS;
- strict Mypy: PASS (548 source files);
- architecture/release contracts: 36 passed;
- PostgreSQL reversible Alembic cycle: PASS;
- pytest: 1051 passed, 0 failed, 0 skipped;
- aggregate branch-aware coverage gate: 90.17% (`27998 / 31049` measured statements+branches); line coverage 93.32%;
- frontend npm audit: PASS;
- frontend TypeScript typecheck: PASS;
- frontend Next.js production build: PASS.

The runtime regression test now asserts all 9 expected scheduled `(source_id, adapter_id)` pairs, including NVD and GitHub Global Advisories, rather than merely loosening a numeric count.

There are no unresolved review threads or blocking reviews. No repository-content change is permitted after this validated head before squash merge. Merge must use `expected_head_sha=40497e48ec3e154ff2e0ea58129a7db1a737fc66`.