### PR TITLE
SA-04: governed CTI, incidents and threat telemetry

### DIFF
--- a/docs/source_activation/SA_04_CTI_INCIDENT_TELEMETRY_IMPLEMENTATION.md
+++ b/docs/source_activation/SA_04_CTI_INCIDENT_TELEMETRY_IMPLEMENTATION.md
@@ -1,0 +1,106 @@
+# SA-04 — CTI, Incident and Threat Telemetry Implementation
+
+## Scope
+
+SA-04 activates two provider-specific public paths on top of the already validated Lot 14 and Lot 15 canonical models:
+
+```text
+SEC target -> submissions metadata -> RawObservation -> IncidentClaimSnapshot
+PhishTank feed -> verified online URL metadata -> RawObservation -> IndicatorSnapshot
+```
+
+Both canonical projection channels are persisted by the shared incremental worker and historical-backfill worker in the same transaction as collection progress.
+
+## SEC EDGAR path
+
+The checked-in `policies/sec_incident_targets.yml` is empty by default. Each future target requires:
+
+- an internal organization UUID;
+- an exact 10-digit SEC CIK;
+- explicit `enabled: true`;
+- a deployment `CIP_SEC_EDGAR_USER_AGENT` value before provider traffic.
+
+The adapter processes one enabled target per execution. It retrieves only `data.sec.gov/submissions/CIK##########.json`, validates that the response CIK equals the target CIK, and scans the bounded `filings.recent` arrays.
+
+Only non-amended Form 8-K variants whose `items` metadata contains Item 1.05 are projected. At most 100 new Item 1.05 records are emitted in one execution. Per-target accession checkpoints prevent already-seen recent metadata from being projected repeatedly.
+
+An Item 1.05 filing maps to a Lot 14 official company confirmation with an exact organization link backed by the deployment's explicit CIK-to-organization target. SA-04 intentionally does not infer:
+
+- occurrence date from `reportDate`;
+- incident subtype from filing metadata;
+- victim count or affected systems;
+- severity beyond the fact that the issuer filed Item 1.05;
+- commercial urgency or opportunity state.
+
+The filing narrative is not downloaded by this adapter.
+
+## PhishTank path
+
+The PhishTank adapter is global defensive telemetry, not organization intelligence.
+
+Production collection requires:
+
+- connected Provider Onboarding secret `api_token`;
+- deployment `CIP_PHISHTANK_USER_AGENT`;
+- the exact authorized `data.phishtank.com/data/` path.
+
+The provider key is used only to construct the outbound feed request. RawObservation uses a key-free provider URL and stores no raw feed body.
+
+One refresh may parse at most 100,000 provider records and projects at most the 1,000 highest PhishTank IDs. Only provider records already marked `verified=yes` and `online=yes` are accepted by the strict schema.
+
+Each accepted record maps to a Lot 15 URL indicator with:
+
+- state `malicious`;
+- source kind `phishing_feed`;
+- provider-aggregate sensor scope;
+- two-hour freshness expiry from collection time;
+- no binary payload;
+- no direct validation;
+- no organization ID or compromise relation.
+
+The provider `target` field is deliberately ignored in the canonical projection because an impersonated brand is not evidence that that organization is compromised or affected.
+
+SA-04 never visits the phishing URL or any infrastructure named by an indicator.
+
+## Shared persistence
+
+`AdapterCollectionBatch` adds:
+
+- `incident_claims`;
+- `threat_indicator_snapshots`.
+
+The incremental worker and backfill worker both call the existing validated persistence functions:
+
+- `persist_incident_claims()`;
+- `persist_indicator_snapshots()`.
+
+No new database migration is needed. SA-04 reuses the Lot 14/15 persistence schema.
+
+## Scheduling and deployment state
+
+SEC and PhishTank schedules are checked in but disabled. This is deliberate:
+
+- SEC has no checked-in target and no default User-Agent;
+- PhishTank has no checked-in application secret and no default User-Agent.
+
+Their activation records therefore prove adapter/governance executability but do not claim `scheduled` or `live_tested`.
+
+## Deferred source families
+
+Licensed incident reporting, ransomware metadata, STIX/TAXII, commercial phishing, malware metadata and other commercial CTI are assigned to SA-07.
+
+Generic provider-family placeholders such as `official-company-incident-disclosures`, `regulator-cert-incident-notices`, and generic advisory families are assigned to SA-10 provider decomposition/reconciliation rather than being falsely counted as provider integrations.
+
+## Safety invariants
+
+```text
+attacker claim != official confirmation
+SEC filing != complete incident narrative
+ingestion time != incident time
+global IOC != organization compromise
+phishing brand target != affected organization
+malicious URL != permission to visit it
+provider data != opportunity
+```
+
+No SA-04 unit test performs live network traffic. Complete delivery still requires all repository gates on one exact final PR head.

--- a/docs/source_activation/SA_04_PROVIDER_AUTHORIZATION.md
+++ b/docs/source_activation/SA_04_PROVIDER_AUTHORIZATION.md
@@ -1,0 +1,66 @@
+# SA-04 Provider Authorization — Incidents and Threat Telemetry
+
+## Decision boundary
+
+This document authorizes only the bounded provider requests described below. It does not authorize threat-actor interaction, `.onion` access, victim files, stolen datasets, credentials, phishing-page visits, malicious-infrastructure connections, scanning, exploitation, organization-compromise inference, commercial opportunity creation, or outreach.
+
+## SEC EDGAR cybersecurity disclosures
+
+- Source ID: `sec-cyber-disclosures`
+- Provider: U.S. Securities and Exchange Commission
+- Approved host: `data.sec.gov`
+- Approved path prefix: `/submissions/`
+- Approved method: `GET`
+- Approved purpose: `incident-intelligence`
+- Authentication: none
+- Required deployment configuration: descriptive SEC-compliant `User-Agent`
+- Targeting: CIKs explicitly enabled in `policies/sec_incident_targets.yml`
+- Raw filing content storage: forbidden
+
+SEC documents its public JSON submissions APIs under `data.sec.gov` and requires automated clients to identify themselves and respect its fair-access limits. SA-04 uses only the issuer submissions metadata endpoint and does not enumerate the global issuer corpus.
+
+SA-04 treats a non-amended Form 8-K family filing containing Item 1.05 as an official company cybersecurity-incident disclosure. The adapter does not download or parse the filing narrative, does not infer the incident occurrence date from `reportDate`, and keeps incident type `unknown` unless another separately authorized official source provides that detail.
+
+## PhishTank verified online phishing data
+
+- Source ID: `phishtank-verified-online`
+- Provider: PhishTank / OpenDNS
+- Approved host: `data.phishtank.com`
+- Approved path prefix: `/data/`
+- Approved method: `GET`
+- Approved purpose: `threat-telemetry`
+- Production authentication: application key through Provider Onboarding secret reference `api_token`
+- Required deployment configuration: descriptive `User-Agent`
+- Raw feed storage: forbidden
+
+PhishTank's published data terms permit use of its data for commercial and non-commercial purposes subject to those terms. Its developer guidance provides database files for automated high-volume consumption and recommends an application key for automated downloads.
+
+SA-04 consumes only verified-online phishing URL metadata. It never connects to the phishing URL. The provider `target`/brand field is not projected as an organization relationship, victim claim, exposure claim, or compromise claim.
+
+The application key may appear only in the outbound provider request path required by the provider. It is resolved transiently from Provider Onboarding and is excluded from RawObservation source URLs, payloads, logs and canonical telemetry.
+
+## Deferred providers
+
+### ThreatFox and URLhaus Community APIs
+
+The community APIs are not activated for this commercial product. Current abuse.ch guidance distinguishes community access from commercial/enhanced access. Any future integration requires a reviewed commercial entitlement and source-specific authorization, handled in SA-07.
+
+### Ransomware.live
+
+A provider API exists, but the project has not established a sufficiently explicit commercial-use/licence decision for this deployment. It remains non-executable pending provider review. No threat-actor portal, victim file, stolen data, screenshot, negotiation message or credential may be collected.
+
+### Existing licensed placeholders
+
+`licensed-incident-reporting`, `licensed-ransomware-metadata`, `licensed-stix-taxii`, `licensed-phishing-metadata`, `licensed-malware-metadata`, and the other licensed passive providers remain non-executable and are assigned to SA-07 unless a concrete contract is selected.
+
+## Mandatory semantics
+
+```text
+SEC filing != complete incident narrative
+official disclosure != automatic commercial urgency
+phishing URL != organization compromise
+impersonated brand != affected organization
+global IOC != prospect exposure
+ransomware claim != official confirmation
+source candidate != execution authorization
+```

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -40,26 +40,36 @@ Symbols:
 | Internet Archive CDX | SA-02 | Y | Y | Y | Y | Y | - | bounded weekly historical metadata discovery; live proof outstanding |
 | Cloudflare DNS-over-HTTPS | SA-03 | Y | Y | Y | Y | N/A | - | target-driven A/AAAA passive lookup; checked-in target registry empty; live proof outstanding |
 | Cert Spotter CT Search API | SA-03 | Y | Y | Y | Y | N/A | - | target-driven CT lookup; production API key/onboarding and deployment target required; live proof outstanding |
+| SEC EDGAR cybersecurity disclosures | SA-04 | Y | Y | Y | Y | N/A | - | targeted Item 1.05 metadata capability; CIK target registry empty and deployment User-Agent required |
+| PhishTank verified online phishing data | SA-04 | Y | Y | Y | Y | N/A | - | global URL telemetry capability; application key/onboarding and deployment User-Agent required |
+| Licensed incident reporting | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Licensed ransomware metadata | SA-07 | Y | - | - | - | - | - | provider licence/commercial-use path not selected; actor/victim content remains prohibited |
+| Licensed STIX/TAXII | SA-07 | Y | - | - | - | - | - | concrete licensed CTI provider/tenant/marking scope not selected |
+| Licensed phishing metadata | SA-07 | Y | - | - | - | - | - | PhishTank covers current public path; commercial augmentation deferred |
+| Licensed malware metadata | SA-07 | Y | - | - | - | - | - | concrete licensed provider not selected; malware binaries remain prohibited |
 | Licensed passive DNS | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
 | Licensed certificate telemetry | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
 | Licensed passive exposure | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
 | Licensed technography | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
 | Licensed cloud-asset observations | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Generic company incident source family | SA-10 | Y | - | - | - | - | - | provider-specific decomposition required after SEC path |
+| Generic regulator/CERT incident family | SA-10 | Y | - | - | - | - | - | concrete official endpoints and authorizations required |
+| Generic vendor/Linux/package advisory families | SA-10 | Y | - | - | - | - | - | provider/ecosystem-specific decomposition required |
 | Sherlock | SA-05 | - | - | - | - | N/A | - | explicit local OSINT capability planned |
 | LinkedIn official API | SA-07 | - | - | - | - | N/A | - | BLOCKED pending approved official/licensed access and adapter |
 | BrixHub | SA-08 | - | - | - | - | N/A | - | BLOCKED pending access/licence/data review |
 
 ## Known broader source families
 
-The repository already models additional candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. Most remain candidate/non-executable and are assigned to later source-activation waves.
+The repository already models additional candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. Candidate families remain non-executable until a concrete provider, method and authorization are selected.
 
-SA-00 established the lifecycle and truth model. SA-01 through SA-03 promote only providers whose implementation, authorization and runtime boundaries are explicit. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
+SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
 
 ## Reconciliation invariant
 
 Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA.
 
-OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10.
+OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10 closes.
 
 ## SA-03 completion boundary
 
@@ -75,4 +85,22 @@ SA-03 is complete only when:
 - no adapter assesses vulnerability applicability, verifies exposure, infers compromise, creates a need/opportunity, or performs outreach;
 - the licensed passive providers remain planned for SA-07 instead of being falsely activated under `.example.invalid` placeholders;
 - deterministic adapter/runtime/registry tests and the complete repository CI pass on one exact final SHA;
+- `live_tested` remains false until separately authorized controlled provider validation is evidenced.
+
+## SA-04 completion boundary
+
+SA-04 is complete only when:
+
+- SEC EDGAR and PhishTank are registered in the same shared collection runtime and emit immutable RawObservations plus the existing Lot 14/15 canonical projections;
+- incremental collection and historical backfill persist `IncidentClaimSnapshot` and `IndicatorSnapshot` projections transactionally with collection progress;
+- the SEC target registry is empty by default, accepts only exact 10-digit CIK bindings to canonical organization UUIDs, and performs no global issuer enumeration;
+- SEC provider traffic fails closed without a descriptive deployment User-Agent and only targeted submissions metadata is retrieved;
+- only non-amended Form 8-K family Item 1.05 metadata becomes an official company confirmation, without inventing occurrence dates, incident type, severity, victim counts or commercial urgency;
+- PhishTank provider traffic fails closed without Provider Onboarding application-key state and a descriptive deployment User-Agent;
+- PhishTank projects only verified-online URL telemetry, never visits the URL, never stores the key in RawObservation, and never converts the provider `target`/brand field into organization-compromise evidence;
+- both checked-in SA-04 schedules remain disabled until deployment-specific prerequisites exist;
+- community/commercial CTI ambiguity is fail-closed: ThreatFox/URLhaus Community and Ransomware.live are not treated as executable commercial sources;
+- licensed incident/ransomware/STIX/phishing/malware sources remain assigned to SA-07, while generic provider-family placeholders remain assigned to SA-10 decomposition;
+- no adapter creates commercial signals, needs, opportunities, contact targets or outreach;
+- deterministic adapter/runtime/registry/persistence tests and the complete repository CI pass on one exact final SHA;
 - `live_tested` remains false until separately authorized controlled provider validation is evidenced.

--- a/policies/collection_schedules.incidents.yml
+++ b/policies/collection_schedules.incidents.yml
@@ -1,0 +1,14 @@
+version: 1
+
+schedules:
+  - source_id: sec-cyber-disclosures
+    adapter_id: sec-submissions-item-1-05
+    enabled: false
+    interval_seconds: 3600
+    lease_seconds: 180
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 300
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600

