### PR TITLE
SA-03: governed passive infrastructure intelligence

### DIFF
--- a/docs/source_activation/SA_03_PASSIVE_INFRASTRUCTURE_IMPLEMENTATION.md
+++ b/docs/source_activation/SA_03_PASSIVE_INFRASTRUCTURE_IMPLEMENTATION.md
@@ -1,0 +1,132 @@
+# SA-03 — Passive Infrastructure Intelligence Implementation
+
+## Scope
+
+SA-03 activates bounded passive domain and infrastructure intelligence on top of the already validated Lot 16 canonical passive-exposure model. It does not add an active reconnaissance engine.
+
+The collection path is:
+
+```text
+enabled target
+  -> source-policy preflight
+  -> approved provider request
+  -> immutable RawObservation
+  -> PassiveObservationSnapshot
+  -> existing Lot 16 persistence/reconciliation
+```
+
+Provider output never writes a CommercialSignal, NeedHypothesis, Opportunity, contact target, or outreach action.
+
+## Target registry
+
+`policies/passive_infrastructure_targets.yml` is the only checked-in target registry for these adapters. The repository default is:
+
+```yaml
+version: 1
+targets: []
+```
+
+Each future target requires an explicit internal organization UUID, a canonical public domain, and `enabled: true`. Domain validation reuses Lot 16 canonical public-domain normalization. Reserved/local/non-public suffixes are rejected.
+
+An empty target registry causes both SA-03 adapters to return a deterministic no-op batch before provider traffic. Cert Spotter also returns before secret resolution when no target exists.
+
+## Cloudflare DNS-over-HTTPS
+
+Runtime identity:
+
+- source: `cloudflare-doh`;
+- adapter: `cloudflare-dns-json`;
+- approved host/path: `cloudflare-dns.com/dns-query`;
+- record families: A and AAAA only;
+- authentication: none.
+
+For each enabled target, the adapter performs only provider-side DNS-over-HTTPS requests. Returned addresses are not contacted.
+
+A globally routable A/AAAA answer maps to a Lot 16 passive snapshot with:
+
+- asset kind `ipv4` or `ipv6`;
+- observation kind `passive_dns`;
+- source-specific record identity;
+- provider TTL represented as the observation expiry;
+- organization link `review_required`;
+- link method `passive_correlation`;
+- explicit `shared_hosting` risk;
+- no active-validation, credential, bypass, exploit, applicability or exposure flag.
+
+Non-global/private/reserved addresses are rejected by the canonical Lot 16 asset normalizer and are not projected.
+
+## Cert Spotter Certificate Transparency
+
+Runtime identity:
+
+- source: `certspotter-ct`;
+- adapter: `certspotter-issuances-api`;
+- approved host/path: `api.certspotter.com/v1/issuances`;
+- production authentication: Provider Onboarding secret `api_token`.
+
+The adapter fails closed when an enabled target exists but the connected provider secret cannot be resolved. No token value is written to RawObservation or canonical persistence.
+
+The provider schema bounds issuance IDs, SHA-256 values and DNS-name arrays. Only issuances whose expanded DNS names match the enabled target domain or one of its subordinate names are retained.
+
+Each retained issuance maps to:
+
+- asset kind `certificate` using the provider-documented hexadecimal `tbs_sha256`;
+- observation kind `certificate`;
+- explicit current/expired state from certificate validity metadata;
+- organization link `review_required` via `passive_correlation`;
+- explicit shared/third-party infrastructure risk semantics;
+- no endpoint deployment claim and no exposure conclusion.
+
+## Shared persistence
+
+`AdapterCollectionBatch` now includes `passive_exposure_projections`.
+
+Both collection modes persist this field through `persist_passive_snapshots()`:
+
+- normal incremental worker;
+- historical backfill worker.
+
+The projection write occurs in the same transaction as the collection completion/checkpoint path, so the runtime cannot report a successful collection while silently discarding the corresponding Lot 16 projection.
+
+No new passive-exposure database table or migration is needed because SA-03 reuses migration `20260806_0016` and the existing Lot 16 persistence layer.
+
+## Scheduling
+
+Both checked-in SA-03 schedules are disabled. This is deliberate:
+
+- the checked-in target registry contains no enabled organizations;
+- Cert Spotter additionally requires deployment onboarding/API-key state;
+- source activation therefore records both providers as executable target-driven capabilities, not as live-scheduled integrations.
+
+A deployment may enable a schedule only after it supplies an authorized target and all provider-specific runtime dependencies.
+
+## Deferred providers
+
+The following candidates are not activated by SA-03:
+
+- RIPEstat, pending an explicit product commercial-use decision;
+- urlscan automated integration, pending approved commercial integration scope and with no scan submission in SA-03;
+- `licensed-passive-dns`;
+- `licensed-certificate-telemetry`;
+- `licensed-passive-exposure`;
+- `licensed-technographic-observations`;
+- `licensed-cloud-asset-observations`.
+
+The five licensed placeholders move to SA-07, whose Master Plan scope covers licensed/premium providers. Their `.example.invalid` catalog entries remain non-executable until a concrete contract is selected.
+
+## Safety invariants
+
+SA-03 preserves these distinctions:
+
+```text
+DNS lookup != organization ownership
+DNS lookup != verified exposure
+certificate issuance != deployed endpoint
+certificate issuance != asset ownership
+passive observation != vulnerability applicability
+passive observation != compromise
+source capability != live-tested integration
+passive intelligence != commercial opportunity
+```
+
+No SA-03 unit test performs live network traffic. Provider behavior is tested with deterministic HTTP transports and bounded fixtures. Full SA completion still requires all repository gates on one exact final PR head.