--- a/policies/collection_schedules.threat_telemetry.yml
+++ b/policies/collection_schedules.threat_telemetry.yml
@@ -1,0 +1,14 @@
+version: 1
+
+schedules:
+  - source_id: phishtank-verified-online
+    adapter_id: phishtank-online-valid-json
+    enabled: false
+    interval_seconds: 3600
+    lease_seconds: 300
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 300
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600

--- a/policies/provider_onboarding.yml
+++ b/policies/provider_onboarding.yml
@@ -192,6 +192,36 @@ providers:
     automatic_onboarding: false
     blocked_reason: null
 
+  - source_id: sec-cyber-disclosures
+    display_name: SEC EDGAR Cybersecurity Disclosures
+    auth_mode: none
+    documentation_url: https://www.sec.gov/search-filings/edgar-application-programming-interfaces
+    signup_url: null
+    console_url: null
+    required_secret_names: []
+    human_actions:
+      - enable_source_policy
+    automatic_onboarding: true
+    blocked_reason: null
+
+  - source_id: phishtank-verified-online
+    display_name: PhishTank Verified Online Database
+    auth_mode: api_key
+    documentation_url: https://www.phishtank.com/developer_info.php
+    signup_url: https://www.phishtank.com/register.php
+    console_url: https://www.phishtank.com/user.php
+    required_secret_names:
+      - api_token
+    human_actions:
+      - open_official_signup
+      - sign_in
+      - accept_provider_terms
+      - retrieve_technical_credentials
+      - register_secret_reference
+      - enable_source_policy
+    automatic_onboarding: false
+    blocked_reason: null
+
   - source_id: linkedin-official-api
     display_name: LinkedIn Official API
     auth_mode: manual

--- a/policies/sec_incident_targets.yml
+++ b/policies/sec_incident_targets.yml
@@ -1,0 +1,2 @@
+version: 1
+targets: []

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -147,50 +147,65 @@ sources:
   - source_id: sec-cyber-disclosures
     display_name: SEC Cybersecurity Disclosures
     category: live_incidents
-    disposition: planned
+    disposition: active
     activation_wave: SA-04
-    stages: [catalogued, reviewed, mapped]
+    requires_schedule: false
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
+
+  - source_id: phishtank-verified-online
+    display_name: PhishTank Verified Online Phishing Database
+    category: threat_telemetry
+    disposition: active
+    activation_wave: SA-04
+    requires_schedule: false
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
   - source_id: official-company-incident-disclosures
     display_name: Public Company Incident Disclosures
     category: live_incidents
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-10
+    reason: Generic source-family placeholder requires provider-specific decomposition after SEC activation.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: regulator-cert-incident-notices
     display_name: Regulator and CERT Incident Notices
     category: live_incidents
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-10
+    reason: Generic regulator/CERT family requires concrete provider endpoints and source-specific authorization.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-incident-reporting
     display_name: Licensed Incident Reporting
     category: live_incidents
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-07
+    reason: Concrete licensed provider, contract, fields, credentials and retention must be selected.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-ransomware-metadata
     display_name: Licensed Ransomware Claim Metadata
     category: live_incidents
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-07
+    reason: Licensed provider review is required; threat-actor portals and victim content remain prohibited.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-stix-taxii
     display_name: Licensed STIX/TAXII Threat Telemetry
     category: threat_telemetry
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-07
+    reason: A concrete licensed CTI provider and collection markings/tenant scope are required.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-phishing-metadata
     display_name: Licensed Phishing Metadata
     category: threat_telemetry
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-07
+    reason: PhishTank covers the current public path; additional licensed metadata requires a concrete contract.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-passive-dns
@@ -211,7 +226,8 @@ sources:
     display_name: Licensed Malware Metadata
     category: threat_telemetry
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-07
+    reason: Concrete licensed provider required; malware binaries and download paths remain prohibited.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-passive-exposure
@@ -255,21 +271,24 @@ sources:
     display_name: Official Vendor PSIRT Advisories
     category: vulnerability_advisory
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-10
+    reason: Generic family must be decomposed into concrete vendor feeds before adapter authorization.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-linux-security-advisories
     display_name: Official Linux Security Advisories
     category: vulnerability_advisory
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-10
+    reason: Generic Linux advisory family requires provider-specific decomposition and value review.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-package-security-advisories
     display_name: Official Package Security Advisories
     category: vulnerability_advisory
     disposition: planned
-    activation_wave: SA-04
+    activation_wave: SA-10
+    reason: Generic package advisory family requires ecosystem-specific provider selection.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-corporate-disclosures

--- a/policies/source_portfolio.incidents.yml
+++ b/policies/source_portfolio.incidents.yml
@@ -5,7 +5,7 @@ sources:
     display_name: SEC Cybersecurity Disclosures
     canonical_url: https://data.sec.gov/submissions/
     category: live_incidents
-    status: candidate
+    status: executable
     freshness_max_age_seconds: 3600
     commercial_use_cases: &incident_use_cases
       - incident_response_context
@@ -13,27 +13,31 @@ sources:
       - regulatory_notification_context
     candidate_origin: lot-14
     monthly_cost_limit: 0
-    metadata: &disabled_metadata
-      executable: false
-      authorization_status: missing
+    metadata:
+      executable: true
+      authorization_status: approved
+      target_registry_required: true
+      descriptive_user_agent_required: true
+      filing_narrative_collection: forbidden
+      global_issuer_enumeration: forbidden
       victim_content_collection: forbidden
       threat_actor_interaction: forbidden
+      automatic_opportunity: forbidden
       autonomous_outreach: forbidden
     adapter:
-      adapter_id: sec-cyber-disclosures
+      adapter_id: sec-submissions-item-1-05
       adapter_version: "1"
-      provider_schema_version: public-filing-metadata-v1
-      modes: &modes
-        - historical_backfill
+      provider_schema_version: sec-submissions-recent-v1
+      modes:
         - incremental_cursor
-      canonical_output_types: &outputs
-        - incident
+        - priority_refresh
+      canonical_output_types:
+        - raw_observation
         - incident_claim_snapshot
-      supports_corrections: true
+      supports_corrections: false
       supports_tombstones: false
-      supports_retractions: true
-      max_page_size: 100
-      max_window_days: 30
+      supports_retractions: false
+      max_page_size: 2000
       cost_per_request: 0
 
   - source_id: official-company-incident-disclosures
@@ -45,13 +49,22 @@ sources:
     commercial_use_cases: *incident_use_cases
     candidate_origin: lot-14
     monthly_cost_limit: 0
-    metadata: *disabled_metadata
+    metadata: &disabled_metadata
+      executable: false
+      authorization_status: missing
+      victim_content_collection: forbidden
+      threat_actor_interaction: forbidden
+      autonomous_outreach: forbidden
     adapter:
       adapter_id: official-company-disclosures
       adapter_version: "1"
       provider_schema_version: official-incident-disclosure-v1
-      modes: *modes
-      canonical_output_types: *outputs
+      modes: &modes
+        - historical_backfill
+        - incremental_cursor
+      canonical_output_types: &outputs
+        - incident
+        - incident_claim_snapshot
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: true

--- a/policies/source_portfolio.threat_telemetry.yml
+++ b/policies/source_portfolio.threat_telemetry.yml
@@ -1,16 +1,52 @@
 version: 1
 
 sources:
+  - source_id: phishtank-verified-online
+    display_name: PhishTank Verified Online Phishing Database
+    canonical_url: https://data.phishtank.com/data/
+    category: threat_telemetry
+    status: executable
+    freshness_max_age_seconds: 7200
+    commercial_use_cases: &use_cases
+      - threat_context
+      - incident_response_context
+      - vulnerability_prioritization_context
+    candidate_origin: SA-04
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      provider_onboarding_required: true
+      descriptive_user_agent_required: true
+      phishing_url_visit: forbidden
+      direct_indicator_connection: forbidden
+      binary_collection: forbidden
+      target_brand_as_compromise: forbidden
+      organization_compromise_inference: forbidden
+      automatic_opportunity: forbidden
+      autonomous_outreach: forbidden
+    adapter:
+      adapter_id: phishtank-online-valid-json
+      adapter_version: "1"
+      provider_schema_version: phishtank-online-valid-json-v1
+      modes:
+        - priority_refresh
+      canonical_output_types:
+        - raw_observation
+        - threat_indicator_snapshot
+      supports_corrections: false
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 1000
+      cost_per_request: 0
+
   - source_id: licensed-stix-taxii
     display_name: Licensed STIX/TAXII Threat Telemetry
     canonical_url: https://example.invalid/stix-taxii/
     category: threat_telemetry
     status: candidate
     freshness_max_age_seconds: 1800
-    commercial_use_cases: &use_cases
-      - threat_context
-      - incident_response_context
-      - vulnerability_prioritization_context
+    commercial_use_cases: *use_cases
     candidate_origin: lot-15
     monthly_cost_limit: 0
     metadata: &disabled_metadata

--- a/policies/sources.incidents.yml
+++ b/policies/sources.incidents.yml
@@ -1,15 +1,15 @@
 version: 1
-reviewed_at: 2026-08-06
+reviewed_at: 2026-08-09
 
 sources:
   - id: sec-cyber-disclosures
     name: SEC public cybersecurity incident disclosures
     base_url: https://data.sec.gov/submissions/
-    status: draft
+    status: enabled
     source_type: api
     owner: U.S. Securities and Exchange Commission
     terms_url: https://www.sec.gov/about/privacy-information
-    licence: SEC public data policy
+    licence: SEC public data and fair-access policy
     allowed_data_categories: &allowed [public_incident_metadata]
     prohibited_data_categories: &prohibited
       - credential
@@ -21,26 +21,27 @@ sources:
     retention_days: 3650
     attribution_required: true
     raw_content_storage: false
-    human_review_required: true
-    authorization: &missing_authorization
-      status: missing
-      document_reference: null
-      reviewed_at: null
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_04_PROVIDER_AUTHORIZATION.md#sec-edgar-cybersecurity-disclosures
+      reviewed_at: "2026-08-09T23:20:00+00:00"
       expires_at: null
-      approved_hosts: []
-      approved_path_prefixes: []
-      approved_purposes: []
-      automated_collection_allowed: false
+      approved_hosts: [data.sec.gov]
+      approved_path_prefixes: [/submissions/]
+      approved_purposes: [incident-intelligence]
+      automated_collection_allowed: true
       raw_storage_allowed: false
     economics: &public_economics
       commercial_value: high
       monthly_cost: 0
       implementation_cost: medium
       maintenance_cost: medium
-      expected_stability: medium
+      expected_stability: high
     notes: >-
-      Public filing mapping is planned, but no issuer scope, accession cursor,
-      user-agent policy, quota, or schedule is authorized by this catalog entry.
+      Targeted submissions metadata only for explicitly enabled CIKs. Runtime requires
+      a descriptive deployment User-Agent. SA-04 filters non-amended Item 1.05 forms
+      and does not download filing narratives or enumerate the global issuer corpus.
 
   - id: official-company-incident-disclosures
     name: Authorized public company incident disclosures
@@ -57,7 +58,16 @@ sources:
     attribution_required: true
     raw_content_storage: false
     human_review_required: true
-    authorization: *missing_authorization
+    authorization: &missing_authorization
+      status: missing
+      document_reference: null
+      reviewed_at: null
+      expires_at: null
+      approved_hosts: []
+      approved_path_prefixes: []
+      approved_purposes: []
+      automated_collection_allowed: false
+      raw_storage_allowed: false
     economics: *public_economics
     notes: >-
       Schema-only placeholder. A real company or filing source requires an exact

--- a/policies/sources.threat_telemetry.yml
+++ b/policies/sources.threat_telemetry.yml
@@ -1,7 +1,49 @@
 version: 1
-reviewed_at: 2026-08-06
+reviewed_at: 2026-08-09
 
 sources:
+  - id: phishtank-verified-online
+    name: PhishTank verified online phishing database
+    base_url: https://data.phishtank.com/data/
+    status: enabled
+    source_type: bulk_file
+    owner: PhishTank / OpenDNS
+    terms_url: https://www.phishtank.org/terms.php
+    licence: PhishTank data terms permit commercial and non-commercial use
+    allowed_data_categories: &allowed [technology_observation]
+    prohibited_data_categories: &prohibited
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 1
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_04_PROVIDER_AUTHORIZATION.md#phishtank-verified-online-phishing-data
+      reviewed_at: "2026-08-09T23:20:00+00:00"
+      expires_at: null
+      approved_hosts: [data.phishtank.com]
+      approved_path_prefixes: [/data/]
+      approved_purposes: [threat-telemetry]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: low
+      maintenance_cost: medium
+      expected_stability: medium
+    notes: >-
+      Automated production retrieval requires a Provider Onboarding application key and a
+      descriptive deployment User-Agent. Only verified-online URL metadata is projected;
+      the phishing URL is never visited and the provider target/brand field never becomes
+      organization-compromise evidence.
+
   - id: licensed-stix-taxii
     name: Licensed STIX and TAXII threat telemetry
     base_url: https://example.invalid/stix-taxii/
@@ -10,13 +52,8 @@ sources:
     owner: Deployment-specific licensed CTI provider
     terms_url: https://example.invalid/terms
     licence: Contract required
-    allowed_data_categories: &allowed [technology_observation]
-    prohibited_data_categories: &prohibited
-      - credential
-      - victim_file
-      - private_communication
-      - private_personal_data
-      - restricted_content
+    allowed_data_categories: *allowed
+    prohibited_data_categories: *prohibited
     rate_limit_per_minute: 10
     retention_days: 1825
     attribution_required: true