--- a/docs/source_activation/SA_03_PASSIVE_INFRASTRUCTURE_IMPLEMENTATION.md
+++ b/docs/source_activation/SA_03_PASSIVE_INFRASTRUCTURE_IMPLEMENTATION.md
@@ -26,7 +26,7 @@ version: 1
 targets: []
 ```
 
-Each future target requires an explicit internal organization UUID, a canonical public domain, and `enabled: true`. Domain validation reuses Lot 16 canonical public-domain normalization. Reserved/local/non-public suffixes are rejected.
+Each future target requires an explicit internal organization UUID, a canonical public domain, and `enabled: true`. Domain validation reuses Lot 16 canonical public-domain normalization. Reserved/local/non-public suffixes are rejected. The registry is bounded to 500 targets.
 
 An empty target registry causes both SA-03 adapters to return a deterministic no-op batch before provider traffic. Cert Spotter also returns before secret resolution when no target exists.
 
@@ -67,6 +67,15 @@ Runtime identity:
 The adapter fails closed when an enabled target exists but the connected provider secret cannot be resolved. No token value is written to RawObservation or canonical persistence.
 
 The provider schema bounds issuance IDs, SHA-256 values and DNS-name arrays. Only issuances whose expanded DNS names match the enabled target domain or one of its subordinate names are retained.
+
+Collection remains bounded and resumable:
+
+- one target and one provider page are processed per adapter execution;
+- enabled targets rotate through a deterministic `target_index` checkpoint;
+- each target keeps its own provider `after` issuance cursor;
+- at most 100 issuances are accepted from one provider page;
+- cursor state is bounded to the same 500-target limit as the registry;
+- a provider page may advance its cursor even when all returned names are out of target scope, preventing a permanently repeated page without promoting those records into observations.
 
 Each retained issuance maps to:
 

--- a/docs/source_activation/SA_03_PROVIDER_AUTHORIZATION.md
+++ b/docs/source_activation/SA_03_PROVIDER_AUTHORIZATION.md
@@ -1,0 +1,71 @@
+# SA-03 Provider Authorization — Passive Infrastructure Intelligence
+
+## Decision boundary
+
+This document authorizes only the bounded provider requests described below for the Cyber Intelligence Platform SA-03 implementation. It does not authorize active scanning, direct connection to returned assets, authenticated enumeration of prospect infrastructure, vulnerability validation, exploitation, compromise inference, autonomous opportunity creation, or outreach.
+
+A provider appearing in this document is not evidence that a discovered asset belongs to an organization. Provider output must pass through the Lot 16 passive-exposure model and organization-link review rules.
+
+## Cloudflare DNS-over-HTTPS
+
+- Source ID: `cloudflare-doh`
+- Owner: Cloudflare
+- Approved host: `cloudflare-dns.com`
+- Approved path: `/dns-query`
+- Approved method: `GET`
+- Approved purpose: `passive-infrastructure-intelligence`
+- Approved record types in SA-03: `A`, `AAAA`
+- Authentication: none
+- Raw response storage: forbidden
+- Canonical retention category: `technology_observation`
+- Targeting: only domains explicitly enabled in `policies/passive_infrastructure_targets.yml`
+
+Cloudflare documents the public 1.1.1.1 DNS-over-HTTPS resolver, including JSON GET requests with `Accept: application/dns-json`, and states that the API does not require authentication. The public resolver remains subject to Cloudflare's published terms of use.
+
+The JSON representation is provider-defined rather than an IETF-standard schema. SA-03 therefore treats schema changes as a source-contract concern, bounds response size, and supports only the A/AAAA fields required for the passive DNS projection.
+
+A DNS answer is a passive resolution observation. It is not proof of asset ownership, dedicated hosting, exposure, vulnerability applicability, or compromise.
+
+## Cert Spotter / SSLMate CT Search API
+
+- Source ID: `certspotter-ct`
+- Owner: Opsmate, Inc. / SSLMate
+- Approved host: `api.certspotter.com`
+- Approved path: `/v1/issuances`
+- Approved method: `GET`
+- Approved purpose: `passive-infrastructure-intelligence`
+- Authentication for production: API key through Provider Onboarding secret reference `api_token`
+- Raw response storage: forbidden
+- Canonical retention category: `technology_observation`
+- Targeting: only domains explicitly enabled in `policies/passive_infrastructure_targets.yml`
+
+SSLMate documents `tbs_sha256` as the hexadecimal SHA-256 digest identifying an issuance. The domain issuance endpoint can be used on a limited unauthenticated basis for personal/evaluation purposes, but SSLMate requests account registration and API-key authentication for production use. CIP therefore does not rely on anonymous production access: the runtime adapter fails closed when an enabled target exists but the connected `api_token` cannot be resolved.
+
+A CT issuance can include a domain because a certificate was issued for it. It does not prove that the certificate is currently installed, that the underlying endpoint is operated directly by the organization, that an asset is exposed, or that any vulnerability applies.
+
+## Providers deliberately not executable in SA-03
+
+### RIPEstat
+
+RIPEstat remains a candidate/non-executable path until the project has an explicit decision covering commercial use for this product and the exact API fields, hosts, paths, cadence, and retention.
+
+### urlscan.io
+
+SA-03 does not submit URLs for scanning and does not automate urlscan search. Any future commercial integration requires a separately approved provider plan/authorization and a new source-policy review.
+
+### Licensed passive providers from Lot 16
+
+The existing `licensed-passive-exposure`, `licensed-technographic-observations`, `licensed-cloud-asset-observations`, `licensed-passive-dns`, and `licensed-certificate-telemetry` placeholders remain non-executable. Their `.example.invalid` entries are governance placeholders, not runnable adapters. They may only be activated after a concrete provider contract identifies the exact allowed fields, licence, credentials, hosts, paths, quotas, cost, retention, and automation scope.
+
+## Mandatory evidence semantics
+
+```text
+DNS lookup != ownership
+certificate issuance != deployed endpoint
+passive asset != verified exposure
+technology/version observation != vulnerability applicability
+provider candidate != execution authorization
+passive observation != commercial opportunity
+```
+
+No SA-03 adapter may bypass these distinctions.

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -13,7 +13,7 @@ Symbols:
 
 `Executable` does not imply `Live tested`. A source is fully integrated only when every required activation stage is present.
 
-## Current core and Wave A sources
+## Current core and activated sources
 
 | Source | Wave | Mapped | Adapter | Authorized | Executable | Scheduled | Live tested | Current result |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
@@ -38,6 +38,13 @@ Symbols:
 | CIRCL Vulnerability-Lookup | SA-01 | Y | Y | Y | Y | N/A | - | bounded explicit-CVE lookup; live proof outstanding |
 | Brave Search API | SA-02 | Y | Y | Y | Y | N/A | - | adapter executable; schedule disabled until deployment onboarding/secret activation; live proof outstanding |
 | Internet Archive CDX | SA-02 | Y | Y | Y | Y | Y | - | bounded weekly historical metadata discovery; live proof outstanding |
+| Cloudflare DNS-over-HTTPS | SA-03 | Y | Y | Y | Y | N/A | - | target-driven A/AAAA passive lookup; checked-in target registry empty; live proof outstanding |
+| Cert Spotter CT Search API | SA-03 | Y | Y | Y | Y | N/A | - | target-driven CT lookup; production API key/onboarding and deployment target required; live proof outstanding |
+| Licensed passive DNS | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Licensed certificate telemetry | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Licensed passive exposure | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Licensed technography | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Licensed cloud-asset observations | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
 | Sherlock | SA-05 | - | - | - | - | N/A | - | explicit local OSINT capability planned |
 | LinkedIn official API | SA-07 | - | - | - | - | N/A | - | BLOCKED pending approved official/licensed access and adapter |
 | BrixHub | SA-08 | - | - | - | - | N/A | - | BLOCKED pending access/licence/data review |
@@ -46,24 +53,26 @@ Symbols:
 
 The repository already models additional candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. Most remain candidate/non-executable and are assigned to later source-activation waves.
 
-SA-00 established the lifecycle and truth model. SA-01 and SA-02 promote only providers whose implementation, authorization and runtime boundaries are explicit. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
+SA-00 established the lifecycle and truth model. SA-01 through SA-03 promote only providers whose implementation, authorization and runtime boundaries are explicit. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
 
 ## Reconciliation invariant
 
-Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. The repository test `test_every_checked_in_source_portfolio_entry_has_activation_record` enforces this invariant and includes the SA-02 search/archive portfolio bundle.
+Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA.
 
 OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10.
 
-## Wave A completion target
+## SA-03 completion boundary
 
-At the end of SA-02:
+SA-03 is complete only when:
 
-- all six SA-01 vulnerability providers have real governed adapters;
-- NVD and GitHub Global Advisories use bounded schedules/checkpoints through the shared collection runtime;
-- query-oriented CVE/EPSS/OSV/CIRCL paths require explicit targets and do not gain fake schedules;
-- the public-web adapter remains executable only for explicitly enabled targets with exact target policies;
-- Brave Search is a real provider adapter but remains deployment-fail-closed without connected secret state and its checked-in schedule is disabled;
-- Internet Archive CDX is a bounded historical-metadata adapter and is a no-op without enabled targets;
-- search-result and archive-index metadata remain quarantined discovery resources with zero claims;
-- every new adapter is covered by deterministic contract tests and the full repository regression gate;
-- `live_tested` remains false until controlled real-provider validation is separately evidenced.
+- Cloudflare DoH and Cert Spotter are registered in the shared collection runtime and map exclusively to immutable RawObservations plus Lot 16 passive snapshots;
+- incremental collection and historical backfill persist those passive snapshots transactionally with their collection progress;
+- the checked-in passive target registry is empty/disabled by default and no adapter performs network activity without an explicit enabled target;
+- Cloudflare is restricted to bounded A/AAAA queries to the approved DoH provider host and never connects to returned addresses;
+- Cert Spotter fails closed without deployment Provider Onboarding/API-key state and accepts only target-domain or subordinate-domain issuances;
+- DNS answers remain review-required organization links with shared-infrastructure risk;
+- certificate issuance remains review-required passive context and never proves endpoint deployment or exposure;
+- no adapter assesses vulnerability applicability, verifies exposure, infers compromise, creates a need/opportunity, or performs outreach;
+- the licensed passive providers remain planned for SA-07 instead of being falsely activated under `.example.invalid` placeholders;
+- deterministic adapter/runtime/registry tests and the complete repository CI pass on one exact final SHA;
+- `live_tested` remains false until separately authorized controlled provider validation is evidenced.

--- a/policies/collection_schedules.passive_infrastructure.yml
+++ b/policies/collection_schedules.passive_infrastructure.yml
@@ -1,0 +1,26 @@
+version: 1
+
+schedules:
+  - source_id: cloudflare-doh
+    adapter_id: cloudflare-dns-json
+    enabled: false
+    interval_seconds: 86400
+    lease_seconds: 180
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 300
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600
+
+  - source_id: certspotter-ct
+    adapter_id: certspotter-issuances-api
+    enabled: false
+    interval_seconds: 86400
+    lease_seconds: 180
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 300
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600

--- a/policies/passive_infrastructure_targets.yml
+++ b/policies/passive_infrastructure_targets.yml
@@ -1,0 +1,2 @@
+version: 1
+targets: []

--- a/policies/provider_onboarding.yml
+++ b/policies/provider_onboarding.yml
@@ -163,6 +163,35 @@ providers:
     automatic_onboarding: true
     blocked_reason: null
 
+  - source_id: cloudflare-doh
+    display_name: Cloudflare 1.1.1.1 DNS-over-HTTPS
+    auth_mode: none
+    documentation_url: https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/make-api-requests/
+    signup_url: null
+    console_url: null
+    required_secret_names: []
+    human_actions: []
+    automatic_onboarding: true
+    blocked_reason: null
+
+  - source_id: certspotter-ct
+    display_name: Cert Spotter Certificate Transparency Search API
+    auth_mode: api_key
+    documentation_url: https://sslmate.com/help/reference/ct_search_api_v1
+    signup_url: https://sslmate.com/account
+    console_url: https://sslmate.com/account/api_keys
+    required_secret_names:
+      - api_token
+    human_actions:
+      - open_official_signup
+      - sign_in
+      - accept_provider_terms
+      - retrieve_technical_credentials
+      - register_secret_reference
+      - enable_source_policy
+    automatic_onboarding: false
+    blocked_reason: null
+
   - source_id: linkedin-official-api
     display_name: LinkedIn Official API
     auth_mode: manual

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -197,14 +197,14 @@ sources:
     display_name: Licensed Passive DNS Metadata
     category: threat_telemetry
     disposition: planned
-    activation_wave: SA-03
+    activation_wave: SA-07
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-certificate-telemetry
     display_name: Licensed Certificate Telemetry
     category: threat_telemetry
     disposition: planned
-    activation_wave: SA-03
+    activation_wave: SA-07
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-malware-metadata
@@ -218,22 +218,38 @@ sources:
     display_name: Licensed Passive Exposure Metadata
     category: passive_exposure
     disposition: planned
-    activation_wave: SA-03
+    activation_wave: SA-07
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-technographic-observations
     display_name: Licensed Passive Technographic Observations
     category: passive_exposure
     disposition: planned
-    activation_wave: SA-03
+    activation_wave: SA-07
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-cloud-asset-observations
     display_name: Licensed Passive Cloud Asset Observations
     category: passive_exposure
     disposition: planned
-    activation_wave: SA-03
+    activation_wave: SA-07
     stages: [catalogued, reviewed, mapped]
+
+  - source_id: cloudflare-doh
+    display_name: Cloudflare 1.1.1.1 DNS-over-HTTPS
+    category: passive_exposure
+    disposition: active
+    activation_wave: SA-03
+    requires_schedule: false
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
+
+  - source_id: certspotter-ct
+    display_name: Cert Spotter Certificate Transparency Search API
+    category: passive_exposure
+    disposition: active
+    activation_wave: SA-03
+    requires_schedule: false
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
   - source_id: official-vendor-psirt
     display_name: Official Vendor PSIRT Advisories

--- a/policies/source_portfolio.passive_infrastructure.yml
+++ b/policies/source_portfolio.passive_infrastructure.yml
@@ -1,0 +1,75 @@
+version: 1
+
+sources:
+  - source_id: cloudflare-doh
+    display_name: Cloudflare 1.1.1.1 DNS-over-HTTPS
+    canonical_url: https://cloudflare-dns.com/dns-query
+    category: passive_exposure
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases:
+      - passive_asset_context
+      - organization_research
+    candidate_origin: SA-03
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      target_registry_required: true
+      active_probe: forbidden
+      direct_asset_connection: forbidden
+      vulnerability_applicability: not_assessed
+      exposure_verification: forbidden
+      organization_compromise_inference: forbidden
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: cloudflare-dns-json
+      adapter_version: "1"
+      provider_schema_version: cloudflare-doh-json-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - passive_asset
+        - passive_observation_snapshot
+      supports_corrections: false
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 512
+      cost_per_request: 0
+
+  - source_id: certspotter-ct
+    display_name: Cert Spotter Certificate Transparency Search API
+    canonical_url: https://api.certspotter.com/v1/issuances
+    category: passive_exposure
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases:
+      - passive_asset_context
+      - organization_research
+    candidate_origin: SA-03
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      provider_onboarding_required: true
+      target_registry_required: true
+      active_probe: forbidden
+      direct_asset_connection: forbidden
+      vulnerability_applicability: not_assessed
+      exposure_verification: forbidden
+      organization_compromise_inference: forbidden
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: certspotter-issuances-api
+      adapter_version: "1"
+      provider_schema_version: certspotter-issuances-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - passive_asset
+        - passive_observation_snapshot
+      supports_corrections: false
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 100
+      cost_per_request: 0

--- a/policies/sources.passive_infrastructure.yml
+++ b/policies/sources.passive_infrastructure.yml
@@ -1,0 +1,78 @@
+version: 1
+reviewed_at: 2026-08-09
+
+sources:
+  - id: cloudflare-doh
+    name: Cloudflare 1.1.1.1 DNS-over-HTTPS
+    base_url: https://cloudflare-dns.com/dns-query
+    status: enabled
+    source_type: api
+    owner: Cloudflare
+    terms_url: https://developers.cloudflare.com/1.1.1.1/terms-of-use/
+    licence: Cloudflare 1.1.1.1 public resolver terms
+    allowed_data_categories: [technology_observation]
+    prohibited_data_categories: &prohibited
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 12
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_03_PROVIDER_AUTHORIZATION.md#cloudflare-dns-over-https
+      reviewed_at: "2026-08-09T22:30:00+00:00"
+      expires_at: null
+      approved_hosts: [cloudflare-dns.com]
+      approved_path_prefixes: [/dns-query]
+      approved_purposes: [passive-infrastructure-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: low
+      maintenance_cost: low
+      expected_stability: medium
+    notes: >-
+      A and AAAA lookups for explicitly enabled domains only. Returned IP addresses are never
+      contacted by this adapter and remain review-required organization associations.
+
+  - id: certspotter-ct
+    name: Cert Spotter Certificate Transparency Search API
+    base_url: https://api.certspotter.com/v1/issuances
+    status: enabled
+    source_type: api
+    owner: Opsmate, Inc. / SSLMate
+    terms_url: https://sslmate.com/policies/tos
+    licence: SSLMate CT Search API terms; authenticated account required for production
+    allowed_data_categories: [technology_observation]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 6
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_03_PROVIDER_AUTHORIZATION.md#cert-spotter--sslmate-ct-search-api
+      reviewed_at: "2026-08-09T22:30:00+00:00"
+      expires_at: null
+      approved_hosts: [api.certspotter.com]
+      approved_path_prefixes: [/v1/issuances]
+      approved_purposes: [passive-infrastructure-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: low
+      maintenance_cost: medium
+      expected_stability: medium
+    notes: >-
+      Production execution requires connected Provider Onboarding with secret reference api_token.
+      Certificate issuance is passive CT metadata and never verifies endpoint deployment or exposure.

--- a/src/cip/adapters/sources/passive_infrastructure/registry.py
+++ b/src/cip/adapters/sources/passive_infrastructure/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from ipaddress import ip_address
 from pathlib import Path
 from uuid import UUID
 
@@ -20,7 +21,12 @@ class PassiveInfrastructureTarget(BaseModel):
     @field_validator("domain")
     @classmethod
     def validate_domain(cls, value: str) -> str:
-        return normalize_domain(value)
+        candidate = value.strip().rstrip(".")
+        try:
+            ip_address(candidate)
+        except ValueError:
+            return normalize_domain(candidate)
+        raise ValueError("passive infrastructure domain target cannot be an IP literal")
 
 
 class PassiveInfrastructureTargetFile(BaseModel):

--- a/src/cip/adapters/sources/passive_infrastructure/registry.py
+++ b/src/cip/adapters/sources/passive_infrastructure/registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from uuid import UUID
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_HOST_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+
+
+class PassiveInfrastructureTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str = Field(min_length=1, max_length=200)
+    organization_id: UUID
+    domain: str = Field(min_length=1, max_length=253)
+    enabled: bool = False
+
+    @field_validator("domain")
+    @classmethod
+    def validate_domain(cls, value: str) -> str:
+        normalized = value.strip().rstrip(".").casefold()
+        labels = normalized.split(".")
+        if len(labels) < 2 or any(not _HOST_LABEL.fullmatch(label) for label in labels):
+            raise ValueError("domain must be a canonical public DNS name")
+        return normalized
+
+
+class PassiveInfrastructureTargetFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    targets: list[PassiveInfrastructureTarget] = Field(default_factory=list)
+
+
+def load_passive_infrastructure_targets(
+    path: Path,
+) -> tuple[PassiveInfrastructureTarget, ...]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    parsed = PassiveInfrastructureTargetFile.model_validate(document)
+    values = tuple(parsed.targets)
+    target_ids = [target.target_id for target in values]
+    if len(target_ids) != len(set(target_ids)):
+        raise ValueError("duplicate passive infrastructure target_id")
+    return values

--- a/src/cip/adapters/sources/passive_infrastructure/registry.py
+++ b/src/cip/adapters/sources/passive_infrastructure/registry.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from uuid import UUID
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-_HOST_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+from cip.modules.passive_exposure.domain.normalization import normalize_domain
 
 
 class PassiveInfrastructureTarget(BaseModel):
@@ -21,11 +20,7 @@ class PassiveInfrastructureTarget(BaseModel):
     @field_validator("domain")
     @classmethod
     def validate_domain(cls, value: str) -> str:
-        normalized = value.strip().rstrip(".").casefold()
-        labels = normalized.split(".")
-        if len(labels) < 2 or any(not _HOST_LABEL.fullmatch(label) for label in labels):
-            raise ValueError("domain must be a canonical public DNS name")
-        return normalized
+        return normalize_domain(value)
 
 
 class PassiveInfrastructureTargetFile(BaseModel):

--- a/src/cip/adapters/sources/passive_infrastructure/registry.py
+++ b/src/cip/adapters/sources/passive_infrastructure/registry.py
@@ -27,7 +27,7 @@ class PassiveInfrastructureTargetFile(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     version: int = Field(ge=1, le=1)
-    targets: list[PassiveInfrastructureTarget] = Field(default_factory=list)
+    targets: list[PassiveInfrastructureTarget] = Field(default_factory=list, max_length=500)
 
 
 def load_passive_infrastructure_targets(

--- a/src/cip/adapters/sources/passive_infrastructure/schemas.py
+++ b/src/cip/adapters/sources/passive_infrastructure/schemas.py
@@ -44,7 +44,7 @@ class CertSpotterCertificate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     id: str = Field(min_length=1, max_length=500)
-    tbs_sha256: str = Field(min_length=1, max_length=512)
+    tbs_sha256: str = Field(pattern=r"^[0-9A-Fa-f]{64}$")
     dns_names: list[DnsName] = Field(default_factory=list, max_length=1_000)
     not_before: datetime | None = None
     not_after: datetime | None = None

--- a/src/cip/adapters/sources/passive_infrastructure/schemas.py
+++ b/src/cip/adapters/sources/passive_infrastructure/schemas.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CloudflareDnsQuestion(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    type: int
+
+
+class CloudflareDnsAnswer(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    type: int
+    TTL: int = Field(ge=0)
+    data: str
+
+
+class CloudflareDnsResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    Status: int
+    Question: list[CloudflareDnsQuestion] = Field(default_factory=list)
+    Answer: list[CloudflareDnsAnswer] = Field(default_factory=list)
+
+
+class CertSpotterCertificate(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1)
+    tbs_sha256: str = Field(min_length=1)
+    dns_names: list[str] = Field(default_factory=list)
+    not_before: datetime | None = None
+    not_after: datetime | None = None

--- a/src/cip/adapters/sources/passive_infrastructure/schemas.py
+++ b/src/cip/adapters/sources/passive_infrastructure/schemas.py
@@ -1,39 +1,50 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+DnsName = Annotated[str, StringConstraints(min_length=1, max_length=253)]
 
 
 class CloudflareDnsQuestion(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    name: str
-    type: int
+    name: DnsName
+    record_type: int = Field(alias="type", ge=1, le=65_535)
 
 
 class CloudflareDnsAnswer(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    name: str
-    type: int
-    TTL: int = Field(ge=0)
-    data: str
+    name: DnsName
+    record_type: int = Field(alias="type", ge=1, le=65_535)
+    ttl: int = Field(alias="TTL", ge=0, le=2_592_000)
+    data: str = Field(min_length=1, max_length=2_048)
 
 
 class CloudflareDnsResponse(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    Status: int
-    Question: list[CloudflareDnsQuestion] = Field(default_factory=list)
-    Answer: list[CloudflareDnsAnswer] = Field(default_factory=list)
+    status: int = Field(alias="Status", ge=0, le=65_535)
+    questions: list[CloudflareDnsQuestion] = Field(
+        default_factory=list,
+        alias="Question",
+        max_length=64,
+    )
+    answers: list[CloudflareDnsAnswer] = Field(
+        default_factory=list,
+        alias="Answer",
+        max_length=512,
+    )
 
 
 class CertSpotterCertificate(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    id: str = Field(min_length=1)
-    tbs_sha256: str = Field(min_length=1)
-    dns_names: list[str] = Field(default_factory=list)
+    id: str = Field(min_length=1, max_length=500)
+    tbs_sha256: str = Field(min_length=1, max_length=512)
+    dns_names: list[DnsName] = Field(default_factory=list, max_length=1_000)
     not_before: datetime | None = None
     not_after: datetime | None = None

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
 from cip.adapters.sources.lever.registry import LeverSite
 from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.smartrecruiters.registry import SmartRecruitersCompany
 from cip.adapters.sources.vulnerability_catalogs.registry import VulnerabilityQueryTarget
@@ -17,6 +18,9 @@ from cip.modules.collection_orchestration.application.identity_adapters import (
     register_identity_adapters,
 )
 from cip.modules.collection_orchestration.application.lever_adapter import LeverAdapter
+from cip.modules.collection_orchestration.application.passive_infrastructure_registration import (
+    register_passive_infrastructure_adapters,
+)
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
 from cip.modules.collection_orchestration.application.reference_adapter import (
@@ -46,12 +50,14 @@ class AdapterCompositionInputs:
     public_web_targets: tuple[PublicWebTarget, ...]
     search_templates: tuple[SearchQueryTemplate, ...]
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
+    passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
 
 
 def build_runtime_adapters(
     inputs: AdapterCompositionInputs,
     *,
     brave_token_provider: Callable[[], str | None],
+    certspotter_token_provider: Callable[[], str | None],
     timeout_seconds: float,
 ) -> dict[tuple[str, str], CollectionAdapter]:
     entries_by_id = {entry.policy.id: entry for entry in inputs.entries}
@@ -82,6 +88,13 @@ def build_runtime_adapters(
         adapters,
         entries_by_id,
         inputs.vulnerability_targets,
+        timeout_seconds=timeout_seconds,
+    )
+    register_passive_infrastructure_adapters(
+        adapters,
+        entries_by_id,
+        inputs.passive_infrastructure_targets,
+        certspotter_token_provider=certspotter_token_provider,
         timeout_seconds=timeout_seconds,
     )
     return adapters

--- a/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from datetime import datetime
-from hashlib import sha256
 from uuid import UUID
 
 import httpx
@@ -20,18 +19,16 @@ from cip.modules.collection_orchestration.application.ports import (
     AdapterCollectionBatch,
     AdapterExecutionError,
 )
-from cip.modules.passive_exposure.domain.asset_models import AssetRef, PassiveAsset
-from cip.modules.passive_exposure.domain.enums import (
-    AssetState,
-    AssetType,
+from cip.modules.passive_exposure.domain.models import (
     AttributionRisk,
+    OrganizationLink,
+    OrganizationLinkMethod,
     OrganizationLinkStatus,
-    PassiveObservationType,
-)
-from cip.modules.passive_exposure.domain.models import PassiveObservationSnapshot
-from cip.modules.passive_exposure.domain.observation_models import (
-    OrganizationAssetLink,
-    PassiveObservation,
+    PassiveAsset,
+    PassiveAssetKind,
+    PassiveObservationKind,
+    PassiveObservationSnapshot,
+    PassiveObservationState,
 )
 from cip.modules.source_governance.domain.models import DataCategory
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
@@ -110,6 +107,11 @@ class CertSpotterAdapter:
                 error_code="source_schema_drift",
                 retryable=False,
             ) from exc
+        certificates = tuple(
+            certificate
+            for certificate in certificates
+            if _matches_target(certificate, target.domain)
+        )
         context = PassiveObservationContext(
             source_id=self.source_id,
             adapter_id=self.adapter_id,
@@ -125,20 +127,25 @@ class CertSpotterAdapter:
                 source_url=target_url,
                 source_record_key=certificate.id,
                 source_record_type="certspotter-issuance",
-                observed_at=_certificate_time(certificate, collected_at),
-                published_at=_certificate_time(certificate, collected_at),
+                observed_at=_observed_at(certificate, collected_at),
+                published_at=collected_at,
             )
             for certificate in certificates
         )
         projections = tuple(
-            _map_certificate(certificate, target=target, collected_at=collected_at)
+            _map_certificate(
+                certificate,
+                target=target,
+                source_url=target_url,
+                collected_at=collected_at,
+            )
             for certificate in certificates
         )
         return AdapterCollectionBatch(
             observations=observations,
             passive_exposure_projections=projections,
             checkpoint_payload={"target_index": next_index},
-            not_modified=not certificates,
+            not_modified=not projections,
         )
 
 
@@ -146,76 +153,70 @@ def _map_certificate(
     certificate: CertSpotterCertificate,
     *,
     target: PassiveInfrastructureTarget,
+    source_url: str,
     collected_at: datetime,
 ) -> PassiveObservationSnapshot:
-    fingerprint = certificate.tbs_sha256.casefold()
-    asset_ref = AssetRef.from_value(AssetType.CERTIFICATE, fingerprint)
-    observed_at = _certificate_time(certificate, collected_at)
-    revision_key = sha256(certificate.model_dump_json().encode("utf-8")).hexdigest()
-    asset = PassiveAsset(
-        ref=asset_ref,
-        first_seen_at=observed_at,
-        last_seen_at=collected_at,
-        expires_at=certificate.not_after,
-        state=AssetState.OBSERVED,
-    )
-    link = OrganizationAssetLink(
-        id=_stable_uuid(f"certspotter-link:{target.target_id}:{fingerprint}"),
-        organization_id=target.organization_id,
-        asset=asset_ref,
-        status=OrganizationLinkStatus.REVIEW_REQUIRED,
-        confidence=0.7,
-        risks=(AttributionRisk.UNVERIFIED_OWNERSHIP,),
-        valid_from=observed_at,
-        valid_to=certificate.not_after,
-        reason="certificate issuance can cover shared or third-party managed infrastructure",
-        provenance_refs=(f"target:{target.target_id}", f"certificate:{certificate.id}"),
-    )
-    observation = PassiveObservation(
-        id=_stable_uuid(f"certspotter-observation:{certificate.id}:{revision_key}"),
-        provider=CertSpotterAdapter.source_id,
-        source_record_key=certificate.id,
-        source_revision_key=revision_key,
-        observation_type=PassiveObservationType.CERTIFICATE_TRANSPARENCY,
-        subject_asset=asset_ref,
-        observed_at=observed_at,
-        valid_from=observed_at,
-        valid_to=certificate.not_after,
-        confidence=0.8,
-        collection_method="certificate_transparency_search_api",
-        hostname_value=target.domain,
-        service_name=None,
-        port=None,
-        certificate_fingerprint=fingerprint,
-        technology_observation_id=None,
-        active_validation=False,
-        credential_use=False,
-        authenticated_access=False,
-        direct_connection_to_asset=False,
-        exploitation_attempted=False,
+    observed_at = _observed_at(certificate, collected_at)
+    expires_at = _optional_utc(certificate.not_after, "not_after")
+    active = expires_at is None or expires_at >= collected_at
+    state = (
+        PassiveObservationState.CURRENT
+        if active
+        else PassiveObservationState.EXPIRED
     )
     return PassiveObservationSnapshot(
-        provider=CertSpotterAdapter.source_id,
+        source_id=CertSpotterAdapter.source_id,
         source_record_key=certificate.id,
-        source_revision_key=revision_key,
-        asset=asset,
-        organization_link=link,
-        observation=observation,
+        source_url=source_url,
+        asset=PassiveAsset(
+            kind=PassiveAssetKind.CERTIFICATE,
+            value=certificate.tbs_sha256,
+        ),
+        observation_kind=PassiveObservationKind.CERTIFICATE,
+        state=state,
+        observed_at=observed_at,
+        published_at=collected_at,
+        modified_at=collected_at,
+        expires_at=expires_at,
+        confidence=0.8,
+        independence_key=f"certspotter-ct:{target.domain}",
+        organization_link=OrganizationLink(
+            status=OrganizationLinkStatus.REVIEW_REQUIRED,
+            method=OrganizationLinkMethod.PASSIVE_CORRELATION,
+            confidence=0.7,
+            organization_id=target.organization_id,
+            reasons=(
+                "certificate issuance can cover shared or third-party managed infrastructure",
+            ),
+            attribution_risks=(AttributionRisk.SHARED_HOSTING,),
+        ),
+        active=active,
     )
 
 
-def _certificate_time(
+def _matches_target(certificate: CertSpotterCertificate, target_domain: str) -> bool:
+    suffix = f".{target_domain}"
+    return any(
+        name.casefold() == target_domain or name.casefold().endswith(suffix)
+        for name in certificate.dns_names
+    )
+
+
+def _observed_at(
     certificate: CertSpotterCertificate,
-    fallback: datetime,
+    collected_at: datetime,
 ) -> datetime:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
     if certificate.not_before is None:
-        return fallback
-    return require_aware_utc(certificate.not_before, field_name="not_before")
+        return collected
+    not_before = require_aware_utc(certificate.not_before, field_name="not_before")
+    return min(not_before, collected)
 
 
-def _stable_uuid(value: str) -> UUID:
-    digest = sha256(value.encode("utf-8")).hexdigest()
-    return UUID(digest[:32])
+def _optional_utc(value: datetime | None, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    return require_aware_utc(value, field_name=field_name)
 
 
 def _next_target(

--- a/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+
+from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
+from cip.adapters.sources.passive_infrastructure.schemas import CertSpotterCertificate
+from cip.modules.collection_orchestration.application.passive_adapter_support import (
+    PassiveObservationContext,
+    authorize_passive_request,
+    get_json,
+    raw_passive_observation,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.passive_exposure.domain.asset_models import AssetRef, PassiveAsset
+from cip.modules.passive_exposure.domain.enums import (
+    AssetState,
+    AssetType,
+    AttributionRisk,
+    OrganizationLinkStatus,
+    PassiveObservationType,
+)
+from cip.modules.passive_exposure.domain.models import PassiveObservationSnapshot
+from cip.modules.passive_exposure.domain.observation_models import (
+    OrganizationAssetLink,
+    PassiveObservation,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class CertSpotterAdapter:
+    source_id = "certspotter-ct"
+    adapter_id = "certspotter-issuances-api"
+    adapter_version = "1"
+    data_category = DataCategory.TECHNOLOGY_OBSERVATION
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[PassiveInfrastructureTarget, ...],
+        *,
+        token_provider: Callable[[], str | None],
+        timeout_seconds: float = 20.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Cert Spotter adapter requires certspotter-ct policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled)
+        self._token_provider = token_provider
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None:
+            return _empty_batch()
+        target_url = self._entry.policy.base_url
+        authorize_passive_request(
+            self._entry,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        token = self._token_provider()
+        if token is None or not token.strip():
+            raise AdapterExecutionError(
+                "Cert Spotter production API secret is unavailable",
+                error_code="provider_not_connected",
+                retryable=False,
+            )
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(
+                client,
+                target_url,
+                params={
+                    "domain": target.domain,
+                    "include_subdomains": "true",
+                    "expand": "dns_names",
+                },
+                headers={"Authorization": f"Bearer {token.strip()}"},
+            )
+        try:
+            certificates = TypeAdapter(list[CertSpotterCertificate]).validate_json(body)
+        except ValidationError as exc:
+            raise AdapterExecutionError(
+                "Cert Spotter response schema changed",
+                error_code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        context = PassiveObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = tuple(
+            raw_passive_observation(
+                certificate,
+                context=context,
+                source_url=target_url,
+                source_record_key=certificate.id,
+                source_record_type="certspotter-issuance",
+                observed_at=_certificate_time(certificate, collected_at),
+                published_at=_certificate_time(certificate, collected_at),
+            )
+            for certificate in certificates
+        )
+        projections = tuple(
+            _map_certificate(certificate, target=target, collected_at=collected_at)
+            for certificate in certificates
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            passive_exposure_projections=projections,
+            checkpoint_payload={"target_index": next_index},
+            not_modified=not certificates,
+        )
+
+
+def _map_certificate(
+    certificate: CertSpotterCertificate,
+    *,
+    target: PassiveInfrastructureTarget,
+    collected_at: datetime,
+) -> PassiveObservationSnapshot:
+    fingerprint = certificate.tbs_sha256.casefold()
+    asset_ref = AssetRef.from_value(AssetType.CERTIFICATE, fingerprint)
+    observed_at = _certificate_time(certificate, collected_at)
+    revision_key = sha256(certificate.model_dump_json().encode("utf-8")).hexdigest()
+    asset = PassiveAsset(
+        ref=asset_ref,
+        first_seen_at=observed_at,
+        last_seen_at=collected_at,
+        expires_at=certificate.not_after,
+        state=AssetState.OBSERVED,
+    )
+    link = OrganizationAssetLink(
+        id=_stable_uuid(f"certspotter-link:{target.target_id}:{fingerprint}"),
+        organization_id=target.organization_id,
+        asset=asset_ref,
+        status=OrganizationLinkStatus.REVIEW_REQUIRED,
+        confidence=0.7,
+        risks=(AttributionRisk.UNVERIFIED_OWNERSHIP,),
+        valid_from=observed_at,
+        valid_to=certificate.not_after,
+        reason="certificate issuance can cover shared or third-party managed infrastructure",
+        provenance_refs=(f"target:{target.target_id}", f"certificate:{certificate.id}"),
+    )
+    observation = PassiveObservation(
+        id=_stable_uuid(f"certspotter-observation:{certificate.id}:{revision_key}"),
+        provider=CertSpotterAdapter.source_id,
+        source_record_key=certificate.id,
+        source_revision_key=revision_key,
+        observation_type=PassiveObservationType.CERTIFICATE_TRANSPARENCY,
+        subject_asset=asset_ref,
+        observed_at=observed_at,
+        valid_from=observed_at,
+        valid_to=certificate.not_after,
+        confidence=0.8,
+        collection_method="certificate_transparency_search_api",
+        hostname_value=target.domain,
+        service_name=None,
+        port=None,
+        certificate_fingerprint=fingerprint,
+        technology_observation_id=None,
+        active_validation=False,
+        credential_use=False,
+        authenticated_access=False,
+        direct_connection_to_asset=False,
+        exploitation_attempted=False,
+    )
+    return PassiveObservationSnapshot(
+        provider=CertSpotterAdapter.source_id,
+        source_record_key=certificate.id,
+        source_revision_key=revision_key,
+        asset=asset,
+        organization_link=link,
+        observation=observation,
+    )
+
+
+def _certificate_time(
+    certificate: CertSpotterCertificate,
+    fallback: datetime,
+) -> datetime:
+    if certificate.not_before is None:
+        return fallback
+    return require_aware_utc(certificate.not_before, field_name="not_before")
+
+
+def _stable_uuid(value: str) -> UUID:
+    digest = sha256(value.encode("utf-8")).hexdigest()
+    return UUID(digest[:32])
+
+
+def _next_target(
+    targets: tuple[PassiveInfrastructureTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[PassiveInfrastructureTarget | None, int]:
+    if not targets:
+        return None, 0
+    value = 0 if payload is None else payload.get("target_index", 0)
+    if not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            "invalid passive target checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(targets)
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        passive_exposure_projections=(),
+        checkpoint_payload={"target_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
@@ -34,6 +34,9 @@ from cip.modules.source_governance.domain.models import DataCategory
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 from cip.shared.kernel.time import require_aware_utc
 
+_MAX_PAGE_SIZE = 100
+_MAX_CURSOR_TARGETS = 500
+
 
 class CertSpotterAdapter:
     source_id = "certspotter-ct"
@@ -84,32 +87,18 @@ class CertSpotterAdapter:
                 error_code="provider_not_connected",
                 retryable=False,
             )
-        with httpx.Client(
-            timeout=self._timeout_seconds,
-            follow_redirects=False,
-            transport=self._transport,
-        ) as client:
-            body = get_json(
-                client,
-                target_url,
-                params={
-                    "domain": target.domain,
-                    "include_subdomains": "true",
-                    "expand": "dns_names",
-                },
-                headers={"Authorization": f"Bearer {token.strip()}"},
-            )
-        try:
-            certificates = TypeAdapter(list[CertSpotterCertificate]).validate_json(body)
-        except ValidationError as exc:
-            raise AdapterExecutionError(
-                "Cert Spotter response schema changed",
-                error_code="source_schema_drift",
-                retryable=False,
-            ) from exc
-        certificates = tuple(
+        cursors = _cursor_map(checkpoint_payload, self._targets)
+        page = self._request_page(
+            target_url,
+            target,
+            token=token.strip(),
+            after=cursors.get(target.target_id),
+        )
+        if page:
+            cursors[target.target_id] = page[-1].id
+        scoped = tuple(
             certificate
-            for certificate in certificates
+            for certificate in page
             if _matches_target(certificate, target.domain)
         )
         context = PassiveObservationContext(
@@ -130,7 +119,7 @@ class CertSpotterAdapter:
                 observed_at=_observed_at(certificate, collected_at),
                 published_at=collected_at,
             )
-            for certificate in certificates
+            for certificate in scoped
         )
         projections = tuple(
             _map_certificate(
@@ -139,14 +128,59 @@ class CertSpotterAdapter:
                 source_url=target_url,
                 collected_at=collected_at,
             )
-            for certificate in certificates
+            for certificate in scoped
         )
         return AdapterCollectionBatch(
             observations=observations,
             passive_exposure_projections=projections,
-            checkpoint_payload={"target_index": next_index},
+            checkpoint_payload={
+                "target_index": next_index,
+                "after_by_target": cursors,
+            },
             not_modified=not projections,
         )
+
+    def _request_page(
+        self,
+        target_url: str,
+        target: PassiveInfrastructureTarget,
+        *,
+        token: str,
+        after: str | None,
+    ) -> tuple[CertSpotterCertificate, ...]:
+        params = {
+            "domain": target.domain,
+            "include_subdomains": "true",
+            "expand": "dns_names",
+        }
+        if after is not None:
+            params["after"] = after
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(
+                client,
+                target_url,
+                params=params,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        try:
+            page = tuple(TypeAdapter(list[CertSpotterCertificate]).validate_json(body))
+        except ValidationError as exc:
+            raise AdapterExecutionError(
+                "Cert Spotter response schema changed",
+                error_code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        if len(page) > _MAX_PAGE_SIZE:
+            raise AdapterExecutionError(
+                "Cert Spotter page exceeds configured bound",
+                error_code="source_page_too_large",
+                retryable=False,
+            )
+        return page
 
 
 def _map_certificate(
@@ -206,6 +240,25 @@ def _matches_target(certificate: CertSpotterCertificate, target_domain: str) -> 
     return False
 
 
+def _cursor_map(
+    payload: Mapping[str, object] | None,
+    targets: tuple[PassiveInfrastructureTarget, ...],
+) -> dict[str, str]:
+    if payload is None:
+        return {}
+    raw = payload.get("after_by_target", {})
+    if not isinstance(raw, dict) or len(raw) > _MAX_CURSOR_TARGETS:
+        raise _invalid_checkpoint()
+    known_ids = {target.target_id for target in targets}
+    cursors: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not isinstance(value, str) or not value.strip():
+            raise _invalid_checkpoint()
+        if key in known_ids:
+            cursors[key] = value.strip()
+    return cursors
+
+
 def _observed_at(
     certificate: CertSpotterCertificate,
     collected_at: datetime,
@@ -231,19 +284,23 @@ def _next_target(
         return None, 0
     value = 0 if payload is None else payload.get("target_index", 0)
     if not isinstance(value, int) or value < 0:
-        raise AdapterExecutionError(
-            "invalid passive target checkpoint",
-            error_code="invalid_checkpoint",
-            retryable=False,
-        )
+        raise _invalid_checkpoint()
     index = value % len(targets)
     return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "invalid passive target checkpoint",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
 
 
 def _empty_batch() -> AdapterCollectionBatch:
     return AdapterCollectionBatch(
         observations=(),
         passive_exposure_projections=(),
-        checkpoint_payload={"target_index": 0},
+        checkpoint_payload={"target_index": 0, "after_by_target": {}},
         not_modified=True,
     )

--- a/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/certspotter_adapter.py
@@ -195,11 +195,15 @@ def _map_certificate(
 
 
 def _matches_target(certificate: CertSpotterCertificate, target_domain: str) -> bool:
-    suffix = f".{target_domain}"
-    return any(
-        name.casefold() == target_domain or name.casefold().endswith(suffix)
-        for name in certificate.dns_names
-    )
+    target = target_domain.rstrip(".").casefold()
+    suffix = f".{target}"
+    for raw_name in certificate.dns_names:
+        name = raw_name.strip().rstrip(".").casefold()
+        if name.startswith("*."):
+            name = name[2:]
+        if name == target or name.endswith(suffix):
+            return True
+    return False
 
 
 def _observed_at(

--- a/src/cip/modules/collection_orchestration/application/cloudflare_dns_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/cloudflare_dns_adapter.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
+from cip.adapters.sources.passive_infrastructure.schemas import (
+    CloudflareDnsAnswer,
+    CloudflareDnsResponse,
+)
+from cip.modules.collection_orchestration.application.passive_adapter_support import (
+    PassiveObservationContext,
+    authorize_passive_request,
+    get_json,
+    raw_passive_observation,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.passive_exposure.domain.asset_models import AssetRef, PassiveAsset
+from cip.modules.passive_exposure.domain.enums import (
+    AssetState,
+    AssetType,
+    AttributionRisk,
+    OrganizationLinkStatus,
+    PassiveObservationType,
+)
+from cip.modules.passive_exposure.domain.models import PassiveObservationSnapshot
+from cip.modules.passive_exposure.domain.observation_models import (
+    OrganizationAssetLink,
+    PassiveObservation,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_DNS_TYPES = ("A", "AAAA")
+
+
+class CloudflareDnsAdapter:
+    source_id = "cloudflare-doh"
+    adapter_id = "cloudflare-dns-json"
+    adapter_version = "1"
+    data_category = DataCategory.TECHNOLOGY_OBSERVATION
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[PassiveInfrastructureTarget, ...],
+        *,
+        timeout_seconds: float = 20.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Cloudflare DNS adapter requires cloudflare-doh policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None:
+            return _empty_batch()
+        target_url = self._entry.policy.base_url
+        authorize_passive_request(
+            self._entry,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        context = PassiveObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = []
+        projections = []
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            for record_type in _DNS_TYPES:
+                response = _query(client, target_url, target.domain, record_type)
+                for answer in response.Answer:
+                    snapshot = _map_answer(answer, target=target, observed_at=collected_at)
+                    if snapshot is None:
+                        continue
+                    observations.append(
+                        raw_passive_observation(
+                            answer,
+                            context=context,
+                            source_url=target_url,
+                            source_record_key=snapshot.source_record_key,
+                            source_record_type="cloudflare-dns-answer",
+                            observed_at=collected_at,
+                        )
+                    )
+                    projections.append(snapshot)
+        return AdapterCollectionBatch(
+            observations=tuple(observations),
+            passive_exposure_projections=tuple(projections),
+            checkpoint_payload={"target_index": next_index},
+            not_modified=not projections,
+        )
+
+
+def _query(
+    client: httpx.Client,
+    target_url: str,
+    domain: str,
+    record_type: str,
+) -> CloudflareDnsResponse:
+    body = get_json(
+        client,
+        target_url,
+        params={"name": domain, "type": record_type},
+        headers={"accept": "application/dns-json"},
+    )
+    try:
+        result = CloudflareDnsResponse.model_validate_json(body)
+    except ValidationError as exc:
+        raise AdapterExecutionError(
+            "Cloudflare DNS response schema changed",
+            error_code="source_schema_drift",
+            retryable=False,
+        ) from exc
+    if result.Status != 0:
+        raise AdapterExecutionError(
+            f"Cloudflare DNS returned DNS status {result.Status}",
+            error_code="provider_dns_error",
+            retryable=False,
+        )
+    return result
+
+
+def _map_answer(
+    answer: CloudflareDnsAnswer,
+    *,
+    target: PassiveInfrastructureTarget,
+    observed_at: datetime,
+) -> PassiveObservationSnapshot | None:
+    if answer.type not in {1, 28}:
+        return None
+    try:
+        asset_ref = AssetRef.from_value(AssetType.IP, answer.data)
+    except ValueError:
+        return None
+    record_key = f"{target.domain}:{answer.type}:{asset_ref.value}"
+    revision_key = sha256(answer.model_dump_json().encode("utf-8")).hexdigest()
+    asset = PassiveAsset(
+        ref=asset_ref,
+        first_seen_at=observed_at,
+        last_seen_at=observed_at,
+        state=AssetState.OBSERVED,
+    )
+    link = OrganizationAssetLink(
+        id=_stable_uuid(f"cloudflare-link:{target.target_id}:{asset_ref.value}"),
+        organization_id=target.organization_id,
+        asset=asset_ref,
+        status=OrganizationLinkStatus.REVIEW_REQUIRED,
+        confidence=0.65,
+        risks=(AttributionRisk.SHARED_HOSTING,),
+        valid_from=observed_at,
+        valid_to=None,
+        reason="DNS resolution can point to shared or CDN infrastructure",
+        provenance_refs=(f"target:{target.target_id}", f"dns:{target.domain}"),
+    )
+    observation = PassiveObservation(
+        id=_stable_uuid(f"cloudflare-observation:{record_key}:{revision_key}"),
+        provider=CloudflareDnsAdapter.source_id,
+        source_record_key=record_key,
+        source_revision_key=revision_key,
+        observation_type=PassiveObservationType.PASSIVE_DNS,
+        subject_asset=asset_ref,
+        observed_at=observed_at,
+        valid_from=observed_at,
+        valid_to=None,
+        confidence=0.75,
+        collection_method="official_dns_over_https",
+        hostname_value=target.domain,
+        service_name=None,
+        port=None,
+        certificate_fingerprint=None,
+        technology_observation_id=None,
+        active_validation=False,
+        credential_use=False,
+        authenticated_access=False,
+        direct_connection_to_asset=False,
+        exploitation_attempted=False,
+    )
+    return PassiveObservationSnapshot(
+        provider=CloudflareDnsAdapter.source_id,
+        source_record_key=record_key,
+        source_revision_key=revision_key,
+        asset=asset,
+        organization_link=link,
+        observation=observation,
+    )
+
+
+def _stable_uuid(value: str) -> UUID:
+    digest = sha256(value.encode("utf-8")).hexdigest()
+    return UUID(digest[:32])
+
+
+def _next_target(
+    targets: tuple[PassiveInfrastructureTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[PassiveInfrastructureTarget | None, int]:
+    if not targets:
+        return None, 0
+    value = 0 if payload is None else payload.get("target_index", 0)
+    if not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            "invalid passive target checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(targets)
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        passive_exposure_projections=(),
+        checkpoint_payload={"target_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/cloudflare_dns_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/cloudflare_dns_adapter.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime
-from hashlib import sha256
+from datetime import datetime, timedelta
 from uuid import UUID
 
 import httpx
@@ -23,23 +22,25 @@ from cip.modules.collection_orchestration.application.ports import (
     AdapterCollectionBatch,
     AdapterExecutionError,
 )
-from cip.modules.passive_exposure.domain.asset_models import AssetRef, PassiveAsset
-from cip.modules.passive_exposure.domain.enums import (
-    AssetState,
-    AssetType,
+from cip.modules.passive_exposure.domain.models import (
     AttributionRisk,
+    OrganizationLink,
+    OrganizationLinkMethod,
     OrganizationLinkStatus,
-    PassiveObservationType,
-)
-from cip.modules.passive_exposure.domain.models import PassiveObservationSnapshot
-from cip.modules.passive_exposure.domain.observation_models import (
-    OrganizationAssetLink,
-    PassiveObservation,
+    PassiveAsset,
+    PassiveAssetKind,
+    PassiveObservationKind,
+    PassiveObservationSnapshot,
+    PassiveObservationState,
 )
 from cip.modules.source_governance.domain.models import DataCategory
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
 _DNS_TYPES = ("A", "AAAA")
+_DNS_ASSET_KINDS = {
+    1: PassiveAssetKind.IPV4,
+    28: PassiveAssetKind.IPV6,
+}
 
 
 class CloudflareDnsAdapter:
@@ -99,8 +100,13 @@ class CloudflareDnsAdapter:
         ) as client:
             for record_type in _DNS_TYPES:
                 response = _query(client, target_url, target.domain, record_type)
-                for answer in response.Answer:
-                    snapshot = _map_answer(answer, target=target, observed_at=collected_at)
+                for answer in response.answers:
+                    snapshot = _map_answer(
+                        answer,
+                        target=target,
+                        source_url=target_url,
+                        observed_at=collected_at,
+                    )
                     if snapshot is None:
                         continue
                     observations.append(
@@ -142,9 +148,9 @@ def _query(
             error_code="source_schema_drift",
             retryable=False,
         ) from exc
-    if result.Status != 0:
+    if result.status != 0:
         raise AdapterExecutionError(
-            f"Cloudflare DNS returned DNS status {result.Status}",
+            f"Cloudflare DNS returned DNS status {result.status}",
             error_code="provider_dns_error",
             retryable=False,
         )
@@ -155,70 +161,39 @@ def _map_answer(
     answer: CloudflareDnsAnswer,
     *,
     target: PassiveInfrastructureTarget,
+    source_url: str,
     observed_at: datetime,
 ) -> PassiveObservationSnapshot | None:
-    if answer.type not in {1, 28}:
+    asset_kind = _DNS_ASSET_KINDS.get(answer.record_type)
+    if asset_kind is None:
         return None
     try:
-        asset_ref = AssetRef.from_value(AssetType.IP, answer.data)
+        asset = PassiveAsset(kind=asset_kind, value=answer.data)
     except ValueError:
         return None
-    record_key = f"{target.domain}:{answer.type}:{asset_ref.value}"
-    revision_key = sha256(answer.model_dump_json().encode("utf-8")).hexdigest()
-    asset = PassiveAsset(
-        ref=asset_ref,
-        first_seen_at=observed_at,
-        last_seen_at=observed_at,
-        state=AssetState.OBSERVED,
-    )
-    link = OrganizationAssetLink(
-        id=_stable_uuid(f"cloudflare-link:{target.target_id}:{asset_ref.value}"),
-        organization_id=target.organization_id,
-        asset=asset_ref,
-        status=OrganizationLinkStatus.REVIEW_REQUIRED,
-        confidence=0.65,
-        risks=(AttributionRisk.SHARED_HOSTING,),
-        valid_from=observed_at,
-        valid_to=None,
-        reason="DNS resolution can point to shared or CDN infrastructure",
-        provenance_refs=(f"target:{target.target_id}", f"dns:{target.domain}"),
-    )
-    observation = PassiveObservation(
-        id=_stable_uuid(f"cloudflare-observation:{record_key}:{revision_key}"),
-        provider=CloudflareDnsAdapter.source_id,
-        source_record_key=record_key,
-        source_revision_key=revision_key,
-        observation_type=PassiveObservationType.PASSIVE_DNS,
-        subject_asset=asset_ref,
-        observed_at=observed_at,
-        valid_from=observed_at,
-        valid_to=None,
-        confidence=0.75,
-        collection_method="official_dns_over_https",
-        hostname_value=target.domain,
-        service_name=None,
-        port=None,
-        certificate_fingerprint=None,
-        technology_observation_id=None,
-        active_validation=False,
-        credential_use=False,
-        authenticated_access=False,
-        direct_connection_to_asset=False,
-        exploitation_attempted=False,
-    )
+    record_key = f"{target.domain}:{answer.record_type}:{asset.value}"
     return PassiveObservationSnapshot(
-        provider=CloudflareDnsAdapter.source_id,
+        source_id=CloudflareDnsAdapter.source_id,
         source_record_key=record_key,
-        source_revision_key=revision_key,
+        source_url=source_url,
         asset=asset,
-        organization_link=link,
-        observation=observation,
+        observation_kind=PassiveObservationKind.PASSIVE_DNS,
+        state=PassiveObservationState.CURRENT,
+        observed_at=observed_at,
+        published_at=observed_at,
+        modified_at=observed_at,
+        expires_at=observed_at + timedelta(seconds=answer.ttl),
+        confidence=0.75,
+        independence_key=f"cloudflare-doh:{target.domain}",
+        organization_link=OrganizationLink(
+            status=OrganizationLinkStatus.REVIEW_REQUIRED,
+            method=OrganizationLinkMethod.PASSIVE_CORRELATION,
+            confidence=0.65,
+            organization_id=target.organization_id,
+            reasons=("DNS resolution can point to shared or CDN infrastructure",),
+            attribution_risks=(AttributionRisk.SHARED_HOSTING,),
+        ),
     )
-
-
-def _stable_uuid(value: str) -> UUID:
-    digest = sha256(value.encode("utf-8")).hexdigest()
-    return UUID(digest[:32])
 
 
 def _next_target(

--- a/src/cip/modules/collection_orchestration/application/passive_adapter_support.py
+++ b/src/cip/modules/collection_orchestration/application/passive_adapter_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
@@ -62,8 +63,8 @@ def get_json(
     client: httpx.Client,
     target_url: str,
     *,
-    params: dict[str, str | int],
-    headers: dict[str, str] | None = None,
+    params: Mapping[str, str | int],
+    headers: Mapping[str, str] | None = None,
 ) -> bytes:
     try:
         response = client.get(target_url, params=params, headers=headers)

--- a/src/cip/modules/collection_orchestration/application/passive_adapter_support.py
+++ b/src/cip/modules/collection_orchestration/application/passive_adapter_support.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel
+
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+MAX_JSON_BYTES = 4 * 1024 * 1024
+PURPOSE = "passive-infrastructure-intelligence"
+
+
+@dataclass(frozen=True, slots=True)
+class PassiveObservationContext:
+    source_id: str
+    adapter_id: str
+    adapter_version: str
+    collection_job_id: UUID
+    collected_at: datetime
+    retention_until: datetime
+
+
+def authorize_passive_request(
+    entry: SourceRegistryEntry,
+    *,
+    target_url: str,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.TECHNOLOGY_OBSERVATION,
+            target_url=target_url,
+            purpose=PURPOSE,
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def get_json(
+    client: httpx.Client,
+    target_url: str,
+    *,
+    params: dict[str, str | int],
+    headers: dict[str, str] | None = None,
+) -> bytes:
+    try:
+        response = client.get(target_url, params=params, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        raise AdapterExecutionError(
+            f"passive provider returned HTTP {status}",
+            error_code=f"http_{status}",
+            retryable=status == 429 or status >= 500,
+        ) from exc
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        raise AdapterExecutionError(
+            str(exc) or type(exc).__name__,
+            error_code="source_transport_error",
+            retryable=True,
+        ) from exc
+    if "json" not in response.headers.get("content-type", "").casefold():
+        raise AdapterExecutionError(
+            "passive provider response is not JSON",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    if len(response.content) > MAX_JSON_BYTES:
+        raise AdapterExecutionError(
+            "passive provider response exceeds size limit",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    return response.content
+
+
+def raw_passive_observation(
+    model: BaseModel,
+    *,
+    context: PassiveObservationContext,
+    source_url: str,
+    source_record_key: str,
+    source_record_type: str,
+    observed_at: datetime | None = None,
+    published_at: datetime | None = None,
+) -> RawObservation:
+    encoded = model.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
+    return RawObservation(
+        source_id=context.source_id,
+        adapter_id=context.adapter_id,
+        adapter_version=context.adapter_version,
+        collection_job_id=context.collection_job_id,
+        source_record_type=source_record_type,
+        source_url=source_url,
+        payload_hash_sha256=sha256(encoded).hexdigest(),
+        data_categories=frozenset({DataCategory.TECHNOLOGY_OBSERVATION}),
+        source_record_key=source_record_key,
+        collected_at=context.collected_at,
+        observed_at=observed_at,
+        published_at=published_at,
+        retention_until=context.retention_until,
+        schema_fingerprint=f"{source_record_type}:v1",
+    )

--- a/src/cip/modules/collection_orchestration/application/passive_infrastructure_registration.py
+++ b/src/cip/modules/collection_orchestration/application/passive_infrastructure_registration.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
+from cip.modules.collection_orchestration.application.certspotter_adapter import (
+    CertSpotterAdapter,
+)
+from cip.modules.collection_orchestration.application.cloudflare_dns_adapter import (
+    CloudflareDnsAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+def register_passive_infrastructure_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    targets: tuple[PassiveInfrastructureTarget, ...],
+    *,
+    certspotter_token_provider: Callable[[], str | None],
+    timeout_seconds: float,
+) -> None:
+    cloudflare_entry = entries_by_id.get(CloudflareDnsAdapter.source_id)
+    if cloudflare_entry is not None:
+        _register(
+            adapters,
+            CloudflareDnsAdapter(
+                cloudflare_entry,
+                targets,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    certspotter_entry = entries_by_id.get(CertSpotterAdapter.source_id)
+    if certspotter_entry is not None:
+        _register(
+            adapters,
+            CertSpotterAdapter(
+                certspotter_entry,
+                targets,
+                token_provider=certspotter_token_provider,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    adapters[(adapter.source_id, adapter.adapter_id)] = adapter

--- a/src/cip/modules/collection_orchestration/application/ports.py
+++ b/src/cip/modules/collection_orchestration/application/ports.py
@@ -10,6 +10,7 @@ from cip.modules.evidence.domain.entities import Evidence
 from cip.modules.opportunities.domain.entities import CommercialSignal
 from cip.modules.organizations.application.identity import IdentityProjection
 from cip.modules.organizations.domain.entities import Organization
+from cip.modules.passive_exposure.domain.models import PassiveObservationSnapshot
 from cip.modules.procurement_history.domain.models import ProcurementHistoryProjection
 from cip.modules.public_footprint.domain.models import PublicFootprintProjection
 from cip.modules.raw_observations.domain.entities import RawObservation
@@ -48,6 +49,7 @@ class AdapterCollectionBatch:
     procurement_projections: tuple[ProcurementHistoryProjection, ...] = ()
     public_footprint_projections: tuple[PublicFootprintProjection, ...] = ()
     vulnerability_snapshots: tuple[VulnerabilitySnapshot, ...] = ()
+    passive_exposure_projections: tuple[PassiveObservationSnapshot, ...] = ()
     quota_remaining: int | None = None
     request_cost: float = 0.0
 

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -15,6 +15,9 @@ from cip.adapters.sources.lever.registry import load_lever_sites
 from cip.adapters.sources.organization_identity.registry import (
     load_organization_identity_targets,
 )
+from cip.adapters.sources.passive_infrastructure.registry import (
+    load_passive_infrastructure_targets,
+)
 from cip.adapters.sources.public_web.registry import load_public_web_targets
 from cip.adapters.sources.smartrecruiters.registry import load_smartrecruiters_companies
 from cip.adapters.sources.vulnerability_catalogs.registry import (
@@ -99,6 +102,11 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
             source_id="brave-search-api",
             secret_name="api_token",
         ),
+        certspotter_token_provider=connected_secret_supplier(
+            factory,
+            source_id="certspotter-ct",
+            secret_name="api_token",
+        ),
         timeout_seconds=settings.source_http_timeout_seconds,
     )
     with session_scope(factory) as session:
@@ -126,6 +134,7 @@ def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
         settings.incident_source_registry_path,
         settings.threat_telemetry_source_registry_path,
         settings.passive_exposure_source_registry_path,
+        settings.passive_infrastructure_source_registry_path,
         settings.advisory_source_registry_path,
         settings.corporate_change_source_registry_path,
         settings.relationship_source_registry_path,
@@ -143,6 +152,7 @@ def _load_portfolio(settings: Settings) -> tuple[SourceCatalogEntry, ...]:
         settings.incident_source_portfolio_path,
         settings.threat_telemetry_source_portfolio_path,
         settings.passive_exposure_source_portfolio_path,
+        settings.passive_infrastructure_source_portfolio_path,
         settings.advisory_source_portfolio_path,
         settings.corporate_change_source_portfolio_path,
         settings.relationship_source_portfolio_path,
@@ -171,6 +181,9 @@ def _load_adapter_inputs(
         vulnerability_targets=load_vulnerability_query_targets(
             settings.vulnerability_query_target_registry_path
         ),
+        passive_infrastructure_targets=load_passive_infrastructure_targets(
+            settings.passive_infrastructure_target_registry_path
+        ),
     )
 
 
@@ -181,6 +194,7 @@ def _load_schedules(settings: Settings) -> tuple[SourceSchedule, ...]:
         settings.public_web_collection_schedule_path,
         settings.vulnerability_collection_schedule_path,
         settings.search_archive_collection_schedule_path,
+        settings.passive_infrastructure_collection_schedule_path,
     )
 
 

--- a/src/cip/modules/collection_orchestration/application/worker.py
+++ b/src/cip/modules/collection_orchestration/application/worker.py
@@ -34,7 +34,7 @@ from cip.modules.organizations.infrastructure.identity_persistence import (
 )
 from cip.modules.organizations.infrastructure.persistence import upsert_organizations
 from cip.modules.passive_exposure.infrastructure.projections import (
-    persist_passive_observations,
+    persist_passive_snapshots,
 )
 from cip.modules.procurement_history.infrastructure.projections import (
     persist_procurement_projections,
@@ -194,7 +194,7 @@ def _complete_success(
             batch.vulnerability_snapshots,
             now=now,
         )
-        persist_passive_observations(
+        persist_passive_snapshots(
             session,
             batch.passive_exposure_projections,
             now=now,

--- a/src/cip/modules/collection_orchestration/application/worker.py
+++ b/src/cip/modules/collection_orchestration/application/worker.py
@@ -33,6 +33,9 @@ from cip.modules.organizations.infrastructure.identity_persistence import (
     persist_identity_projections,
 )
 from cip.modules.organizations.infrastructure.persistence import upsert_organizations
+from cip.modules.passive_exposure.infrastructure.projections import (
+    persist_passive_observations,
+)
 from cip.modules.procurement_history.infrastructure.projections import (
     persist_procurement_projections,
 )
@@ -189,6 +192,11 @@ def _complete_success(
         persist_vulnerability_snapshots(
             session,
             batch.vulnerability_snapshots,
+            now=now,
+        )
+        persist_passive_observations(
+            session,
+            batch.passive_exposure_projections,
             now=now,
         )
         _record_success_health(

--- a/src/cip/modules/source_portfolio/application/backfill_worker.py
+++ b/src/cip/modules/source_portfolio/application/backfill_worker.py
@@ -18,7 +18,7 @@ from cip.modules.collection_orchestration.infrastructure.repository_completion i
 from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.organizations.infrastructure.persistence import upsert_organizations
 from cip.modules.passive_exposure.infrastructure.projections import (
-    persist_passive_observations,
+    persist_passive_snapshots,
 )
 from cip.modules.procurement_history.infrastructure.projections import (
     persist_procurement_projections,
@@ -134,7 +134,7 @@ def run_backfill_once(
             batch.vulnerability_snapshots,
             now=completed_at,
         )
-        persist_passive_observations(
+        persist_passive_snapshots(
             session,
             batch.passive_exposure_projections,
             now=completed_at,

--- a/src/cip/modules/source_portfolio/application/backfill_worker.py
+++ b/src/cip/modules/source_portfolio/application/backfill_worker.py
@@ -17,6 +17,9 @@ from cip.modules.collection_orchestration.infrastructure.repository_completion i
 )
 from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.organizations.infrastructure.persistence import upsert_organizations
+from cip.modules.passive_exposure.infrastructure.projections import (
+    persist_passive_observations,
+)
 from cip.modules.procurement_history.infrastructure.projections import (
     persist_procurement_projections,
 )
@@ -129,6 +132,11 @@ def run_backfill_once(
         persist_vulnerability_snapshots(
             session,
             batch.vulnerability_snapshots,
+            now=completed_at,
+        )
+        persist_passive_observations(
+            session,
+            batch.passive_exposure_projections,
             now=completed_at,
         )
         record_collection_success(

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -35,6 +35,9 @@ class Settings(BaseSettings):
     passive_exposure_source_registry_path: Path = Path(
         "policies/sources.passive_exposure.yml"
     )
+    passive_infrastructure_source_registry_path: Path = Path(
+        "policies/sources.passive_infrastructure.yml"
+    )
     advisory_source_registry_path: Path = Path("policies/sources.advisories.yml")
     corporate_change_source_registry_path: Path = Path(
         "policies/sources.corporate_changes.yml"
@@ -62,6 +65,9 @@ class Settings(BaseSettings):
     passive_exposure_source_portfolio_path: Path = Path(
         "policies/source_portfolio.passive_exposure.yml"
     )
+    passive_infrastructure_source_portfolio_path: Path = Path(
+        "policies/source_portfolio.passive_infrastructure.yml"
+    )
     advisory_source_portfolio_path: Path = Path("policies/source_portfolio.advisories.yml")
     corporate_change_source_portfolio_path: Path = Path(
         "policies/source_portfolio.corporate_changes.yml"
@@ -86,6 +92,9 @@ class Settings(BaseSettings):
     vulnerability_query_target_registry_path: Path = Path(
         "policies/vulnerability_query_targets.yml"
     )
+    passive_infrastructure_target_registry_path: Path = Path(
+        "policies/passive_infrastructure_targets.yml"
+    )
     retention_policy_path: Path = Path("policies/retention.yml")
     collection_schedule_path: Path = Path("policies/collection_schedules.yml")
     decp_collection_schedule_path: Path = Path("policies/collection_schedules.decp.yml")
@@ -97,6 +106,9 @@ class Settings(BaseSettings):
     )
     search_archive_collection_schedule_path: Path = Path(
         "policies/collection_schedules.search_archives.yml"
+    )
+    passive_infrastructure_collection_schedule_path: Path = Path(
+        "policies/collection_schedules.passive_infrastructure.yml"
     )
     control_plane_token: str = Field(
         default="development-control-token",

--- a/tests/integration/test_passive_projection_collection_paths.py
+++ b/tests/integration/test_passive_projection_collection_paths.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    CollectionAdapter,
+)
+from cip.modules.collection_orchestration.application.worker import WorkerStatus, run_worker_once
+from cip.modules.collection_orchestration.domain.models import CollectionJob, SourceSchedule
+from cip.modules.collection_orchestration.infrastructure.repository import enqueue_job
+from cip.modules.data_governance.domain.retention import RetentionPolicy, RetentionRule
+from cip.modules.passive_exposure.domain.models import (
+    OrganizationLink,
+    OrganizationLinkMethod,
+    OrganizationLinkStatus,
+    PassiveAsset,
+    PassiveAssetKind,
+    PassiveObservationKind,
+    PassiveObservationSnapshot,
+    PassiveObservationState,
+)
+from cip.modules.passive_exposure.infrastructure.models import (
+    PassiveAssetRecord,
+    PassiveObservationSnapshotRecord,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.raw_observations.infrastructure.models import RawObservationRecord
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.models import SourceRecord
+from cip.modules.source_portfolio.application.backfill_worker import (
+    BackfillWorkerStatus,
+    run_backfill_once,
+)
+from cip.modules.source_portfolio.application.service import request_backfill, sync_source_portfolio
+from cip.modules.source_portfolio.infrastructure.registry import load_source_portfolio
+from cip.shared.persistence.metadata import get_metadata
+from cip.shared.persistence.session import session_scope
+
+NOW = datetime(2026, 8, 9, 22, 30, tzinfo=UTC)
+
+
+class PassiveProjectionAdapter:
+    source_id = "reference-synthetic"
+    adapter_id = "reference-synthetic-adapter"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        del checkpoint_payload
+        record_key = f"passive-{collection_job_id}"
+        observation = RawObservation(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version="1",
+            collection_job_id=collection_job_id,
+            source_record_type="passive_reference",
+            source_record_key=record_key,
+            source_url=f"https://example.invalid/{record_key}",
+            payload_hash_sha256="9" * 64,
+            data_categories=frozenset({self.data_category}),
+            collected_at=collected_at,
+            observed_at=collected_at,
+            published_at=collected_at,
+            source_updated_at=collected_at,
+            schema_fingerprint="passive-reference-v1",
+            retention_until=retention_until,
+        )
+        snapshot = PassiveObservationSnapshot(
+            source_id=self.source_id,
+            source_record_key=record_key,
+            source_url=f"https://example.invalid/{record_key}",
+            asset=PassiveAsset(kind=PassiveAssetKind.IPV4, value="8.8.8.8"),
+            observation_kind=PassiveObservationKind.PASSIVE_DNS,
+            state=PassiveObservationState.CURRENT,
+            observed_at=collected_at,
+            published_at=collected_at,
+            modified_at=collected_at,
+            confidence=0.5,
+            organization_link=OrganizationLink(
+                status=OrganizationLinkStatus.UNRESOLVED,
+                method=OrganizationLinkMethod.NONE,
+                confidence=0.0,
+            ),
+        )
+        return AdapterCollectionBatch(
+            observations=(observation,),
+            checkpoint_payload={"sequence": 1},
+            not_modified=False,
+            passive_exposure_projections=(snapshot,),
+        )
+
+
+def test_incremental_worker_persists_raw_and_passive_projection_atomically() -> None:
+    factory = _factory()
+    adapter = PassiveProjectionAdapter()
+    _seed_source(factory)
+    with session_scope(factory) as session:
+        schedule = SourceSchedule(adapter.source_id, adapter.adapter_id, 300)
+        job = CollectionJob.from_schedule(schedule, scheduled_for=NOW)
+        assert enqueue_job(session, job) is True
+
+    outcome = run_worker_once(
+        factory,
+        worker_id="passive-worker",
+        adapters={(adapter.source_id, adapter.adapter_id): cast(CollectionAdapter, adapter)},
+        retention_policy=_retention_policy(),
+        clock=lambda: NOW + timedelta(seconds=1),
+    )
+
+    assert outcome.status is WorkerStatus.SUCCEEDED
+    assert outcome.observations_written == 1
+    _assert_passive_writes(factory)
+
+
+def test_backfill_worker_persists_raw_and_passive_projection_atomically() -> None:
+    factory = _factory()
+    adapter = PassiveProjectionAdapter()
+    _seed_source(factory)
+    with session_scope(factory) as session:
+        request_backfill(
+            session,
+            adapter.source_id,
+            (("2026-01-01", "2026-02-01"),),
+            actor="passive-backfill-test",
+            now=NOW,
+        )
+
+    outcome = run_backfill_once(
+        factory,
+        worker_id="passive-backfill-worker",
+        adapters={(adapter.source_id, adapter.adapter_id): cast(CollectionAdapter, adapter)},
+        retention_policy=_retention_policy(),
+        clock=lambda: NOW + timedelta(seconds=1),
+    )
+
+    assert outcome.status is BackfillWorkerStatus.SUCCEEDED
+    assert outcome.observations_written == 1
+    _assert_passive_writes(factory)
+
+
+def _assert_passive_writes(factory: sessionmaker[Session]) -> None:
+    with factory() as session:
+        assert session.scalar(select(func.count(RawObservationRecord.id))) == 1
+        assert session.scalar(select(func.count(PassiveAssetRecord.id))) == 1
+        assert session.scalar(select(func.count(PassiveObservationSnapshotRecord.id))) == 1
+        asset = session.scalar(select(PassiveAssetRecord))
+        assert asset is not None
+        assert asset.asset_kind == PassiveAssetKind.IPV4.value
+        assert asset.asset_value == "8.8.8.8"
+        assert asset.active is True
+
+
+def _seed_source(factory: sessionmaker[Session]) -> None:
+    with session_scope(factory) as session:
+        session.add(_source_record())
+        sync_source_portfolio(
+            session,
+            load_source_portfolio(Path("policies/source_portfolio.yml")),
+            now=NOW,
+        )
+
+
+def _factory() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    get_metadata().create_all(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+
+
+def _source_record() -> SourceRecord:
+    return SourceRecord(
+        id="reference-synthetic",
+        name="Synthetic reference adapter",
+        base_url="https://example.invalid/source-portfolio-reference",
+        status="enabled",
+        source_type="api",
+        owner="Cyber Intelligence Platform",
+        terms_url=None,
+        licence=None,
+        allowed_data_categories=[DataCategory.PUBLIC_RESULT_METADATA.value],
+        prohibited_data_categories=[],
+        rate_limit_per_minute=None,
+        retention_days=30,
+        attribution_required=False,
+        raw_content_storage=False,
+        human_review_required=False,
+        authorization_status="approved",
+        authorization_document_reference="TEST-REFERENCE",
+        authorization_reviewed_at=NOW,
+        authorization_expires_at=NOW + timedelta(days=365),
+        approved_hosts=["example.invalid"],
+        approved_path_prefixes=["/source-portfolio-reference"],
+        approved_purposes=["runtime-contract-validation"],
+        automated_collection_allowed=True,
+        raw_storage_allowed=False,
+    )
+
+
+def _retention_policy() -> RetentionPolicy:
+    return RetentionPolicy(
+        version=1,
+        rules={
+            DataCategory.PUBLIC_RESULT_METADATA: RetentionRule(
+                retention_days=30,
+                review_interval_days=7,
+            )
+        },
+        prohibited_categories=frozenset(),
+        suppression_minimum_days=365,
+        backup_deletion_propagation_max_days=30,
+        restoration_requires_suppressions=True,
+    )

--- a/tests/unit/adapters/test_passive_infrastructure_target_registry.py
+++ b/tests/unit/adapters/test_passive_infrastructure_target_registry.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from cip.adapters.sources.passive_infrastructure.registry import (
+    load_passive_infrastructure_targets,
+)
+
+ORGANIZATION_ID = UUID("00000000-0000-0000-0000-000000000305")
+
+
+def test_checked_in_passive_target_registry_is_empty_by_default() -> None:
+    targets = load_passive_infrastructure_targets(
+        Path("policies/passive_infrastructure_targets.yml")
+    )
+
+    assert targets == ()
+
+
+def test_target_registry_normalizes_public_domain(tmp_path: Path) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        f"""version: 1
+targets:
+  - target_id: example
+    organization_id: {ORGANIZATION_ID}
+    domain: EXAMPLE.COM.
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+
+    targets = load_passive_infrastructure_targets(path)
+
+    assert targets[0].domain == "example.com"
+    assert targets[0].enabled is True
+
+
+@pytest.mark.parametrize("domain", ["localhost", "corp.local", "example.invalid", "10.0.0.1"])
+def test_target_registry_rejects_non_public_domains(tmp_path: Path, domain: str) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        f"""version: 1
+targets:
+  - target_id: invalid
+    organization_id: {ORGANIZATION_ID}
+    domain: {domain}
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_passive_infrastructure_targets(path)
+
+
+def test_target_registry_rejects_duplicate_target_ids(tmp_path: Path) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        f"""version: 1
+targets:
+  - target_id: duplicate
+    organization_id: {ORGANIZATION_ID}
+    domain: example.com
+  - target_id: duplicate
+    organization_id: {ORGANIZATION_ID}
+    domain: example.org
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate passive infrastructure target_id"):
+        load_passive_infrastructure_targets(path)

--- a/tests/unit/collection_orchestration/test_passive_infrastructure_adapters.py
+++ b/tests/unit/collection_orchestration/test_passive_infrastructure_adapters.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+
+from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
+from cip.modules.collection_orchestration.application.certspotter_adapter import (
+    CertSpotterAdapter,
+)
+from cip.modules.collection_orchestration.application.cloudflare_dns_adapter import (
+    CloudflareDnsAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.passive_exposure.domain.models import (
+    AttributionRisk,
+    OrganizationLinkStatus,
+    PassiveAssetKind,
+    PassiveObservationKind,
+    PassiveObservationState,
+)
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 9, 22, 30, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+JOB_ID = UUID("00000000-0000-0000-0000-000000000303")
+ORGANIZATION_ID = UUID("00000000-0000-0000-0000-000000000304")
+REGISTRY = Path("policies/sources.passive_infrastructure.yml")
+
+
+def test_cloudflare_maps_only_passive_review_required_dns_observations() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        record_type = request.url.params["type"]
+        data = "8.8.8.8" if record_type == "A" else "2606:4700:4700::1111"
+        numeric_type = 1 if record_type == "A" else 28
+        return _json_response(
+            {
+                "Status": 0,
+                "Question": [{"name": "example.com", "type": numeric_type}],
+                "Answer": [
+                    {
+                        "name": "example.com",
+                        "type": numeric_type,
+                        "TTL": 300,
+                        "data": data,
+                    }
+                ],
+            }
+        )
+
+    adapter = CloudflareDnsAdapter(
+        _entry("cloudflare-doh"),
+        (_target(),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 2
+    assert {request.url.params["type"] for request in requests} == {"A", "AAAA"}
+    assert all(request.url.host == "cloudflare-dns.com" for request in requests)
+    assert all(request.headers["accept"] == "application/dns-json" for request in requests)
+    assert len(batch.observations) == 2
+    assert len(batch.passive_exposure_projections) == 2
+    assert {
+        snapshot.asset.kind for snapshot in batch.passive_exposure_projections
+    } == {PassiveAssetKind.IPV4, PassiveAssetKind.IPV6}
+    for snapshot in batch.passive_exposure_projections:
+        assert snapshot.observation_kind is PassiveObservationKind.PASSIVE_DNS
+        assert snapshot.organization_link.status is OrganizationLinkStatus.REVIEW_REQUIRED
+        assert AttributionRisk.SHARED_HOSTING in snapshot.organization_link.attribution_risks
+        assert snapshot.active_probe_performed is False
+        assert snapshot.direct_validation_performed is False
+        assert snapshot.vulnerability_applicability_assessed is False
+        assert snapshot.exposure_verified is False
+        assert snapshot.can_support_exposure_conclusion is False
+
+
+def test_cloudflare_without_targets_performs_no_network() -> None:
+    adapter = CloudflareDnsAdapter(
+        _entry("cloudflare-doh"),
+        (),
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert batch.passive_exposure_projections == ()
+
+
+def test_cloudflare_discards_non_global_dns_answers() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        record_type = request.url.params["type"]
+        numeric_type = 1 if record_type == "A" else 28
+        data = "192.168.1.20" if record_type == "A" else "fe80::1"
+        return _json_response(
+            {
+                "Status": 0,
+                "Answer": [
+                    {
+                        "name": "example.com",
+                        "type": numeric_type,
+                        "TTL": 60,
+                        "data": data,
+                    }
+                ],
+            }
+        )
+
+    adapter = CloudflareDnsAdapter(
+        _entry("cloudflare-doh"),
+        (_target(),),
+        transport=httpx.MockTransport(handler),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.not_modified is True
+    assert batch.passive_exposure_projections == ()
+
+
+def test_certspotter_without_targets_skips_secret_and_network() -> None:
+    secret_calls = 0
+
+    def token_provider() -> str:
+        nonlocal secret_calls
+        secret_calls += 1
+        return "unused"
+
+    adapter = CertSpotterAdapter(
+        _entry("certspotter-ct"),
+        (),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.not_modified is True
+    assert secret_calls == 0
+
+
+def test_certspotter_fails_closed_without_connected_secret() -> None:
+    adapter = CertSpotterAdapter(
+        _entry("certspotter-ct"),
+        (_target(),),
+        token_provider=lambda: None,
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        _collect(adapter)
+
+    assert error.value.error_code == "provider_not_connected"
+    assert error.value.retryable is False
+
+
+def test_certspotter_maps_scoped_wildcard_certificate_without_exposure_claim() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _json_response(
+            [
+                {
+                    "id": "issuance-1",
+                    "tbs_sha256": "a" * 64,
+                    "dns_names": ["*.example.com", "other.example.net"],
+                    "not_before": "2026-08-01T00:00:00Z",
+                    "not_after": "2026-10-01T00:00:00Z",
+                },
+                {
+                    "id": "out-of-scope",
+                    "tbs_sha256": "b" * 64,
+                    "dns_names": ["unrelated.test.invalid"],
+                    "not_before": "2026-08-01T00:00:00Z",
+                    "not_after": "2026-10-01T00:00:00Z",
+                },
+            ]
+        )
+
+    adapter = CertSpotterAdapter(
+        _entry("certspotter-ct"),
+        (_target(),),
+        token_provider=lambda: "test-api-token",
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.host == "api.certspotter.com"
+    assert request.url.params["domain"] == "example.com"
+    assert request.url.params["include_subdomains"] == "true"
+    assert request.headers["Authorization"] == "Bearer test-api-token"
+    assert len(batch.observations) == 1
+    assert len(batch.passive_exposure_projections) == 1
+    snapshot = batch.passive_exposure_projections[0]
+    assert snapshot.source_record_key == "issuance-1"
+    assert snapshot.asset.kind is PassiveAssetKind.CERTIFICATE
+    assert snapshot.asset.value == "a" * 64
+    assert snapshot.observation_kind is PassiveObservationKind.CERTIFICATE
+    assert snapshot.state is PassiveObservationState.CURRENT
+    assert snapshot.organization_link.status is OrganizationLinkStatus.REVIEW_REQUIRED
+    assert snapshot.exposure_verified is False
+    assert snapshot.can_support_exposure_conclusion is False
+    assert "test-api-token" not in batch.observations[0].payload_hash_sha256
+
+
+def test_certspotter_marks_expired_issuance_inactive() -> None:
+    adapter = CertSpotterAdapter(
+        _entry("certspotter-ct"),
+        (_target(),),
+        token_provider=lambda: "test-api-token",
+        transport=httpx.MockTransport(
+            lambda _request: _json_response(
+                [
+                    {
+                        "id": "expired-1",
+                        "tbs_sha256": "c" * 64,
+                        "dns_names": ["example.com"],
+                        "not_before": "2025-01-01T00:00:00Z",
+                        "not_after": "2025-12-31T00:00:00Z",
+                    }
+                ]
+            )
+        ),
+    )
+
+    batch = _collect(adapter)
+    snapshot = batch.passive_exposure_projections[0]
+
+    assert snapshot.state is PassiveObservationState.EXPIRED
+    assert snapshot.active is False
+    assert snapshot.can_support_exposure_conclusion is False
+
+
+def _collect(adapter: CloudflareDnsAdapter | CertSpotterAdapter):
+    return adapter.collect(
+        collection_job_id=JOB_ID,
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _entry(source_id: str) -> SourceRegistryEntry:
+    entries = {entry.policy.id: entry for entry in load_source_registry(REGISTRY)}
+    return entries[source_id]
+
+
+def _target() -> PassiveInfrastructureTarget:
+    return PassiveInfrastructureTarget(
+        target_id="example-target",
+        organization_id=ORGANIZATION_ID,
+        domain="example.com",
+        enabled=True,
+    )
+
+
+def _json_response(payload: object) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "application/json"},
+        content=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _fail_network(_request: httpx.Request) -> httpx.Response:
+    raise AssertionError("network must not run")

--- a/tests/unit/collection_orchestration/test_passive_infrastructure_adapters.py
+++ b/tests/unit/collection_orchestration/test_passive_infrastructure_adapters.py
@@ -206,6 +206,12 @@ def test_certspotter_maps_scoped_wildcard_certificate_without_exposure_claim() -
     assert request.headers["Authorization"] == "Bearer test-api-token"
     assert len(batch.observations) == 1
     assert len(batch.passive_exposure_projections) == 1
+    assert batch.checkpoint_payload["after_by_target"] == {
+        "example-target": "out-of-scope"
+    }
+    raw = batch.observations[0]
+    assert raw.payload_reference is None
+    assert "test-api-token" not in raw.source_url
     snapshot = batch.passive_exposure_projections[0]
     assert snapshot.source_record_key == "issuance-1"
     assert snapshot.asset.kind is PassiveAssetKind.CERTIFICATE
@@ -215,7 +221,47 @@ def test_certspotter_maps_scoped_wildcard_certificate_without_exposure_claim() -
     assert snapshot.organization_link.status is OrganizationLinkStatus.REVIEW_REQUIRED
     assert snapshot.exposure_verified is False
     assert snapshot.can_support_exposure_conclusion is False
-    assert "test-api-token" not in batch.observations[0].payload_hash_sha256
+
+
+def test_certspotter_reuses_provider_after_cursor_on_next_collection() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 1:
+            return _json_response(
+                [
+                    {
+                        "id": "cursor-1",
+                        "tbs_sha256": "d" * 64,
+                        "dns_names": ["example.com"],
+                        "not_before": "2026-08-01T00:00:00Z",
+                        "not_after": "2026-10-01T00:00:00Z",
+                    }
+                ]
+            )
+        return _json_response([])
+
+    adapter = CertSpotterAdapter(
+        _entry("certspotter-ct"),
+        (_target(),),
+        token_provider=lambda: "test-api-token",
+        transport=httpx.MockTransport(handler),
+    )
+    first = _collect(adapter)
+    second = adapter.collect(
+        collection_job_id=JOB_ID,
+        checkpoint_payload=first.checkpoint_payload,
+        collected_at=NOW + timedelta(minutes=5),
+        retention_until=RETENTION,
+    )
+
+    assert "after" not in requests[0].url.params
+    assert requests[1].url.params["after"] == "cursor-1"
+    assert second.not_modified is True
+    assert second.checkpoint_payload["after_by_target"] == {
+        "example-target": "cursor-1"
+    }
 
 
 def test_certspotter_marks_expired_issuance_inactive() -> None:

--- a/tests/unit/collection_orchestration/test_passive_infrastructure_runtime.py
+++ b/tests/unit/collection_orchestration/test_passive_infrastructure_runtime.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.modules.collection_orchestration.application.runtime import build_collection_runtime
+from cip.shared.config.settings import Settings
+from cip.shared.persistence.metadata import get_metadata
+from cip.shared.persistence.session import create_database_engine
+
+
+def test_runtime_registers_passive_adapters_without_enabling_schedules(tmp_path: Path) -> None:
+    settings = Settings(
+        _env_file=None,
+        database_url=f"sqlite+pysqlite:///{tmp_path / 'passive-runtime.db'}",
+    )
+    get_metadata().create_all(create_database_engine(settings.database_url))
+
+    runtime = build_collection_runtime(settings)
+
+    assert ("cloudflare-doh", "cloudflare-dns-json") in runtime.adapters
+    assert ("certspotter-ct", "certspotter-issuances-api") in runtime.adapters
+    passive_schedules = {
+        (schedule.source_id, schedule.adapter_id): schedule
+        for schedule in runtime.schedules
+        if schedule.source_id in {"cloudflare-doh", "certspotter-ct"}
+    }
+    assert set(passive_schedules) == {
+        ("cloudflare-doh", "cloudflare-dns-json"),
+        ("certspotter-ct", "certspotter-issuances-api"),
+    }
+    assert all(not schedule.enabled for schedule in passive_schedules.values())

--- a/tests/unit/provider_onboarding/test_provider_registry.py
+++ b/tests/unit/provider_onboarding/test_provider_registry.py
@@ -13,7 +13,7 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     profiles = load_provider_profiles(Path("policies/provider_onboarding.yml"))
     by_source = {profile.source_id: profile for profile in profiles}
 
-    assert len(profiles) == 16
+    assert len(profiles) == 18
     assert by_source["cisa-kev"].initial_state is OnboardingState.CONNECTED
     assert by_source["sirene-api"].auth_mode is AuthMode.NONE
     assert by_source["inpi-rne"].required_secret_names == ("username", "password")
@@ -21,6 +21,11 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     assert by_source["brave-search-api"].required_secret_names == ("api_token",)
     assert by_source["brave-search-api"].initial_state is OnboardingState.NOT_CONFIGURED
     assert by_source["internet-archive-cdx"].initial_state is OnboardingState.CONNECTED
+    assert by_source["cloudflare-doh"].auth_mode is AuthMode.NONE
+    assert by_source["cloudflare-doh"].initial_state is OnboardingState.CONNECTED
+    assert by_source["certspotter-ct"].auth_mode is AuthMode.API_KEY
+    assert by_source["certspotter-ct"].required_secret_names == ("api_token",)
+    assert by_source["certspotter-ct"].initial_state is OnboardingState.NOT_CONFIGURED
     assert by_source["linkedin-official-api"].initial_state is OnboardingState.NOT_CONFIGURED
     assert by_source["linkedin-authorized-browser"].initial_state is OnboardingState.BLOCKED
     assert by_source["brixhub"].initial_state is OnboardingState.BLOCKED

--- a/tests/unit/source_activation/test_portfolio_reconciliation.py
+++ b/tests/unit/source_activation/test_portfolio_reconciliation.py
@@ -18,6 +18,7 @@ def test_every_checked_in_source_portfolio_entry_has_activation_record() -> None
         settings.incident_source_portfolio_path,
         settings.threat_telemetry_source_portfolio_path,
         settings.passive_exposure_source_portfolio_path,
+        settings.passive_infrastructure_source_portfolio_path,
         settings.advisory_source_portfolio_path,
         settings.corporate_change_source_portfolio_path,
         settings.relationship_source_portfolio_path,

--- a/tests/unit/test_passive_infrastructure_source_registries.py
+++ b/tests/unit/test_passive_infrastructure_source_registries.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.modules.collection_orchestration.infrastructure.schedule_loader import (
+    load_collection_schedules,
+)
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    SourceStatus,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_portfolio.domain.models import CatalogStatus
+from cip.modules.source_portfolio.infrastructure.registry import load_source_portfolio
+
+SOURCE_PATH = Path("policies/sources.passive_infrastructure.yml")
+PORTFOLIO_PATH = Path("policies/source_portfolio.passive_infrastructure.yml")
+SCHEDULE_PATH = Path("policies/collection_schedules.passive_infrastructure.yml")
+EXPECTED_IDS = {"cloudflare-doh", "certspotter-ct"}
+
+
+def test_passive_sources_are_governed_without_active_validation_authority() -> None:
+    entries = load_source_registry(SOURCE_PATH)
+
+    assert {entry.policy.id for entry in entries} == EXPECTED_IDS
+    assert all(entry.policy.status is SourceStatus.ENABLED for entry in entries)
+    assert all(entry.authorization.status is AuthorizationStatus.APPROVED for entry in entries)
+    assert all(entry.authorization.automated_collection_allowed for entry in entries)
+    assert all(entry.authorization.approved_hosts for entry in entries)
+    assert all(entry.authorization.approved_path_prefixes for entry in entries)
+    assert all(
+        entry.authorization.approved_purposes == {"passive-infrastructure-intelligence"}
+        for entry in entries
+    )
+    assert all(not entry.policy.raw_content_storage for entry in entries)
+    assert all(not entry.authorization.raw_storage_allowed for entry in entries)
+
+
+def test_passive_portfolio_is_executable_but_never_claims_exposure_or_opportunity() -> None:
+    entries = load_source_portfolio(PORTFOLIO_PATH)
+
+    assert {entry.source_id for entry in entries} == EXPECTED_IDS
+    assert all(entry.status is CatalogStatus.EXECUTABLE for entry in entries)
+    assert all(entry.executable for entry in entries)
+    assert all(entry.adapter is not None for entry in entries)
+    assert all(entry.metadata.get("active_probe") == "forbidden" for entry in entries)
+    assert all(
+        entry.metadata.get("direct_asset_connection") == "forbidden" for entry in entries
+    )
+    assert all(
+        entry.metadata.get("vulnerability_applicability") == "not_assessed"
+        for entry in entries
+    )
+    assert all(
+        entry.metadata.get("exposure_verification") == "forbidden" for entry in entries
+    )
+    assert all(entry.metadata.get("automatic_opportunity") == "forbidden" for entry in entries)
+
+
+def test_passive_schedules_are_checked_in_but_disabled_until_deployment_activation() -> None:
+    schedules = load_collection_schedules(SCHEDULE_PATH)
+
+    assert {(item.source_id, item.adapter_id) for item in schedules} == {
+        ("cloudflare-doh", "cloudflare-dns-json"),
+        ("certspotter-ct", "certspotter-issuances-api"),
+    }
+    assert all(schedule.enabled is False for schedule in schedules)


### PR DESCRIPTION
Closes #70

## SA-03 — governed passive infrastructure intelligence

### Clean sequencing
- Exact base: completed SA-02 squash `a2da9b9ad7f38d29a4b96be7224bfc083a6710b1` on `main`.
- Exact final head: `a3631100f1d191a10dd0a5090c8c073d70ecfcbd`.
- This PR contains only SA-03 passive-infrastructure activation work.

## Implemented
- shared `AdapterCollectionBatch.passive_exposure_projections` channel using the existing Lot 16 canonical `PassiveObservationSnapshot` model;
- transactional persistence through `persist_passive_snapshots()` in both incremental worker and historical backfill paths;
- explicit `passive_infrastructure_targets.yml` registry, empty by default, canonical-domain validated and bounded to 500 targets;
- Cloudflare DNS-over-HTTPS adapter limited to target-driven A/AAAA provider lookups;
- globally routable returned IPs only; private/reserved/non-global addresses are not projected;
- returned addresses are never contacted and remain `review_required` organization associations with shared-infrastructure risk;
- Cert Spotter CT Search API adapter with Provider Onboarding secret `api_token` required for production execution;
- Cert Spotter fails closed before network when no connected secret exists for an enabled target;
- scoped target/subdomain/wildcard SAN filtering;
- bounded one-page-per-execution CT collection, max 100 issuances, deterministic target rotation and per-target provider `after` cursors;
- exact Source Governance, Source Portfolio, Provider Onboarding, activation-truth and disabled deployment schedule bundles;
- provider authorization and implementation documentation;
- Source Coverage Matrix updated without fabricating `live_tested=true`;
- pre-existing `.example.invalid` licensed passive providers moved to SA-07 instead of being falsely activated.

## Provider decisions
- `cloudflare-doh`: executable target-driven capability, no secret, schedule disabled until a deployment supplies an authorized target;
- `certspotter-ct`: executable target-driven capability, schedule disabled, production request path additionally requires connected Provider Onboarding/API key;
- RIPEstat: remains non-executable pending explicit commercial-use approval for this product;
- urlscan: remains non-executable pending approved commercial integration scope; SA-03 performs no scan submission;
- licensed passive DNS/certificate/exposure/technography/cloud placeholders remain non-executable for SA-07.

## Security and evidence boundaries
- SourcePolicy is evaluated before provider HTTP;
- HTTPS exact host/path/purpose scope;
- bounded response size/provider page/target/cursor state;
- redirects disabled;
- retry only transport/timeouts, HTTP 429 and HTTP 5xx;
- unit tests use deterministic `httpx.MockTransport`; no live-network unit tests;
- `DNS lookup != organization ownership`;
- `DNS lookup != verified exposure`;
- `certificate issuance != deployed endpoint`;
- `certificate issuance != asset ownership`;
- `passive observation != vulnerability applicability`;
- `passive observation != compromise`;
- no direct signal, need, opportunity, contact-target or outreach path.

## Final exact-head validation — PASS
Exact final head `a3631100f1d191a10dd0a5090c8c073d70ecfcbd` passed CI #1474 / run `31340884747` completely:

- dependency consistency: PASS;
- pip-audit: PASS;
- Ruff: PASS;
- strict Mypy: PASS across the complete source tree;
- architecture/release contracts: **36 passed**;
- PostgreSQL reversible Alembic cycle: PASS;
- pytest: **1080 passed, 0 failed, 0 skipped**;
- aggregate branch-aware coverage: **90.06%** (`28683 / 31850` measured lines+branches); line coverage **93.20%**;
- frontend npm audit: PASS;
- frontend TypeScript typecheck: PASS;
- frontend Next.js production build: PASS.

There are no unresolved review threads or blocking reviews. No repository-content change is permitted after this validated head before squash merge. Merge must use `expected_head_sha=a3631100f1d191a10dd0a5090c8c073d70ecfcbd`.