--- a/src/cip/adapters/sources/incident_catalogs/sec_registry.py
+++ b/src/cip/adapters/sources/incident_catalogs/sec_registry.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from uuid import UUID
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_CIK = re.compile(r"^[0-9]{10}$")
+
+
+class SecIncidentTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str = Field(min_length=1, max_length=200)
+    organization_id: UUID
+    cik: str
+    enabled: bool = False
+
+    @field_validator("cik")
+    @classmethod
+    def validate_cik(cls, value: str) -> str:
+        normalized = value.strip()
+        if not _CIK.fullmatch(normalized):
+            raise ValueError("SEC CIK must contain exactly 10 digits")
+        return normalized
+
+
+class SecIncidentTargetFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    targets: list[SecIncidentTarget] = Field(default_factory=list, max_length=500)
+
+
+def load_sec_incident_targets(path: Path) -> tuple[SecIncidentTarget, ...]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    parsed = SecIncidentTargetFile.model_validate(document)
+    targets = tuple(parsed.targets)
+    ids = [target.target_id for target in targets]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate SEC incident target_id")
+    ciks = [target.cik for target in targets]
+    if len(ciks) != len(set(ciks)):
+        raise ValueError("duplicate SEC CIK target")
+    return targets

--- a/src/cip/adapters/sources/incident_catalogs/sec_schemas.py
+++ b/src/cip/adapters/sources/incident_catalogs/sec_schemas.py
@@ -12,7 +12,7 @@ class SecRecentFilings(BaseModel):
 
     accessionNumber: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
     filingDate: list[date] = Field(max_length=_MAX_RECENT_FILINGS)
-    reportDate: list[date] = Field(max_length=_MAX_RECENT_FILINGS)
+    reportDate: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
     acceptanceDateTime: list[datetime] = Field(max_length=_MAX_RECENT_FILINGS)
     form: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
     items: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
@@ -53,5 +53,4 @@ class SecCyberFilingRecord(BaseModel):
     form: str = Field(min_length=1, max_length=40)
     item: str = Field(min_length=1, max_length=100)
     filing_date: date
-    report_date: date
     accepted_at: datetime

--- a/src/cip/adapters/sources/incident_catalogs/sec_schemas.py
+++ b/src/cip/adapters/sources/incident_catalogs/sec_schemas.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_MAX_RECENT_FILINGS = 2_000
+
+
+class SecRecentFilings(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    accessionNumber: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
+    filingDate: list[date] = Field(max_length=_MAX_RECENT_FILINGS)
+    reportDate: list[date] = Field(max_length=_MAX_RECENT_FILINGS)
+    acceptanceDateTime: list[datetime] = Field(max_length=_MAX_RECENT_FILINGS)
+    form: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
+    items: list[str] = Field(max_length=_MAX_RECENT_FILINGS)
+
+    @model_validator(mode="after")
+    def validate_parallel_arrays(self) -> SecRecentFilings:
+        lengths = {
+            len(self.accessionNumber),
+            len(self.filingDate),
+            len(self.reportDate),
+            len(self.acceptanceDateTime),
+            len(self.form),
+            len(self.items),
+        }
+        if len(lengths) != 1:
+            raise ValueError("SEC recent filing arrays must have identical lengths")
+        return self
+
+
+class SecFilings(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    recent: SecRecentFilings
+
+
+class SecSubmissionResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    cik: str | int
+    name: str = Field(min_length=1, max_length=500)
+    filings: SecFilings
+
+
+class SecCyberFilingRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    accession_number: str = Field(pattern=r"^[0-9]{10}-[0-9]{2}-[0-9]{6}$")
+    form: str = Field(min_length=1, max_length=40)
+    item: str = Field(min_length=1, max_length=100)
+    filing_date: date
+    report_date: date
+    accepted_at: datetime

--- a/src/cip/adapters/sources/threat_catalogs/phishtank_schemas.py
+++ b/src/cip/adapters/sources/threat_catalogs/phishtank_schemas.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PhishTankFeedRecord(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    phish_id: int = Field(gt=0)
+    phish_detail_url: str = Field(pattern=r"^https?://", max_length=2_048)
+    url: str = Field(min_length=1, max_length=2_048)
+    submission_time: datetime
+    verified: Literal["yes"]
+    verification_time: datetime
+    online: Literal["yes"]
+    target: str | None = Field(default=None, max_length=500)

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
+from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
 from cip.adapters.sources.lever.registry import LeverSite
 from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
 from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
@@ -16,6 +17,9 @@ from cip.modules.collection_orchestration.application.decp_adapter import DecpAd
 from cip.modules.collection_orchestration.application.greenhouse_adapter import GreenhouseAdapter
 from cip.modules.collection_orchestration.application.identity_adapters import (
     register_identity_adapters,
+)
+from cip.modules.collection_orchestration.application.intelligence_registration import (
+    register_intelligence_adapters,
 )
 from cip.modules.collection_orchestration.application.lever_adapter import LeverAdapter
 from cip.modules.collection_orchestration.application.passive_infrastructure_registration import (
@@ -51,6 +55,7 @@ class AdapterCompositionInputs:
     search_templates: tuple[SearchQueryTemplate, ...]
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
+    sec_incident_targets: tuple[SecIncidentTarget, ...]
 
 
 def build_runtime_adapters(
@@ -58,6 +63,9 @@ def build_runtime_adapters(
     *,
     brave_token_provider: Callable[[], str | None],
     certspotter_token_provider: Callable[[], str | None],
+    phishtank_token_provider: Callable[[], str | None],
+    sec_user_agent: str | None,
+    phishtank_user_agent: str | None,
     timeout_seconds: float,
 ) -> dict[tuple[str, str], CollectionAdapter]:
     entries_by_id = {entry.policy.id: entry for entry in inputs.entries}
@@ -95,6 +103,15 @@ def build_runtime_adapters(
         entries_by_id,
         inputs.passive_infrastructure_targets,
         certspotter_token_provider=certspotter_token_provider,
+        timeout_seconds=timeout_seconds,
+    )
+    register_intelligence_adapters(
+        adapters,
+        entries_by_id,
+        inputs.sec_incident_targets,
+        phishtank_token_provider=phishtank_token_provider,
+        sec_user_agent=sec_user_agent,
+        phishtank_user_agent=phishtank_user_agent,
         timeout_seconds=timeout_seconds,
     )
     return adapters

--- a/src/cip/modules/collection_orchestration/application/intelligence_adapter_support.py
+++ b/src/cip/modules/collection_orchestration/application/intelligence_adapter_support.py
@@ -83,7 +83,7 @@ def get_json(
         ) from exc
     except (httpx.TimeoutException, httpx.TransportError) as exc:
         raise AdapterExecutionError(
-            str(exc) or type(exc).__name__,
+            "intelligence provider transport failure",
             error_code="source_transport_error",
             retryable=True,
         ) from exc

--- a/src/cip/modules/collection_orchestration/application/intelligence_adapter_support.py
+++ b/src/cip/modules/collection_orchestration/application/intelligence_adapter_support.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel
+
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+MAX_JSON_BYTES = 8 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class IntelligenceObservationContext:
+    source_id: str
+    adapter_id: str
+    adapter_version: str
+    collection_job_id: UUID
+    data_category: DataCategory
+    collected_at: datetime
+    retention_until: datetime
+
+
+def authorize_intelligence_request(
+    entry: SourceRegistryEntry,
+    *,
+    category: DataCategory,
+    purpose: str,
+    target_url: str,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=category,
+            target_url=target_url,
+            purpose=purpose,
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def get_json(
+    client: httpx.Client,
+    target_url: str,
+    *,
+    headers: Mapping[str, str],
+) -> bytes:
+    try:
+        response = client.get(target_url, headers=headers)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        raise AdapterExecutionError(
+            f"intelligence provider returned HTTP {status}",
+            error_code=f"http_{status}",
+            retryable=status == 429 or status >= 500,
+        ) from exc
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        raise AdapterExecutionError(
+            str(exc) or type(exc).__name__,
+            error_code="source_transport_error",
+            retryable=True,
+        ) from exc
+    if "json" not in response.headers.get("content-type", "").casefold():
+        raise AdapterExecutionError(
+            "intelligence provider response is not JSON",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    if len(response.content) > MAX_JSON_BYTES:
+        raise AdapterExecutionError(
+            "intelligence provider response exceeds size limit",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    return response.content
+
+
+def raw_intelligence_observation(
+    model: BaseModel,
+    *,
+    context: IntelligenceObservationContext,
+    source_url: str,
+    source_record_key: str,
+    source_record_type: str,
+    observed_at: datetime | None = None,
+    published_at: datetime | None = None,
+    source_updated_at: datetime | None = None,
+) -> RawObservation:
+    encoded = model.model_dump_json(by_alias=True, exclude_none=True).encode("utf-8")
+    return RawObservation(
+        source_id=context.source_id,
+        adapter_id=context.adapter_id,
+        adapter_version=context.adapter_version,
+        collection_job_id=context.collection_job_id,
+        source_record_type=source_record_type,
+        source_url=source_url,
+        payload_hash_sha256=sha256(encoded).hexdigest(),
+        data_categories=frozenset({context.data_category}),
+        source_record_key=source_record_key,
+        collected_at=context.collected_at,
+        observed_at=observed_at,
+        published_at=published_at,
+        source_updated_at=source_updated_at,
+        retention_until=context.retention_until,
+        schema_fingerprint=f"{source_record_type}:v1",
+    )

--- a/src/cip/modules/collection_orchestration/application/intelligence_adapter_support.py
+++ b/src/cip/modules/collection_orchestration/application/intelligence_adapter_support.py
@@ -18,7 +18,8 @@ from cip.modules.source_governance.domain.models import (
 )
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
-MAX_JSON_BYTES = 8 * 1024 * 1024
+DEFAULT_MAX_JSON_BYTES = 8 * 1024 * 1024
+HARD_MAX_JSON_BYTES = 64 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,7 +67,10 @@ def get_json(
     target_url: str,
     *,
     headers: Mapping[str, str],
+    max_bytes: int = DEFAULT_MAX_JSON_BYTES,
 ) -> bytes:
+    if not 1 <= max_bytes <= HARD_MAX_JSON_BYTES:
+        raise ValueError("max_bytes is outside the intelligence response bound")
     try:
         response = client.get(target_url, headers=headers)
         response.raise_for_status()
@@ -89,7 +93,7 @@ def get_json(
             error_code="unsafe_source_response",
             retryable=False,
         )
-    if len(response.content) > MAX_JSON_BYTES:
+    if len(response.content) > max_bytes:
         raise AdapterExecutionError(
             "intelligence provider response exceeds size limit",
             error_code="unsafe_source_response",

--- a/src/cip/modules/collection_orchestration/application/intelligence_registration.py
+++ b/src/cip/modules/collection_orchestration/application/intelligence_registration.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
+from cip.modules.collection_orchestration.application.phishtank_adapter import PhishTankAdapter
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.collection_orchestration.application.sec_incident_adapter import (
+    SecCyberDisclosureAdapter,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+def register_intelligence_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    sec_targets: tuple[SecIncidentTarget, ...],
+    *,
+    phishtank_token_provider: Callable[[], str | None],
+    sec_user_agent: str | None,
+    phishtank_user_agent: str | None,
+    timeout_seconds: float,
+) -> None:
+    sec_entry = entries_by_id.get(SecCyberDisclosureAdapter.source_id)
+    if sec_entry is not None:
+        _register(
+            adapters,
+            SecCyberDisclosureAdapter(
+                sec_entry,
+                sec_targets,
+                user_agent=sec_user_agent,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    phishtank_entry = entries_by_id.get(PhishTankAdapter.source_id)
+    if phishtank_entry is not None:
+        _register(
+            adapters,
+            PhishTankAdapter(
+                phishtank_entry,
+                token_provider=phishtank_token_provider,
+                user_agent=phishtank_user_agent,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    adapters[(adapter.source_id, adapter.adapter_id)] = adapter

--- a/src/cip/modules/collection_orchestration/application/phishtank_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/phishtank_adapter.py
@@ -41,7 +41,7 @@ class PhishTankAdapter:
     source_id = "phishtank-verified-online"
     adapter_id = "phishtank-online-valid-json"
     adapter_version = "1"
-    data_category = DataCategory.PUBLIC_INCIDENT_METADATA
+    data_category = DataCategory.TECHNOLOGY_OBSERVATION
 
     def __init__(
         self,

--- a/src/cip/modules/collection_orchestration/application/phishtank_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/phishtank_adapter.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime, timedelta
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+
+from cip.adapters.sources.threat_catalogs.mappers import map_phishing_metadata
+from cip.adapters.sources.threat_catalogs.phishtank_schemas import PhishTankFeedRecord
+from cip.adapters.sources.threat_catalogs.schemas import (
+    ObservableType,
+    PhishingMetadataRecord,
+    ProviderState,
+)
+from cip.modules.collection_orchestration.application.intelligence_adapter_support import (
+    HARD_MAX_JSON_BYTES,
+    IntelligenceObservationContext,
+    authorize_intelligence_request,
+    get_json,
+    raw_intelligence_observation,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.modules.threat_telemetry.domain.models import IndicatorSnapshot
+from cip.shared.kernel.time import require_aware_utc
+
+_MAX_FEED_RECORDS = 100_000
+_MAX_PROJECTED_RECORDS = 1_000
+_FRESHNESS = timedelta(hours=2)
+PURPOSE = "threat-telemetry"
+
+
+class PhishTankAdapter:
+    source_id = "phishtank-verified-online"
+    adapter_id = "phishtank-online-valid-json"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_INCIDENT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        *,
+        token_provider: Callable[[], str | None],
+        user_agent: str | None,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("PhishTank adapter requires phishtank-verified-online policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._token_provider = token_provider
+        self._user_agent = user_agent.strip() if user_agent else None
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        del checkpoint_payload
+        token = self._token_provider()
+        if token is None or not token.strip():
+            raise AdapterExecutionError(
+                "PhishTank automated feed requires an application key",
+                error_code="provider_not_connected",
+                retryable=False,
+            )
+        if self._user_agent is None:
+            raise AdapterExecutionError(
+                "PhishTank automated feed requires a descriptive User-Agent",
+                error_code="provider_not_configured",
+                retryable=False,
+            )
+        request_url = (
+            f"{self._entry.policy.base_url}{quote(token.strip(), safe='')}/online-valid.json"
+        )
+        authorize_intelligence_request(
+            self._entry,
+            category=self.data_category,
+            purpose=PURPOSE,
+            target_url=request_url,
+            collected_at=collected_at,
+        )
+        records = self._fetch(request_url)
+        selected = tuple(
+            sorted(records, key=lambda record: record.phish_id, reverse=True)[
+                :_MAX_PROJECTED_RECORDS
+            ]
+        )
+        context = IntelligenceObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            data_category=self.data_category,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = []
+        snapshots = []
+        safe_source_url = f"{self._entry.policy.base_url}online-valid.json"
+        for record in selected:
+            snapshot = _map_record(record, collected_at=collected_at)
+            if snapshot is None:
+                continue
+            observations.append(
+                raw_intelligence_observation(
+                    record,
+                    context=context,
+                    source_url=safe_source_url,
+                    source_record_key=str(record.phish_id),
+                    source_record_type="phishtank-verified-online",
+                    observed_at=record.submission_time,
+                    published_at=record.verification_time,
+                    source_updated_at=collected_at,
+                )
+            )
+            snapshots.append(snapshot)
+        return AdapterCollectionBatch(
+            observations=tuple(observations),
+            threat_indicator_snapshots=tuple(snapshots),
+            checkpoint_payload={"feed_size": len(records)},
+            not_modified=not snapshots,
+        )
+
+    def _fetch(self, request_url: str) -> tuple[PhishTankFeedRecord, ...]:
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(
+                client,
+                request_url,
+                headers={"User-Agent": self._user_agent or ""},
+                max_bytes=HARD_MAX_JSON_BYTES,
+            )
+        try:
+            records = tuple(TypeAdapter(list[PhishTankFeedRecord]).validate_json(body))
+        except ValidationError as exc:
+            raise AdapterExecutionError(
+                "PhishTank feed schema changed",
+                error_code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        if len(records) > _MAX_FEED_RECORDS:
+            raise AdapterExecutionError(
+                "PhishTank feed exceeds record bound",
+                error_code="source_page_too_large",
+                retryable=False,
+            )
+        return records
+
+
+def _map_record(
+    record: PhishTankFeedRecord,
+    *,
+    collected_at: datetime,
+) -> IndicatorSnapshot | None:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    submitted = require_aware_utc(record.submission_time, field_name="submission_time")
+    verified = require_aware_utc(record.verification_time, field_name="verification_time")
+    modified = max(verified, collected)
+    try:
+        metadata = PhishingMetadataRecord(
+            record_id=str(record.phish_id),
+            source_url=(
+                "https://www.phishtank.com/phish_detail.php?phish_id="
+                f"{record.phish_id}"
+            ),
+            observable_type=ObservableType.URL,
+            value=record.url,
+            state=ProviderState.MALICIOUS,
+            published_at=verified,
+            modified_at=modified,
+            first_seen_at=submitted,
+            last_seen_at=collected,
+            expires_at=collected + _FRESHNESS,
+            confidence=0.95,
+            source_precedence=80,
+            independence_key=PhishTankAdapter.source_id,
+            sensor_scope="provider_aggregate",
+            historical_only=False,
+            active=True,
+        )
+        return map_phishing_metadata(metadata, source_id=PhishTankAdapter.source_id)
+    except ValueError:
+        return None

--- a/src/cip/modules/collection_orchestration/application/ports.py
+++ b/src/cip/modules/collection_orchestration/application/ports.py
@@ -7,6 +7,7 @@ from typing import Protocol
 from uuid import UUID
 
 from cip.modules.evidence.domain.entities import Evidence
+from cip.modules.incident_intelligence.domain.models import IncidentClaimSnapshot
 from cip.modules.opportunities.domain.entities import CommercialSignal
 from cip.modules.organizations.application.identity import IdentityProjection
 from cip.modules.organizations.domain.entities import Organization
@@ -15,6 +16,7 @@ from cip.modules.procurement_history.domain.models import ProcurementHistoryProj
 from cip.modules.public_footprint.domain.models import PublicFootprintProjection
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.threat_telemetry.domain.models import IndicatorSnapshot
 from cip.modules.vulnerability_knowledge.domain.models import VulnerabilitySnapshot
 
 
@@ -50,6 +52,8 @@ class AdapterCollectionBatch:
     public_footprint_projections: tuple[PublicFootprintProjection, ...] = ()
     vulnerability_snapshots: tuple[VulnerabilitySnapshot, ...] = ()
     passive_exposure_projections: tuple[PassiveObservationSnapshot, ...] = ()
+    incident_claims: tuple[IncidentClaimSnapshot, ...] = ()
+    threat_indicator_snapshots: tuple[IndicatorSnapshot, ...] = ()
     quota_remaining: int | None = None
     request_cost: float = 0.0
 

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -11,6 +11,7 @@ from time import sleep
 from sqlalchemy.orm import Session, sessionmaker
 
 from cip.adapters.sources.greenhouse.registry import load_greenhouse_boards
+from cip.adapters.sources.incident_catalogs.sec_registry import load_sec_incident_targets
 from cip.adapters.sources.lever.registry import load_lever_sites
 from cip.adapters.sources.organization_identity.registry import (
     load_organization_identity_targets,
@@ -107,6 +108,13 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
             source_id="certspotter-ct",
             secret_name="api_token",
         ),
+        phishtank_token_provider=connected_secret_supplier(
+            factory,
+            source_id="phishtank-verified-online",
+            secret_name="api_token",
+        ),
+        sec_user_agent=settings.sec_edgar_user_agent,
+        phishtank_user_agent=settings.phishtank_user_agent,
         timeout_seconds=settings.source_http_timeout_seconds,
     )
     with session_scope(factory) as session:
@@ -184,6 +192,9 @@ def _load_adapter_inputs(
         passive_infrastructure_targets=load_passive_infrastructure_targets(
             settings.passive_infrastructure_target_registry_path
         ),
+        sec_incident_targets=load_sec_incident_targets(
+            settings.sec_incident_target_registry_path
+        ),
     )
 
 
@@ -195,6 +206,8 @@ def _load_schedules(settings: Settings) -> tuple[SourceSchedule, ...]:
         settings.vulnerability_collection_schedule_path,
         settings.search_archive_collection_schedule_path,
         settings.passive_infrastructure_collection_schedule_path,
+        settings.incident_collection_schedule_path,
+        settings.threat_telemetry_collection_schedule_path,
     )
 
 

--- a/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
-from datetime import UTC, date, datetime
+from datetime import datetime
 from uuid import UUID
 
 import httpx
@@ -30,6 +30,7 @@ from cip.modules.collection_orchestration.application.ports import (
     AdapterCollectionBatch,
     AdapterExecutionError,
 )
+from cip.modules.incident_intelligence.domain.models import IncidentClaimSnapshot
 from cip.modules.source_governance.domain.models import DataCategory
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 from cip.shared.kernel.time import require_aware_utc
@@ -204,7 +205,7 @@ def _map_filing(
     target: SecIncidentTarget,
     issuer_name: str,
     source_url: str,
-):
+) -> IncidentClaimSnapshot:
     record = OfficialIncidentDisclosure(
         record_id=filing.accession_number,
         incident_key=f"sec-item-1.05:{target.cik}:{filing.accession_number}",

--- a/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
@@ -40,6 +41,12 @@ _ITEM_105 = re.compile(r"(?:^|[,;\s])1\.05(?:$|[,;\s])")
 _MAX_CYBER_FILINGS_PER_RUN = 100
 _MAX_CURSOR_TARGETS = 500
 PURPOSE = "incident-intelligence"
+
+
+@dataclass(frozen=True, slots=True)
+class _FilingSelection:
+    filings: tuple[SecCyberFilingRecord, ...]
+    next_cursor: str | None
 
 
 class SecCyberDisclosureAdapter:
@@ -95,17 +102,12 @@ class SecCyberDisclosureAdapter:
         response = self._fetch(target_url)
         _validate_response_cik(response.cik, target.cik)
         cursors = _cursor_map(checkpoint_payload, self._targets)
-        newest_accession = (
-            response.filings.recent.accessionNumber[0]
-            if response.filings.recent.accessionNumber
-            else None
-        )
-        filings = _new_cyber_filings(
+        selection = _select_cyber_filings(
             response,
             stop_at=cursors.get(target.target_id),
         )
-        if newest_accession is not None:
-            cursors[target.target_id] = newest_accession
+        if selection.next_cursor is not None:
+            cursors[target.target_id] = selection.next_cursor
         context = IntelligenceObservationContext(
             source_id=self.source_id,
             adapter_id=self.adapter_id,
@@ -125,7 +127,7 @@ class SecCyberDisclosureAdapter:
                 published_at=filing.accepted_at,
                 source_updated_at=filing.accepted_at,
             )
-            for filing in filings
+            for filing in selection.filings
         )
         claims = tuple(
             _map_filing(
@@ -134,7 +136,7 @@ class SecCyberDisclosureAdapter:
                 issuer_name=response.name,
                 source_url=target_url,
             )
-            for filing in filings
+            for filing in selection.filings
         )
         return AdapterCollectionBatch(
             observations=observations,
@@ -167,35 +169,46 @@ class SecCyberDisclosureAdapter:
             ) from exc
 
 
-def _new_cyber_filings(
+def _select_cyber_filings(
     response: SecSubmissionResponse,
     *,
     stop_at: str | None,
-) -> tuple[SecCyberFilingRecord, ...]:
+) -> _FilingSelection:
     recent = response.filings.recent
     records: list[SecCyberFilingRecord] = []
     for index, accession in enumerate(recent.accessionNumber):
         if accession == stop_at:
             break
-        form = recent.form[index].strip().upper()
-        items = recent.items[index]
-        if form not in _ALLOWED_FORMS or _ITEM_105.search(items) is None:
-            continue
-        records.append(
-            SecCyberFilingRecord(
-                accession_number=accession,
-                form=form,
-                item="1.05",
-                filing_date=recent.filingDate[index],
-                accepted_at=require_aware_utc(
-                    recent.acceptanceDateTime[index],
-                    field_name="acceptanceDateTime",
-                ),
-            )
-        )
-        if len(records) >= _MAX_CYBER_FILINGS_PER_RUN:
-            break
-    return tuple(records)
+        record = _cyber_filing_at(response, index=index, accession=accession)
+        if record is not None:
+            records.append(record)
+    if len(records) > _MAX_CYBER_FILINGS_PER_RUN:
+        selected = tuple(records[-_MAX_CYBER_FILINGS_PER_RUN:])
+        return _FilingSelection(selected, selected[0].accession_number)
+    newest_accession = recent.accessionNumber[0] if recent.accessionNumber else stop_at
+    return _FilingSelection(tuple(records), newest_accession)
+
+
+def _cyber_filing_at(
+    response: SecSubmissionResponse,
+    *,
+    index: int,
+    accession: str,
+) -> SecCyberFilingRecord | None:
+    recent = response.filings.recent
+    form = recent.form[index].strip().upper()
+    if form not in _ALLOWED_FORMS or _ITEM_105.search(recent.items[index]) is None:
+        return None
+    return SecCyberFilingRecord(
+        accession_number=accession,
+        form=form,
+        item="1.05",
+        filing_date=recent.filingDate[index],
+        accepted_at=require_aware_utc(
+            recent.acceptanceDateTime[index],
+            field_name="acceptanceDateTime",
+        ),
+    )
 
 
 def _map_filing(

--- a/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import UTC, date, datetime
+from uuid import UUID
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.incident_catalogs.mappers import map_official_disclosure
+from cip.adapters.sources.incident_catalogs.schemas import (
+    OfficialDisclosureKind,
+    OfficialIncidentDisclosure,
+    OrganizationReference,
+    PublicIncidentKind,
+)
+from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
+from cip.adapters.sources.incident_catalogs.sec_schemas import (
+    SecCyberFilingRecord,
+    SecSubmissionResponse,
+)
+from cip.modules.collection_orchestration.application.intelligence_adapter_support import (
+    IntelligenceObservationContext,
+    authorize_intelligence_request,
+    get_json,
+    raw_intelligence_observation,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+_ALLOWED_FORMS = frozenset({"8-K", "8-K12B", "8-K12G3", "8-K15D5"})
+_ITEM_105 = re.compile(r"(?:^|[,;\s])1\.05(?:$|[,;\s])")
+_MAX_CYBER_FILINGS_PER_RUN = 100
+_MAX_CURSOR_TARGETS = 500
+PURPOSE = "incident-intelligence"
+
+
+class SecCyberDisclosureAdapter:
+    source_id = "sec-cyber-disclosures"
+    adapter_id = "sec-submissions-item-1-05"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_INCIDENT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[SecIncidentTarget, ...],
+        *,
+        user_agent: str | None,
+        timeout_seconds: float = 20.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("SEC adapter requires sec-cyber-disclosures policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled)
+        self._user_agent = user_agent.strip() if user_agent else None
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None:
+            return _empty_batch()
+        if self._user_agent is None:
+            raise AdapterExecutionError(
+                "SEC automated access requires a declared User-Agent",
+                error_code="provider_not_configured",
+                retryable=False,
+            )
+        target_url = f"{self._entry.policy.base_url}CIK{target.cik}.json"
+        authorize_intelligence_request(
+            self._entry,
+            category=self.data_category,
+            purpose=PURPOSE,
+            target_url=target_url,
+            collected_at=collected_at,
+        )
+        response = self._fetch(target_url)
+        _validate_response_cik(response.cik, target.cik)
+        cursors = _cursor_map(checkpoint_payload, self._targets)
+        newest_accession = (
+            response.filings.recent.accessionNumber[0]
+            if response.filings.recent.accessionNumber
+            else None
+        )
+        filings = _new_cyber_filings(
+            response,
+            stop_at=cursors.get(target.target_id),
+        )
+        if newest_accession is not None:
+            cursors[target.target_id] = newest_accession
+        context = IntelligenceObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            data_category=self.data_category,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        observations = tuple(
+            raw_intelligence_observation(
+                filing,
+                context=context,
+                source_url=target_url,
+                source_record_key=filing.accession_number,
+                source_record_type="sec-item-1-05-filing",
+                published_at=filing.accepted_at,
+                source_updated_at=filing.accepted_at,
+            )
+            for filing in filings
+        )
+        claims = tuple(
+            _map_filing(
+                filing,
+                target=target,
+                issuer_name=response.name,
+                source_url=target_url,
+            )
+            for filing in filings
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            incident_claims=claims,
+            checkpoint_payload={
+                "target_index": next_index,
+                "last_accession_by_target": cursors,
+            },
+            not_modified=not claims,
+        )
+
+    def _fetch(self, target_url: str) -> SecSubmissionResponse:
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            body = get_json(
+                client,
+                target_url,
+                headers={"User-Agent": self._user_agent or ""},
+            )
+        try:
+            return SecSubmissionResponse.model_validate_json(body)
+        except ValidationError as exc:
+            raise AdapterExecutionError(
+                "SEC submissions response schema changed",
+                error_code="source_schema_drift",
+                retryable=False,
+            ) from exc
+
+
+def _new_cyber_filings(
+    response: SecSubmissionResponse,
+    *,
+    stop_at: str | None,
+) -> tuple[SecCyberFilingRecord, ...]:
+    recent = response.filings.recent
+    records: list[SecCyberFilingRecord] = []
+    for index, accession in enumerate(recent.accessionNumber):
+        if accession == stop_at:
+            break
+        form = recent.form[index].strip().upper()
+        items = recent.items[index]
+        if form not in _ALLOWED_FORMS or _ITEM_105.search(items) is None:
+            continue
+        records.append(
+            SecCyberFilingRecord(
+                accession_number=accession,
+                form=form,
+                item="1.05",
+                filing_date=recent.filingDate[index],
+                report_date=recent.reportDate[index],
+                accepted_at=require_aware_utc(
+                    recent.acceptanceDateTime[index],
+                    field_name="acceptanceDateTime",
+                ),
+            )
+        )
+        if len(records) >= _MAX_CYBER_FILINGS_PER_RUN:
+            break
+    return tuple(records)
+
+
+def _map_filing(
+    filing: SecCyberFilingRecord,
+    *,
+    target: SecIncidentTarget,
+    issuer_name: str,
+    source_url: str,
+):
+    record = OfficialIncidentDisclosure(
+        record_id=filing.accession_number,
+        incident_key=f"sec-item-1.05:{target.cik}:{filing.accession_number}",
+        source_url=source_url,
+        disclosure_kind=OfficialDisclosureKind.COMPANY_CONFIRMATION,
+        incident_kind=PublicIncidentKind.UNKNOWN,
+        title=f"SEC {filing.form} Item 1.05 cybersecurity incident disclosure",
+        summary=(
+            "Official SEC filing metadata indicates a material cybersecurity incident "
+            "disclosure under Item 1.05. The filing narrative was not collected by SA-04."
+        ),
+        organization=OrganizationReference(
+            claimed_name=issuer_name,
+            exact_registration_id=f"SEC-CIK:{target.cik}",
+            exact_organization_id=str(target.organization_id),
+        ),
+        published_at=filing.accepted_at,
+        modified_at=filing.accepted_at,
+        confirmed_at=filing.accepted_at,
+    )
+    return map_official_disclosure(record, source_id=SecCyberDisclosureAdapter.source_id)
+
+
+def _validate_response_cik(value: str | int, expected: str) -> None:
+    normalized = str(value).strip().zfill(10)
+    if normalized != expected:
+        raise AdapterExecutionError(
+            "SEC response CIK does not match requested target",
+            error_code="source_identity_mismatch",
+            retryable=False,
+        )
+
+
+def _cursor_map(
+    payload: Mapping[str, object] | None,
+    targets: tuple[SecIncidentTarget, ...],
+) -> dict[str, str]:
+    if payload is None:
+        return {}
+    raw = payload.get("last_accession_by_target", {})
+    if not isinstance(raw, dict) or len(raw) > _MAX_CURSOR_TARGETS:
+        raise _invalid_checkpoint()
+    known_ids = {target.target_id for target in targets}
+    result: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise _invalid_checkpoint()
+        if key in known_ids:
+            result[key] = value
+    return result
+
+
+def _next_target(
+    targets: tuple[SecIncidentTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[SecIncidentTarget | None, int]:
+    if not targets:
+        return None, 0
+    value = 0 if payload is None else payload.get("target_index", 0)
+    if not isinstance(value, int) or value < 0:
+        raise _invalid_checkpoint()
+    index = value % len(targets)
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "invalid SEC incident checkpoint",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        incident_claims=(),
+        checkpoint_payload={"target_index": 0, "last_accession_by_target": {}},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/sec_incident_adapter.py
@@ -187,7 +187,6 @@ def _new_cyber_filings(
                 form=form,
                 item="1.05",
                 filing_date=recent.filingDate[index],
-                report_date=recent.reportDate[index],
                 accepted_at=require_aware_utc(
                     recent.acceptanceDateTime[index],
                     field_name="acceptanceDateTime",

--- a/src/cip/modules/collection_orchestration/application/worker.py
+++ b/src/cip/modules/collection_orchestration/application/worker.py
@@ -23,6 +23,7 @@ from cip.modules.collection_orchestration.infrastructure.repository import (
     fail_job,
 )
 from cip.modules.data_governance.domain.retention import RetentionPolicy
+from cip.modules.incident_intelligence.infrastructure.projections import persist_incident_claims
 from cip.modules.opportunities.infrastructure.projections import (
     persist_commercial_projections,
 )
@@ -54,6 +55,7 @@ from cip.modules.source_portfolio.application.service import (
     record_source_value_event,
 )
 from cip.modules.source_portfolio.domain.models import SchemaState
+from cip.modules.threat_telemetry.infrastructure.projections import persist_indicator_snapshots
 from cip.modules.vulnerability_knowledge.infrastructure.projections import (
     persist_vulnerability_snapshots,
 )
@@ -197,6 +199,12 @@ def _complete_success(
         persist_passive_snapshots(
             session,
             batch.passive_exposure_projections,
+            now=now,
+        )
+        persist_incident_claims(session, batch.incident_claims, now=now)
+        persist_indicator_snapshots(
+            session,
+            batch.threat_indicator_snapshots,
             now=now,
         )
         _record_success_health(

--- a/src/cip/modules/source_portfolio/application/backfill_worker.py
+++ b/src/cip/modules/source_portfolio/application/backfill_worker.py
@@ -16,6 +16,7 @@ from cip.modules.collection_orchestration.infrastructure.repository_completion i
     insert_observations,
 )
 from cip.modules.data_governance.domain.retention import RetentionPolicy
+from cip.modules.incident_intelligence.infrastructure.projections import persist_incident_claims
 from cip.modules.organizations.infrastructure.persistence import upsert_organizations
 from cip.modules.passive_exposure.infrastructure.projections import (
     persist_passive_snapshots,
@@ -42,6 +43,7 @@ from cip.modules.source_portfolio.application.service import (
 )
 from cip.modules.source_portfolio.domain.models import SchemaState
 from cip.modules.source_portfolio.infrastructure.models import BackfillPartitionRecord
+from cip.modules.threat_telemetry.infrastructure.projections import persist_indicator_snapshots
 from cip.modules.vulnerability_knowledge.infrastructure.projections import (
     persist_vulnerability_snapshots,
 )
@@ -137,6 +139,12 @@ def run_backfill_once(
         persist_passive_snapshots(
             session,
             batch.passive_exposure_projections,
+            now=completed_at,
+        )
+        persist_incident_claims(session, batch.incident_claims, now=completed_at)
+        persist_indicator_snapshots(
+            session,
+            batch.threat_indicator_snapshots,
             now=completed_at,
         )
         record_collection_success(

--- a/src/cip/modules/source_portfolio/application/backfill_worker.py
+++ b/src/cip/modules/source_portfolio/application/backfill_worker.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session, sessionmaker
 
 from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
     AdapterExecutionError,
     CollectionAdapter,
 )
@@ -117,7 +118,33 @@ def run_backfill_once(
             now=_read_clock(clock),
         )
 
-    completed_at = _read_clock(clock)
+    written = _complete_backfill_success(
+        factory,
+        partition=partition,
+        worker_id=worker_id,
+        batch=batch,
+        completed_at=_read_clock(clock),
+    )
+    status = (
+        BackfillWorkerStatus.NOT_MODIFIED
+        if batch.not_modified
+        else BackfillWorkerStatus.SUCCEEDED
+    )
+    return BackfillWorkerOutcome(
+        status,
+        partition_id=partition.id,
+        observations_written=written,
+    )
+
+
+def _complete_backfill_success(
+    factory: sessionmaker[Session],
+    *,
+    partition: BackfillPartitionRecord,
+    worker_id: str,
+    batch: AdapterCollectionBatch,
+    completed_at: datetime,
+) -> int:
     with session_scope(factory) as session:
         written = insert_observations(session, batch.observations)
         upsert_organizations(session, batch.procurement_organizations)
@@ -182,16 +209,7 @@ def run_backfill_once(
                 occurred_at=completed_at,
             ),
         )
-    status = (
-        BackfillWorkerStatus.NOT_MODIFIED
-        if batch.not_modified
-        else BackfillWorkerStatus.SUCCEEDED
-    )
-    return BackfillWorkerOutcome(
-        status,
-        partition_id=partition.id,
-        observations_written=written,
-    )
+    return written
 
 
 def _claim_partition(

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
     passive_infrastructure_target_registry_path: Path = Path(
         "policies/passive_infrastructure_targets.yml"
     )
+    sec_incident_target_registry_path: Path = Path("policies/sec_incident_targets.yml")
     retention_policy_path: Path = Path("policies/retention.yml")
     collection_schedule_path: Path = Path("policies/collection_schedules.yml")
     decp_collection_schedule_path: Path = Path("policies/collection_schedules.decp.yml")
@@ -110,6 +111,14 @@ class Settings(BaseSettings):
     passive_infrastructure_collection_schedule_path: Path = Path(
         "policies/collection_schedules.passive_infrastructure.yml"
     )
+    incident_collection_schedule_path: Path = Path(
+        "policies/collection_schedules.incidents.yml"
+    )
+    threat_telemetry_collection_schedule_path: Path = Path(
+        "policies/collection_schedules.threat_telemetry.yml"
+    )
+    sec_edgar_user_agent: str | None = Field(default=None, max_length=300)
+    phishtank_user_agent: str | None = Field(default=None, max_length=300)
     control_plane_token: str = Field(
         default="development-control-token",
         min_length=16,

--- a/tests/integration/test_incident_telemetry_projection_paths.py
+++ b/tests/integration/test_incident_telemetry_projection_paths.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+from uuid import UUID
+
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    CollectionAdapter,
+)
+from cip.modules.collection_orchestration.application.worker import WorkerStatus, run_worker_once
+from cip.modules.collection_orchestration.domain.models import CollectionJob, SourceSchedule
+from cip.modules.collection_orchestration.infrastructure.repository import enqueue_job
+from cip.modules.data_governance.domain.retention import RetentionPolicy, RetentionRule
+from cip.modules.incident_intelligence.domain.models import (
+    IncidentClaimSnapshot,
+    IncidentClaimType,
+    IncidentSourceKind,
+    IncidentType,
+    OrganizationLinkStatus,
+)
+from cip.modules.incident_intelligence.infrastructure.models import (
+    IncidentClaimSnapshotRecord,
+    IncidentRecord,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.raw_observations.infrastructure.models import RawObservationRecord
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.models import SourceRecord
+from cip.modules.source_portfolio.application.backfill_worker import (
+    BackfillWorkerStatus,
+    run_backfill_once,
+)
+from cip.modules.source_portfolio.application.service import request_backfill, sync_source_portfolio
+from cip.modules.source_portfolio.infrastructure.registry import load_source_portfolio
+from cip.modules.threat_telemetry.domain.models import (
+    IndicatorSnapshot,
+    IndicatorState,
+    IndicatorType,
+    SensorScope,
+    TelemetrySourceKind,
+)
+from cip.modules.threat_telemetry.infrastructure.models import (
+    ThreatIndicatorRecord,
+    ThreatIndicatorSnapshotRecord,
+)
+from cip.shared.persistence.metadata import get_metadata
+from cip.shared.persistence.session import session_scope
+
+NOW = datetime(2026, 8, 9, 23, 30, tzinfo=UTC)
+
+
+class IntelligenceProjectionAdapter:
+    source_id = "reference-synthetic"
+    adapter_id = "reference-synthetic-adapter"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        del checkpoint_payload
+        record_key = f"intelligence-{collection_job_id}"
+        observation = RawObservation(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version="1",
+            collection_job_id=collection_job_id,
+            source_record_type="intelligence_reference",
+            source_record_key=record_key,
+            source_url=f"https://example.invalid/{record_key}",
+            payload_hash_sha256="8" * 64,
+            data_categories=frozenset({self.data_category}),
+            collected_at=collected_at,
+            observed_at=collected_at,
+            published_at=collected_at,
+            source_updated_at=collected_at,
+            schema_fingerprint="intelligence-reference-v1",
+            retention_until=retention_until,
+        )
+        incident = IncidentClaimSnapshot(
+            source_id=self.source_id,
+            source_kind=IncidentSourceKind.RESEARCH,
+            source_record_key=record_key,
+            source_url=f"https://example.invalid/{record_key}",
+            incident_key=f"incident:{collection_job_id}",
+            claim_type=IncidentClaimType.RESEARCHER_REPORT,
+            incident_type=IncidentType.UNKNOWN,
+            title="Synthetic incident metadata",
+            summary="Synthetic metadata used only to validate collection persistence.",
+            claimed_organization_name=None,
+            organization_id=None,
+            organization_link_status=OrganizationLinkStatus.UNRESOLVED,
+            published_at=collected_at,
+            modified_at=collected_at,
+        )
+        indicator = IndicatorSnapshot(
+            source_id=self.source_id,
+            source_kind=TelemetrySourceKind.PHISHING_FEED,
+            source_record_key=record_key,
+            source_url=f"https://example.invalid/{record_key}",
+            indicator_type=IndicatorType.URL,
+            indicator_value="https://phish.example.net/login",
+            state=IndicatorState.MALICIOUS,
+            published_at=collected_at,
+            modified_at=collected_at,
+            first_seen_at=collected_at,
+            last_seen_at=collected_at,
+            expires_at=collected_at + timedelta(hours=2),
+            sensor_scope=SensorScope.PROVIDER_AGGREGATE,
+            confidence=0.9,
+            source_precedence=80,
+        )
+        return AdapterCollectionBatch(
+            observations=(observation,),
+            checkpoint_payload={"sequence": 1},
+            not_modified=False,
+            incident_claims=(incident,),
+            threat_indicator_snapshots=(indicator,),
+        )
+
+
+def test_incremental_worker_persists_incident_and_telemetry_projections() -> None:
+    factory = _factory()
+    adapter = IntelligenceProjectionAdapter()
+    _seed_source(factory)
+    with session_scope(factory) as session:
+        job = CollectionJob.from_schedule(
+            SourceSchedule(adapter.source_id, adapter.adapter_id, 300),
+            scheduled_for=NOW,
+        )
+        assert enqueue_job(session, job) is True
+
+    outcome = run_worker_once(
+        factory,
+        worker_id="intelligence-worker",
+        adapters={(adapter.source_id, adapter.adapter_id): cast(CollectionAdapter, adapter)},
+        retention_policy=_retention_policy(),
+        clock=lambda: NOW + timedelta(seconds=1),
+    )
+
+    assert outcome.status is WorkerStatus.SUCCEEDED
+    assert outcome.observations_written == 1
+    _assert_projection_writes(factory)
+
+
+def test_backfill_worker_persists_incident_and_telemetry_projections() -> None:
+    factory = _factory()
+    adapter = IntelligenceProjectionAdapter()
+    _seed_source(factory)
+    with session_scope(factory) as session:
+        request_backfill(
+            session,
+            adapter.source_id,
+            (("2026-01-01", "2026-02-01"),),
+            actor="intelligence-backfill-test",
+            now=NOW,
+        )
+
+    outcome = run_backfill_once(
+        factory,
+        worker_id="intelligence-backfill-worker",
+        adapters={(adapter.source_id, adapter.adapter_id): cast(CollectionAdapter, adapter)},
+        retention_policy=_retention_policy(),
+        clock=lambda: NOW + timedelta(seconds=1),
+    )
+
+    assert outcome.status is BackfillWorkerStatus.SUCCEEDED
+    assert outcome.observations_written == 1
+    _assert_projection_writes(factory)
+
+
+def _assert_projection_writes(factory: sessionmaker[Session]) -> None:
+    with factory() as session:
+        assert session.scalar(select(func.count(RawObservationRecord.id))) == 1
+        assert session.scalar(select(func.count(IncidentRecord.id))) == 1
+        assert session.scalar(select(func.count(IncidentClaimSnapshotRecord.id))) == 1
+        assert session.scalar(select(func.count(ThreatIndicatorRecord.id))) == 1
+        assert session.scalar(select(func.count(ThreatIndicatorSnapshotRecord.id))) == 1
+
+
+def _seed_source(factory: sessionmaker[Session]) -> None:
+    with session_scope(factory) as session:
+        session.add(_source_record())
+        sync_source_portfolio(
+            session,
+            load_source_portfolio(Path("policies/source_portfolio.yml")),
+            now=NOW,
+        )
+
+
+def _factory() -> sessionmaker[Session]:
+    engine = create_engine(
+        "sqlite+pysqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    get_metadata().create_all(engine)
+    return sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
+
+
+def _source_record() -> SourceRecord:
+    return SourceRecord(
+        id="reference-synthetic",
+        name="Synthetic reference adapter",
+        base_url="https://example.invalid/source-portfolio-reference",
+        status="enabled",
+        source_type="api",
+        owner="Cyber Intelligence Platform",
+        terms_url=None,
+        licence=None,
+        allowed_data_categories=[DataCategory.PUBLIC_RESULT_METADATA.value],
+        prohibited_data_categories=[],
+        rate_limit_per_minute=None,
+        retention_days=30,
+        attribution_required=False,
+        raw_content_storage=False,
+        human_review_required=False,
+        authorization_status="approved",
+        authorization_document_reference="TEST-REFERENCE",
+        authorization_reviewed_at=NOW,
+        authorization_expires_at=NOW + timedelta(days=365),
+        approved_hosts=["example.invalid"],
+        approved_path_prefixes=["/source-portfolio-reference"],
+        approved_purposes=["runtime-contract-validation"],
+        automated_collection_allowed=True,
+        raw_storage_allowed=False,
+    )
+
+
+def _retention_policy() -> RetentionPolicy:
+    return RetentionPolicy(
+        version=1,
+        rules={
+            DataCategory.PUBLIC_RESULT_METADATA: RetentionRule(
+                retention_days=30,
+                review_interval_days=7,
+            )
+        },
+        prohibited_categories=frozenset(),
+        suppression_minimum_days=365,
+        backup_deletion_propagation_max_days=30,
+        restoration_requires_suppressions=True,
+    )

--- a/tests/unit/adapters/test_sec_incident_target_registry.py
+++ b/tests/unit/adapters/test_sec_incident_target_registry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from cip.adapters.sources.incident_catalogs.sec_registry import load_sec_incident_targets
+
+ORGANIZATION_ID = UUID("00000000-0000-0000-0000-000000000406")
+
+
+def test_checked_in_sec_target_registry_is_empty_by_default() -> None:
+    targets = load_sec_incident_targets(Path("policies/sec_incident_targets.yml"))
+
+    assert targets == ()
+
+
+def test_sec_target_registry_accepts_exact_ten_digit_cik(tmp_path: Path) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        f"""version: 1
+targets:
+  - target_id: issuer
+    organization_id: {ORGANIZATION_ID}
+    cik: "0000320193"
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+
+    targets = load_sec_incident_targets(path)
+
+    assert targets[0].cik == "0000320193"
+    assert targets[0].enabled is True
+
+
+@pytest.mark.parametrize("cik", ["320193", "000032019A", "00000320193", ""])
+def test_sec_target_registry_rejects_noncanonical_ciks(
+    tmp_path: Path,
+    cik: str,
+) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        f"""version: 1
+targets:
+  - target_id: invalid
+    organization_id: {ORGANIZATION_ID}
+    cik: "{cik}"
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_sec_incident_targets(path)
+
+
+def test_sec_target_registry_rejects_duplicate_cik(tmp_path: Path) -> None:
+    path = tmp_path / "targets.yml"
+    path.write_text(
+        f"""version: 1
+targets:
+  - target_id: issuer-one
+    organization_id: {ORGANIZATION_ID}
+    cik: "0000320193"
+  - target_id: issuer-two
+    organization_id: 00000000-0000-0000-0000-000000000407
+    cik: "0000320193"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate SEC CIK target"):
+        load_sec_incident_targets(path)

--- a/tests/unit/adapters/test_sec_submission_schema.py
+++ b/tests/unit/adapters/test_sec_submission_schema.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from cip.adapters.sources.incident_catalogs.sec_schemas import SecSubmissionResponse
+
+
+def test_sec_submission_schema_accepts_empty_report_date_cells() -> None:
+    response = SecSubmissionResponse.model_validate(
+        {
+            "cik": 320193,
+            "name": "Example Issuer",
+            "filings": {
+                "recent": {
+                    "accessionNumber": ["0000320193-26-000010"],
+                    "filingDate": ["2026-08-09"],
+                    "reportDate": [""],
+                    "acceptanceDateTime": ["2026-08-09T20:00:00Z"],
+                    "form": ["8-K"],
+                    "items": ["1.05"],
+                }
+            },
+        }
+    )
+
+    assert response.filings.recent.reportDate == [""]

--- a/tests/unit/collection_orchestration/test_incident_telemetry_adapters.py
+++ b/tests/unit/collection_orchestration/test_incident_telemetry_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import UUID
@@ -120,6 +121,33 @@ def test_sec_maps_only_non_amended_item_105_as_official_confirmation() -> None:
     assert claim.is_official_confirmation is True
 
 
+def test_sec_capped_batches_converge_without_skipping_filings() -> None:
+    accessions = [f"0000320193-26-{number:06d}" for number in range(101, 0, -1)]
+    payload = _sec_recent_payload(accessions)
+    adapter = SecCyberDisclosureAdapter(
+        _entry(INCIDENT_REGISTRY, "sec-cyber-disclosures"),
+        (_sec_target(),),
+        user_agent="CIP security-research contact@example.com",
+        transport=httpx.MockTransport(lambda _request: _json_response(payload)),
+    )
+
+    first = _collect(adapter)
+    second = _collect(adapter, checkpoint_payload=first.checkpoint_payload)
+
+    first_keys = {observation.source_record_key for observation in first.observations}
+    second_keys = {observation.source_record_key for observation in second.observations}
+    assert len(first_keys) == 100
+    assert len(second_keys) == 1
+    assert first_keys.isdisjoint(second_keys)
+    assert first_keys | second_keys == set(accessions)
+    assert first.checkpoint_payload["last_accession_by_target"] == {
+        "issuer-example": accessions[1]
+    }
+    assert second.checkpoint_payload["last_accession_by_target"] == {
+        "issuer-example": accessions[0]
+    }
+
+
 def test_sec_rejects_mismatched_response_cik() -> None:
     adapter = SecCyberDisclosureAdapter(
         _entry(INCIDENT_REGISTRY, "sec-cyber-disclosures"),
@@ -200,10 +228,14 @@ def test_phishtank_projects_global_url_telemetry_without_brand_compromise() -> N
     assert snapshot.expires_at == NOW + timedelta(hours=2)
 
 
-def _collect(adapter: SecCyberDisclosureAdapter | PhishTankAdapter):
+def _collect(
+    adapter: SecCyberDisclosureAdapter | PhishTankAdapter,
+    *,
+    checkpoint_payload: Mapping[str, object] | None = None,
+):
     return adapter.collect(
         collection_job_id=JOB_ID,
-        checkpoint_payload=None,
+        checkpoint_payload=checkpoint_payload,
         collected_at=NOW,
         retention_until=RETENTION,
     )
@@ -220,6 +252,19 @@ def _sec_target() -> SecIncidentTarget:
         cik="0000320193",
         enabled=True,
     )
+
+
+def _sec_recent_payload(accessions: list[str]) -> dict[str, object]:
+    count = len(accessions)
+    recent: dict[str, list[object]] = {
+        "accessionNumber": accessions,
+        "filingDate": ["2026-08-09"] * count,
+        "reportDate": [""] * count,
+        "acceptanceDateTime": ["2026-08-09T20:00:00Z"] * count,
+        "form": ["8-K"] * count,
+        "items": ["1.05"] * count,
+    }
+    return {"cik": 320193, "name": "Example Issuer", "filings": {"recent": recent}}
 
 
 def _empty_recent() -> dict[str, list[object]]:

--- a/tests/unit/collection_orchestration/test_incident_telemetry_adapters.py
+++ b/tests/unit/collection_orchestration/test_incident_telemetry_adapters.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+
+from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
+from cip.modules.collection_orchestration.application.phishtank_adapter import PhishTankAdapter
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.collection_orchestration.application.sec_incident_adapter import (
+    SecCyberDisclosureAdapter,
+)
+from cip.modules.incident_intelligence.domain.models import (
+    IncidentClaimType,
+    IncidentType,
+    OrganizationLinkStatus,
+)
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+from cip.modules.threat_telemetry.domain.models import (
+    IndicatorState,
+    IndicatorType,
+    SensorScope,
+)
+
+NOW = datetime(2026, 8, 9, 23, 30, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+JOB_ID = UUID("00000000-0000-0000-0000-000000000404")
+ORGANIZATION_ID = UUID("00000000-0000-0000-0000-000000000405")
+INCIDENT_REGISTRY = Path("policies/sources.incidents.yml")
+TELEMETRY_REGISTRY = Path("policies/sources.threat_telemetry.yml")
+
+
+def test_sec_without_targets_performs_no_network_and_needs_no_user_agent() -> None:
+    adapter = SecCyberDisclosureAdapter(
+        _entry(INCIDENT_REGISTRY, "sec-cyber-disclosures"),
+        (),
+        user_agent=None,
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.not_modified is True
+    assert batch.incident_claims == ()
+
+
+def test_sec_enabled_target_requires_declared_user_agent_before_network() -> None:
+    adapter = SecCyberDisclosureAdapter(
+        _entry(INCIDENT_REGISTRY, "sec-cyber-disclosures"),
+        (_sec_target(),),
+        user_agent=None,
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        _collect(adapter)
+
+    assert error.value.error_code == "provider_not_configured"
+    assert error.value.retryable is False
+
+
+def test_sec_maps_only_non_amended_item_105_as_official_confirmation() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _json_response(
+            {
+                "cik": 320193,
+                "name": "Example Issuer",
+                "filings": {
+                    "recent": {
+                        "accessionNumber": [
+                            "0000320193-26-000010",
+                            "0000320193-26-000009",
+                            "0000320193-26-000008",
+                        ],
+                        "filingDate": ["2026-08-09", "2026-08-08", "2026-08-07"],
+                        "reportDate": ["2026-08-09", "2026-08-08", "2026-08-07"],
+                        "acceptanceDateTime": [
+                            "2026-08-09T20:00:00Z",
+                            "2026-08-08T20:00:00Z",
+                            "2026-08-07T20:00:00Z",
+                        ],
+                        "form": ["8-K", "8-K/A", "10-Q"],
+                        "items": ["1.05,9.01", "1.05", "1.05"],
+                    }
+                },
+            }
+        )
+
+    adapter = SecCyberDisclosureAdapter(
+        _entry(INCIDENT_REGISTRY, "sec-cyber-disclosures"),
+        (_sec_target(),),
+        user_agent="CIP security-research contact@example.com",
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 1
+    assert requests[0].url.host == "data.sec.gov"
+    assert requests[0].url.path == "/submissions/CIK0000320193.json"
+    assert requests[0].headers["User-Agent"] == "CIP security-research contact@example.com"
+    assert len(batch.observations) == 1
+    assert len(batch.incident_claims) == 1
+    claim = batch.incident_claims[0]
+    assert claim.claim_type is IncidentClaimType.COMPANY_CONFIRMATION
+    assert claim.incident_type is IncidentType.UNKNOWN
+    assert claim.organization_id == ORGANIZATION_ID
+    assert claim.organization_link_status is OrganizationLinkStatus.EXACT
+    assert claim.occurrence_start_at is None
+    assert claim.confirmed_at == datetime(2026, 8, 9, 20, 0, tzinfo=UTC)
+    assert claim.is_official_confirmation is True
+
+
+def test_sec_rejects_mismatched_response_cik() -> None:
+    adapter = SecCyberDisclosureAdapter(
+        _entry(INCIDENT_REGISTRY, "sec-cyber-disclosures"),
+        (_sec_target(),),
+        user_agent="CIP contact@example.com",
+        transport=httpx.MockTransport(
+            lambda _request: _json_response(
+                {
+                    "cik": 1,
+                    "name": "Wrong issuer",
+                    "filings": {"recent": _empty_recent()},
+                }
+            )
+        ),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        _collect(adapter)
+
+    assert error.value.error_code == "source_identity_mismatch"
+
+
+def test_phishtank_requires_key_before_network() -> None:
+    adapter = PhishTankAdapter(
+        _entry(TELEMETRY_REGISTRY, "phishtank-verified-online"),
+        token_provider=lambda: None,
+        user_agent="CIP contact@example.com",
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        _collect(adapter)
+
+    assert error.value.error_code == "provider_not_connected"
+
+
+def test_phishtank_projects_global_url_telemetry_without_brand_compromise() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _json_response(
+            [
+                {
+                    "phish_id": 101,
+                    "phish_detail_url": "https://www.phishtank.com/phish_detail.php?phish_id=101",
+                    "url": "https://phish.example.net/login",
+                    "submission_time": "2026-08-09T20:00:00Z",
+                    "verified": "yes",
+                    "verification_time": "2026-08-09T20:05:00Z",
+                    "online": "yes",
+                    "target": "Example Bank",
+                }
+            ]
+        )
+
+    adapter = PhishTankAdapter(
+        _entry(TELEMETRY_REGISTRY, "phishtank-verified-online"),
+        token_provider=lambda: "secret-key",
+        user_agent="CIP contact@example.com",
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 1
+    assert requests[0].url.host == "data.phishtank.com"
+    assert "/secret-key/online-valid.json" in requests[0].url.path
+    assert requests[0].headers["User-Agent"] == "CIP contact@example.com"
+    assert len(batch.observations) == 1
+    assert "secret-key" not in batch.observations[0].source_url
+    assert len(batch.threat_indicator_snapshots) == 1
+    snapshot = batch.threat_indicator_snapshots[0]
+    assert snapshot.indicator_type is IndicatorType.URL
+    assert snapshot.state is IndicatorState.MALICIOUS
+    assert snapshot.sensor_scope is SensorScope.PROVIDER_AGGREGATE
+    assert snapshot.direct_validation_performed is False
+    assert snapshot.relations == ()
+    assert snapshot.expires_at == NOW + timedelta(hours=2)
+
+
+def _collect(adapter: SecCyberDisclosureAdapter | PhishTankAdapter):
+    return adapter.collect(
+        collection_job_id=JOB_ID,
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _entry(path: Path, source_id: str) -> SourceRegistryEntry:
+    return {entry.policy.id: entry for entry in load_source_registry(path)}[source_id]
+
+
+def _sec_target() -> SecIncidentTarget:
+    return SecIncidentTarget(
+        target_id="issuer-example",
+        organization_id=ORGANIZATION_ID,
+        cik="0000320193",
+        enabled=True,
+    )
+
+
+def _empty_recent() -> dict[str, list[object]]:
+    return {
+        "accessionNumber": [],
+        "filingDate": [],
+        "reportDate": [],
+        "acceptanceDateTime": [],
+        "form": [],
+        "items": [],
+    }
+
+
+def _json_response(payload: object) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "application/json"},
+        content=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _fail_network(_request: httpx.Request) -> httpx.Response:
+    raise AssertionError("network must not run")

--- a/tests/unit/collection_orchestration/test_incident_telemetry_runtime.py
+++ b/tests/unit/collection_orchestration/test_incident_telemetry_runtime.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.modules.collection_orchestration.application.runtime import build_collection_runtime
+from cip.shared.config.settings import Settings
+from cip.shared.persistence.metadata import get_metadata
+from cip.shared.persistence.session import create_database_engine
+
+
+def test_runtime_registers_sa04_adapters_with_deployment_schedules_disabled(
+    tmp_path: Path,
+) -> None:
+    settings = Settings(
+        _env_file=None,
+        database_url=f"sqlite+pysqlite:///{tmp_path / 'sa04-runtime.db'}",
+    )
+    get_metadata().create_all(create_database_engine(settings.database_url))
+
+    runtime = build_collection_runtime(settings)
+
+    assert ("sec-cyber-disclosures", "sec-submissions-item-1-05") in runtime.adapters
+    assert ("phishtank-verified-online", "phishtank-online-valid-json") in runtime.adapters
+    schedules = {
+        (schedule.source_id, schedule.adapter_id): schedule
+        for schedule in runtime.schedules
+        if schedule.source_id in {"sec-cyber-disclosures", "phishtank-verified-online"}
+    }
+    assert set(schedules) == {
+        ("sec-cyber-disclosures", "sec-submissions-item-1-05"),
+        ("phishtank-verified-online", "phishtank-online-valid-json"),
+    }
+    assert all(not schedule.enabled for schedule in schedules.values())

--- a/tests/unit/collection_orchestration/test_intelligence_adapter_support.py
+++ b/tests/unit/collection_orchestration/test_intelligence_adapter_support.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from cip.modules.collection_orchestration.application.intelligence_adapter_support import (
+    get_json,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+
+TARGET_URL = "https://provider.example.test/data"
+
+
+def test_get_json_marks_rate_limit_as_retryable() -> None:
+    with httpx.Client(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(429))
+    ) as client:
+        with pytest.raises(AdapterExecutionError) as error:
+            get_json(client, TARGET_URL, headers={})
+
+    assert error.value.error_code == "http_429"
+    assert error.value.retryable is True
+    assert str(error.value) == "intelligence provider returned HTTP 429"
+
+
+def test_get_json_rejects_non_json_response() -> None:
+    with httpx.Client(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                content=b"<html></html>",
+            )
+        )
+    ) as client:
+        with pytest.raises(AdapterExecutionError) as error:
+            get_json(client, TARGET_URL, headers={})
+
+    assert error.value.error_code == "unsafe_source_response"
+    assert error.value.retryable is False
+    assert str(error.value) == "intelligence provider response is not JSON"
+
+
+def test_get_json_rejects_response_over_explicit_bound() -> None:
+    with httpx.Client(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                content=b"12345",
+            )
+        )
+    ) as client:
+        with pytest.raises(AdapterExecutionError) as error:
+            get_json(client, TARGET_URL, headers={}, max_bytes=4)
+
+    assert error.value.error_code == "unsafe_source_response"
+    assert str(error.value) == "intelligence provider response exceeds size limit"
+
+
+@pytest.mark.parametrize("max_bytes", [0, -1, 64 * 1024 * 1024 + 1])
+def test_get_json_rejects_invalid_response_bound(max_bytes: int) -> None:
+    with httpx.Client(transport=httpx.MockTransport(_fail_network)) as client:
+        with pytest.raises(ValueError, match="outside the intelligence response bound"):
+            get_json(client, TARGET_URL, headers={}, max_bytes=max_bytes)
+
+
+def _fail_network(_request: httpx.Request) -> httpx.Response:
+    raise AssertionError("invalid bounds must fail before network")

--- a/tests/unit/collection_orchestration/test_intelligence_adapter_support.py
+++ b/tests/unit/collection_orchestration/test_intelligence_adapter_support.py
@@ -12,11 +12,13 @@ TARGET_URL = "https://provider.example.test/data"
 
 
 def test_get_json_marks_rate_limit_as_retryable() -> None:
-    with httpx.Client(
-        transport=httpx.MockTransport(lambda _request: httpx.Response(429))
-    ) as client:
-        with pytest.raises(AdapterExecutionError) as error:
-            get_json(client, TARGET_URL, headers={})
+    with (
+        httpx.Client(
+            transport=httpx.MockTransport(lambda _request: httpx.Response(429))
+        ) as client,
+        pytest.raises(AdapterExecutionError) as error,
+    ):
+        get_json(client, TARGET_URL, headers={})
 
     assert error.value.error_code == "http_429"
     assert error.value.retryable is True
@@ -24,17 +26,19 @@ def test_get_json_marks_rate_limit_as_retryable() -> None:
 
 
 def test_get_json_rejects_non_json_response() -> None:
-    with httpx.Client(
-        transport=httpx.MockTransport(
-            lambda _request: httpx.Response(
-                200,
-                headers={"content-type": "text/html"},
-                content=b"<html></html>",
+    with (
+        httpx.Client(
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    headers={"content-type": "text/html"},
+                    content=b"<html></html>",
+                )
             )
-        )
-    ) as client:
-        with pytest.raises(AdapterExecutionError) as error:
-            get_json(client, TARGET_URL, headers={})
+        ) as client,
+        pytest.raises(AdapterExecutionError) as error,
+    ):
+        get_json(client, TARGET_URL, headers={})
 
     assert error.value.error_code == "unsafe_source_response"
     assert error.value.retryable is False
@@ -42,17 +46,19 @@ def test_get_json_rejects_non_json_response() -> None:
 
 
 def test_get_json_rejects_response_over_explicit_bound() -> None:
-    with httpx.Client(
-        transport=httpx.MockTransport(
-            lambda _request: httpx.Response(
-                200,
-                headers={"content-type": "application/json"},
-                content=b"12345",
+    with (
+        httpx.Client(
+            transport=httpx.MockTransport(
+                lambda _request: httpx.Response(
+                    200,
+                    headers={"content-type": "application/json"},
+                    content=b"12345",
+                )
             )
-        )
-    ) as client:
-        with pytest.raises(AdapterExecutionError) as error:
-            get_json(client, TARGET_URL, headers={}, max_bytes=4)
+        ) as client,
+        pytest.raises(AdapterExecutionError) as error,
+    ):
+        get_json(client, TARGET_URL, headers={}, max_bytes=4)
 
     assert error.value.error_code == "unsafe_source_response"
     assert str(error.value) == "intelligence provider response exceeds size limit"
@@ -60,9 +66,11 @@ def test_get_json_rejects_response_over_explicit_bound() -> None:
 
 @pytest.mark.parametrize("max_bytes", [0, -1, 64 * 1024 * 1024 + 1])
 def test_get_json_rejects_invalid_response_bound(max_bytes: int) -> None:
-    with httpx.Client(transport=httpx.MockTransport(_fail_network)) as client:
-        with pytest.raises(ValueError, match="outside the intelligence response bound"):
-            get_json(client, TARGET_URL, headers={}, max_bytes=max_bytes)
+    with (
+        httpx.Client(transport=httpx.MockTransport(_fail_network)) as client,
+        pytest.raises(ValueError, match="outside the intelligence response bound"),
+    ):
+        get_json(client, TARGET_URL, headers={}, max_bytes=max_bytes)
 
 
 def _fail_network(_request: httpx.Request) -> httpx.Response:

--- a/tests/unit/collection_orchestration/test_intelligence_transport_redaction.py
+++ b/tests/unit/collection_orchestration/test_intelligence_transport_redaction.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+
+from cip.modules.collection_orchestration.application.phishtank_adapter import PhishTankAdapter
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+NOW = datetime(2026, 8, 9, 23, 30, tzinfo=UTC)
+
+
+def test_phishtank_transport_error_never_exposes_key_from_request_url() -> None:
+    entry = {
+        item.policy.id: item
+        for item in load_source_registry(Path("policies/sources.threat_telemetry.yml"))
+    }["phishtank-verified-online"]
+
+    def failing_transport(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(f"failed to connect to {request.url}", request=request)
+
+    adapter = PhishTankAdapter(
+        entry,
+        token_provider=lambda: "secret-key",
+        user_agent="CIP contact@example.com",
+        transport=httpx.MockTransport(failing_transport),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        adapter.collect(
+            collection_job_id=UUID("00000000-0000-0000-0000-000000000408"),
+            checkpoint_payload=None,
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+    assert error.value.error_code == "source_transport_error"
+    assert error.value.retryable is True
+    assert str(error.value) == "intelligence provider transport failure"
+    assert "secret-key" not in str(error.value)

--- a/tests/unit/provider_onboarding/test_provider_registry.py
+++ b/tests/unit/provider_onboarding/test_provider_registry.py
@@ -13,7 +13,7 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     profiles = load_provider_profiles(Path("policies/provider_onboarding.yml"))
     by_source = {profile.source_id: profile for profile in profiles}
 
-    assert len(profiles) == 18
+    assert len(profiles) == 20
     assert by_source["cisa-kev"].initial_state is OnboardingState.CONNECTED
     assert by_source["sirene-api"].auth_mode is AuthMode.NONE
     assert by_source["inpi-rne"].required_secret_names == ("username", "password")
@@ -26,6 +26,11 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     assert by_source["certspotter-ct"].auth_mode is AuthMode.API_KEY
     assert by_source["certspotter-ct"].required_secret_names == ("api_token",)
     assert by_source["certspotter-ct"].initial_state is OnboardingState.NOT_CONFIGURED
+    assert by_source["sec-cyber-disclosures"].auth_mode is AuthMode.NONE
+    assert by_source["sec-cyber-disclosures"].initial_state is OnboardingState.CONNECTED
+    assert by_source["phishtank-verified-online"].auth_mode is AuthMode.API_KEY
+    assert by_source["phishtank-verified-online"].required_secret_names == ("api_token",)
+    assert by_source["phishtank-verified-online"].initial_state is OnboardingState.NOT_CONFIGURED
     assert by_source["linkedin-official-api"].initial_state is OnboardingState.NOT_CONFIGURED
     assert by_source["linkedin-authorized-browser"].initial_state is OnboardingState.BLOCKED
     assert by_source["brixhub"].initial_state is OnboardingState.BLOCKED

--- a/tests/unit/test_incident_source_registries.py
+++ b/tests/unit/test_incident_source_registries.py
@@ -12,13 +12,14 @@ from cip.modules.source_portfolio.infrastructure.registry import load_source_por
 
 SOURCE_PATH = Path("policies/sources.incidents.yml")
 PORTFOLIO_PATH = Path("policies/source_portfolio.incidents.yml")
-EXPECTED_IDS = {
-    "sec-cyber-disclosures",
+SEC_SOURCE_ID = "sec-cyber-disclosures"
+CANDIDATE_IDS = {
     "official-company-incident-disclosures",
     "regulator-cert-incident-notices",
     "licensed-incident-reporting",
     "licensed-ransomware-metadata",
 }
+EXPECTED_IDS = CANDIDATE_IDS | {SEC_SOURCE_ID}
 PROHIBITED = {
     DataCategory.CREDENTIAL,
     DataCategory.VICTIM_FILE,
@@ -28,13 +29,22 @@ PROHIBITED = {
 }
 
 
-def test_incident_sources_are_governed_but_not_authorized() -> None:
+def test_incident_sources_preserve_governance_across_activation_states() -> None:
     entries = load_source_registry(SOURCE_PATH)
+    by_id = {entry.policy.id: entry for entry in entries}
 
-    assert {entry.policy.id for entry in entries} == EXPECTED_IDS
-    assert all(entry.policy.status is SourceStatus.DRAFT for entry in entries)
-    assert all(not entry.authorization.automated_collection_allowed for entry in entries)
-    assert all(not entry.authorization.approved_hosts for entry in entries)
+    assert set(by_id) == EXPECTED_IDS
+    sec = by_id[SEC_SOURCE_ID]
+    assert sec.policy.status is SourceStatus.ENABLED
+    assert sec.authorization.automated_collection_allowed is True
+    assert sec.authorization.approved_hosts == frozenset({"data.sec.gov"})
+
+    for source_id in CANDIDATE_IDS:
+        entry = by_id[source_id]
+        assert entry.policy.status is SourceStatus.DRAFT
+        assert entry.authorization.automated_collection_allowed is False
+        assert not entry.authorization.approved_hosts
+
     assert all(
         entry.policy.prohibited_data_categories >= PROHIBITED
         for entry in entries
@@ -42,13 +52,22 @@ def test_incident_sources_are_governed_but_not_authorized() -> None:
     assert all(not entry.policy.raw_content_storage for entry in entries)
 
 
-def test_incident_portfolio_entries_are_non_executable_candidates() -> None:
+def test_incident_portfolio_distinguishes_sec_from_candidates() -> None:
     entries = load_source_portfolio(PORTFOLIO_PATH)
+    by_id = {entry.source_id: entry for entry in entries}
 
-    assert {entry.source_id for entry in entries} == EXPECTED_IDS
-    assert all(entry.status is CatalogStatus.CANDIDATE for entry in entries)
-    assert all(not entry.executable for entry in entries)
-    assert all(entry.adapter is not None for entry in entries)
+    assert set(by_id) == EXPECTED_IDS
+    sec = by_id[SEC_SOURCE_ID]
+    assert sec.status is CatalogStatus.EXECUTABLE
+    assert sec.executable is True
+    assert sec.adapter is not None
+
+    for source_id in CANDIDATE_IDS:
+        entry = by_id[source_id]
+        assert entry.status is CatalogStatus.CANDIDATE
+        assert entry.executable is False
+        assert entry.adapter is not None
+
     assert all(
         entry.metadata.get("victim_content_collection") == "forbidden"
         for entry in entries

--- a/tests/unit/test_incident_telemetry_source_registries.py
+++ b/tests/unit/test_incident_telemetry_source_registries.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.modules.collection_orchestration.infrastructure.schedule_loader import (
+    load_collection_schedules,
+)
+from cip.modules.source_governance.domain.models import AuthorizationStatus, SourceStatus
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_portfolio.domain.models import CatalogStatus
+from cip.modules.source_portfolio.infrastructure.registry import load_source_portfolio
+
+INCIDENT_SOURCE_PATH = Path("policies/sources.incidents.yml")
+TELEMETRY_SOURCE_PATH = Path("policies/sources.threat_telemetry.yml")
+INCIDENT_PORTFOLIO_PATH = Path("policies/source_portfolio.incidents.yml")
+TELEMETRY_PORTFOLIO_PATH = Path("policies/source_portfolio.threat_telemetry.yml")
+INCIDENT_SCHEDULE_PATH = Path("policies/collection_schedules.incidents.yml")
+TELEMETRY_SCHEDULE_PATH = Path("policies/collection_schedules.threat_telemetry.yml")
+
+
+def test_sec_source_is_enabled_with_exact_metadata_only_authorization() -> None:
+    entry = _source(INCIDENT_SOURCE_PATH, "sec-cyber-disclosures")
+
+    assert entry.policy.status is SourceStatus.ENABLED
+    assert entry.authorization.status is AuthorizationStatus.APPROVED
+    assert entry.authorization.approved_hosts == {"data.sec.gov"}
+    assert entry.authorization.approved_path_prefixes == ("/submissions/",)
+    assert entry.authorization.approved_purposes == {"incident-intelligence"}
+    assert entry.authorization.automated_collection_allowed is True
+    assert entry.policy.raw_content_storage is False
+    assert entry.authorization.raw_storage_allowed is False
+
+
+def test_phishtank_source_is_enabled_with_exact_metadata_only_authorization() -> None:
+    entry = _source(TELEMETRY_SOURCE_PATH, "phishtank-verified-online")
+
+    assert entry.policy.status is SourceStatus.ENABLED
+    assert entry.authorization.status is AuthorizationStatus.APPROVED
+    assert entry.authorization.approved_hosts == {"data.phishtank.com"}
+    assert entry.authorization.approved_path_prefixes == ("/data/",)
+    assert entry.authorization.approved_purposes == {"threat-telemetry"}
+    assert entry.authorization.automated_collection_allowed is True
+    assert entry.policy.raw_content_storage is False
+    assert entry.authorization.raw_storage_allowed is False
+
+
+def test_sa04_portfolios_are_executable_without_compromise_or_opportunity_authority() -> None:
+    sec = _portfolio(INCIDENT_PORTFOLIO_PATH, "sec-cyber-disclosures")
+    phishtank = _portfolio(TELEMETRY_PORTFOLIO_PATH, "phishtank-verified-online")
+
+    assert sec.status is CatalogStatus.EXECUTABLE
+    assert sec.executable is True
+    assert sec.metadata["filing_narrative_collection"] == "forbidden"
+    assert sec.metadata["global_issuer_enumeration"] == "forbidden"
+    assert sec.metadata["automatic_opportunity"] == "forbidden"
+    assert sec.metadata["autonomous_outreach"] == "forbidden"
+
+    assert phishtank.status is CatalogStatus.EXECUTABLE
+    assert phishtank.executable is True
+    assert phishtank.metadata["phishing_url_visit"] == "forbidden"
+    assert phishtank.metadata["direct_indicator_connection"] == "forbidden"
+    assert phishtank.metadata["target_brand_as_compromise"] == "forbidden"
+    assert phishtank.metadata["organization_compromise_inference"] == "forbidden"
+    assert phishtank.metadata["automatic_opportunity"] == "forbidden"
+
+
+def test_sa04_schedules_are_present_but_disabled_by_default() -> None:
+    schedules = (
+        *load_collection_schedules(INCIDENT_SCHEDULE_PATH),
+        *load_collection_schedules(TELEMETRY_SCHEDULE_PATH),
+    )
+
+    assert {(item.source_id, item.adapter_id) for item in schedules} == {
+        ("sec-cyber-disclosures", "sec-submissions-item-1-05"),
+        ("phishtank-verified-online", "phishtank-online-valid-json"),
+    }
+    assert all(schedule.enabled is False for schedule in schedules)
+
+
+def _source(path: Path, source_id: str):
+    return {entry.policy.id: entry for entry in load_source_registry(path)}[source_id]
+
+
+def _portfolio(path: Path, source_id: str):
+    return {entry.source_id: entry for entry in load_source_portfolio(path)}[source_id]

--- a/tests/unit/test_threat_telemetry_source_registries.py
+++ b/tests/unit/test_threat_telemetry_source_registries.py
@@ -9,13 +9,15 @@ from cip.modules.source_portfolio.infrastructure.registry import load_source_por
 
 SOURCE_PATH = Path("policies/sources.threat_telemetry.yml")
 PORTFOLIO_PATH = Path("policies/source_portfolio.threat_telemetry.yml")
-EXPECTED_IDS = {
+PHISHTANK_SOURCE_ID = "phishtank-verified-online"
+CANDIDATE_IDS = {
     "licensed-stix-taxii",
     "licensed-phishing-metadata",
     "licensed-passive-dns",
     "licensed-certificate-telemetry",
     "licensed-malware-metadata",
 }
+EXPECTED_IDS = CANDIDATE_IDS | {PHISHTANK_SOURCE_ID}
 PROHIBITED = {
     DataCategory.CREDENTIAL,
     DataCategory.VICTIM_FILE,
@@ -25,13 +27,22 @@ PROHIBITED = {
 }
 
 
-def test_threat_sources_are_governed_but_not_authorized() -> None:
+def test_threat_sources_preserve_governance_across_activation_states() -> None:
     entries = load_source_registry(SOURCE_PATH)
+    by_id = {entry.policy.id: entry for entry in entries}
 
-    assert {entry.policy.id for entry in entries} == EXPECTED_IDS
-    assert all(entry.policy.status is SourceStatus.DRAFT for entry in entries)
-    assert all(not entry.authorization.automated_collection_allowed for entry in entries)
-    assert all(not entry.authorization.approved_hosts for entry in entries)
+    assert set(by_id) == EXPECTED_IDS
+    phishtank = by_id[PHISHTANK_SOURCE_ID]
+    assert phishtank.policy.status is SourceStatus.ENABLED
+    assert phishtank.authorization.automated_collection_allowed is True
+    assert phishtank.authorization.approved_hosts == frozenset({"data.phishtank.com"})
+
+    for source_id in CANDIDATE_IDS:
+        entry = by_id[source_id]
+        assert entry.policy.status is SourceStatus.DRAFT
+        assert entry.authorization.automated_collection_allowed is False
+        assert not entry.authorization.approved_hosts
+
     assert all(
         entry.policy.prohibited_data_categories >= PROHIBITED
         for entry in entries
@@ -39,13 +50,22 @@ def test_threat_sources_are_governed_but_not_authorized() -> None:
     assert all(not entry.policy.raw_content_storage for entry in entries)
 
 
-def test_threat_portfolio_entries_are_non_executable_candidates() -> None:
+def test_threat_portfolio_distinguishes_phishtank_from_candidates() -> None:
     entries = load_source_portfolio(PORTFOLIO_PATH)
+    by_id = {entry.source_id: entry for entry in entries}
 
-    assert {entry.source_id for entry in entries} == EXPECTED_IDS
-    assert all(entry.status is CatalogStatus.CANDIDATE for entry in entries)
-    assert all(not entry.executable for entry in entries)
-    assert all(entry.adapter is not None for entry in entries)
+    assert set(by_id) == EXPECTED_IDS
+    phishtank = by_id[PHISHTANK_SOURCE_ID]
+    assert phishtank.status is CatalogStatus.EXECUTABLE
+    assert phishtank.executable is True
+    assert phishtank.adapter is not None
+
+    for source_id in CANDIDATE_IDS:
+        entry = by_id[source_id]
+        assert entry.status is CatalogStatus.CANDIDATE
+        assert entry.executable is False
+        assert entry.adapter is not None
+
     assert all(
         entry.metadata.get("direct_indicator_connection") == "forbidden"
         for entry in entries


### PR DESCRIPTION
Closes #72

## SA-04 — governed CTI, incidents and threat telemetry

Clean base: merged SA-03 squash `2607593a94ec7cc5607586f466cddd3af1222102`.

### Implemented executable provider scope
- SEC EDGAR targeted Item 1.05 cybersecurity disclosure metadata;
- PhishTank verified-online defensive phishing metadata.

### Canonical persistence
- `AdapterCollectionBatch` carries Lot 14 `incident_claims` and Lot 15 `threat_indicator_snapshots`;
- incremental worker persists both through the existing Lot 14/15 projection layers;
- historical backfill persists the same projections transactionally;
- no new incident/telemetry persistence schema was introduced.

### Safety / evidence semantics
- SEC is target-bound by explicit CIK registry, metadata-only, validates response CIK, filters non-amended Item 1.05 filings, does not invent occurrence dates or incident type, and drains capped backlogs without skipping filings;
- PhishTank remains global threat telemetry only: no brand-compromise inference, no IOC visit/direct validation, Provider Onboarding secret only, and transport errors are redacted so application keys cannot leak through persisted errors;
- schedules are disabled by default and `live_tested` remains false;
- no threat-actor portal interaction, `.onion` access, victim files, credentials, phishing-page visits, malicious infrastructure connection, active scanning, compromise inference, commercial signal/opportunity creation or outreach.

### Deferred by explicit disposition
- licensed incident reporting / ransomware metadata / STIX-TAXII / commercial phishing / malware metadata -> SA-07;
- generic incident/PSIRT/provider-family placeholders -> SA-10 provider decomposition/reconciliation.

### Review fixes
- P1 transport-error secret leakage: fixed with provider-agnostic error messages plus deterministic regression test;
- P2 SEC >100 filing backlog cursor: fixed with convergent capped batches plus deterministic `101 -> 100 + 1` no-skip/no-duplicate test.

### Exact final validation
Head SHA: `72d9c04c38ec8b5550dee58441d3f7484fcde178`
CI run: #1524
- Ruff: PASS
- Mypy strict: PASS (571 source files)
- Architecture/release contracts: PASS (36 tests)
- Alembic upgrade/downgrade/upgrade: PASS
- Full pytest: PASS — 1109 tests
- aggregate branch-aware coverage: 90.09%
- frontend audit/typecheck/build: PASS

No content change is permitted after this exact-head validation without rerunning the complete CI.