### PR TITLE
Priority B-1: governed RDAP passive registration metadata

### DIFF
--- a/docs/source_activation/PRIORITY_B_01_RDAP.md
+++ b/docs/source_activation/PRIORITY_B_01_RDAP.md
@@ -1,0 +1,72 @@
+# Priority B-1 — Governed Public RDAP
+
+## Objective
+
+Complete the open RDAP portion of Priority B without introducing a second passive-asset model or a generic web client.
+
+## Runtime path
+
+```text
+explicit RDAP target
+  -> IANA RFC 9224 bootstrap
+  -> exact HTTPS authoritative RDAP service
+  -> minimal public RDAP schema
+  -> sanitized RawObservation
+  -> Lot 16 PassiveObservationSnapshot(registration)
+  -> existing incremental/backfill persistence
+```
+
+The checked-in target registry is empty and the checked-in schedule is disabled, so a default deployment performs no RDAP network activity.
+
+## Supported targets
+
+- domain;
+- globally routable IPv4;
+- globally routable IPv6;
+- 32-bit ASN.
+
+Targets are normalized and bound to an internal organization UUID. Duplicate normalized resources are rejected.
+
+## Bootstrap matching
+
+- domains use the most specific matching DNS suffix;
+- IPv4/IPv6 use the longest matching prefix;
+- ASN uses the most specific containing numeric range.
+
+Only HTTPS endpoints from the matching IANA bootstrap entry are eligible. Redirects are disabled. The response is revalidated against the requested domain, IP allocation range, or ASN range before a snapshot is emitted.
+
+## Canonical evidence semantics
+
+RDAP is represented as `PassiveObservationKind.REGISTRATION` in Lot 16.
+
+The organization association is always `review_required` with `passive_correlation`. Registration or allocation does not prove current operational ownership. Attribution risks remain explicit:
+
+- domain -> `abandoned_domain`;
+- IP -> `reassigned_address`;
+- ASN -> `reseller`.
+
+All snapshots remain `metadata_only`, `passive_only`, with active probing, credential use, direct validation, applicability assessment, and exposure verification false through the Lot 16 model.
+
+## Privacy boundary
+
+The provider schema intentionally omits RDAP entities and vCard/contact structures. Unknown response fields are discarded by parsing. Raw HTTP response bytes are not stored; the persisted `RawObservation` hashes the sanitized structured provider model.
+
+No registrant email, phone, postal address, entity/vCard, nonpublic registration data, RDRS access, authentication, or contact enrichment belongs in this capability.
+
+## Activation state
+
+The adapter, governance entry, portfolio entry, schedule definition, runtime registration, target registry, and deterministic tests are present. `scheduled` and `live_tested` remain false until deployment activation and separately authorized controlled validation.
+
+## Completion tests
+
+B-1 must prove:
+
+- empty target registry -> no network;
+- domain bootstrap + exact identity;
+- IPv4 longest-prefix selection;
+- ASN range selection;
+- non-HTTPS authoritative endpoint fails closed;
+- response identity mismatch fails closed;
+- RDAP contacts/entities are not materialized;
+- governance/portfolio/schedule/runtime reconciliation;
+- full repository backend and frontend CI on one exact final SHA.

--- a/docs/source_activation/PRIORITY_B_RDAP_AUTHORIZATION.md
+++ b/docs/source_activation/PRIORITY_B_RDAP_AUTHORIZATION.md
@@ -1,0 +1,65 @@
+# Priority B — Public RDAP Authorization
+
+## Scope
+
+`iana-rdap-public` is a bounded public-registration capability for explicitly configured domain, IPv4, IPv6, and ASN targets. It is not a WHOIS contact harvester and it does not request nonpublic registration data.
+
+The adapter uses the IANA RDAP bootstrap registries defined by RFC 9224:
+
+- `https://data.iana.org/rdap/dns.json`
+- `https://data.iana.org/rdap/ipv4.json`
+- `https://data.iana.org/rdap/ipv6.json`
+- `https://data.iana.org/rdap/asn.json`
+
+The policy-authorized first hop is restricted to `data.iana.org/rdap/`.
+
+## Authoritative second-hop rule
+
+The authoritative RDAP endpoint is not supplied by a user, search result, redirect, or provider payload outside the IANA bootstrap document.
+
+For each target the adapter:
+
+1. downloads the matching IANA bootstrap registry over HTTPS;
+2. selects the most specific matching service for the domain suffix, IP prefix, or ASN range;
+3. accepts only an HTTPS base URL from that matching service;
+4. derives one exact resource URL under the same scheme and host;
+5. performs no redirect following;
+6. revalidates that the returned RDAP object covers the requested target.
+
+A bootstrap entry without an HTTPS endpoint fails closed. A derived URL that changes host, embeds credentials, or escapes the selected authoritative endpoint fails closed.
+
+## Public fields only
+
+The persisted provider model contains only a minimal registration/allocation subset needed for passive evidence:
+
+- object class;
+- public handle/name/domain identifier where applicable;
+- public IP allocation range or ASN range where applicable;
+- bounded status values and public event timestamps.
+
+RDAP `entities`, vCards, email addresses, telephone numbers, postal/contact records, registrant/administrative/technical contacts, and other person-oriented fields are intentionally absent from the materialized schema. Unknown provider fields are ignored before `RawObservation` is constructed; the raw HTTP response body itself is not stored.
+
+## Explicit exclusions
+
+The capability must not:
+
+- use ICANN RDRS or another nonpublic-registration access path;
+- authenticate to retrieve nonpublic registration data;
+- harvest registrant or contact PII;
+- enumerate targets not explicitly present in the deployment target registry;
+- use RDAP registration/allocation as proof of current operational ownership;
+- infer deployment, vulnerability applicability, exposure, compromise, need, opportunity, or outreach authorization;
+- actively probe, connect to, scan, or exploit the returned resource.
+
+## Target and schedule activation
+
+`policies/rdap_targets.yml` is checked in empty. The RDAP schedule is checked in disabled. Deployment activation requires explicit organization-bound targets and an operational decision to enable the schedule.
+
+`live_tested` remains false until a separately authorized controlled provider validation is recorded on an exact release candidate.
+
+## References reviewed
+
+- RFC 9224, *Finding the Authoritative Registration Data (RDAP) Service*: https://www.rfc-editor.org/rfc/rfc9224
+- IANA RDAP bootstrap registries: https://data.iana.org/rdap/
+- ICANN RDAP resources: https://www.icann.org/en/contracted-parties/registry-operators/resources/registration-data-access-protocol
+- ICANN Registration Data Request Service information: https://www.icann.org/rdrs-en

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -40,6 +40,7 @@ Symbols:
 | Internet Archive CDX | SA-02 | Y | Y | Y | Y | Y | - | bounded weekly historical metadata discovery; live proof outstanding |
 | Cloudflare DNS-over-HTTPS | SA-03 | Y | Y | Y | Y | N/A | - | target-driven A/AAAA passive lookup; checked-in target registry empty; live proof outstanding |
 | Cert Spotter CT Search API | SA-03 | Y | Y | Y | Y | N/A | - | target-driven CT lookup; production API key/onboarding and deployment target required; live proof outstanding |
+| IANA-bootstrapped public RDAP | Priority B-1 | Y | Y | Y | Y | N/A | - | target-driven public registration/allocation metadata; checked-in target registry empty; live proof outstanding |
 | SEC EDGAR cybersecurity disclosures | SA-04 | Y | Y | Y | Y | N/A | - | targeted Item 1.05 metadata capability; CIK target registry empty and deployment User-Agent required |
 | PhishTank verified online phishing data | SA-04 | Y | Y | Y | Y | N/A | - | global URL telemetry capability; application key/onboarding and deployment User-Agent required |
 | Licensed incident reporting | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
@@ -63,13 +64,31 @@ Symbols:
 
 The repository already models additional candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. Candidate families remain non-executable until a concrete provider, method and authorization are selected.
 
-SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
+SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Priority B completion continues the same provider-level discipline for passive organization and technology evidence. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
 
 ## Reconciliation invariant
 
-Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA.
+Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA/Priority-B increment.
 
 OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10 closes.
+
+## Priority B-1 RDAP completion boundary
+
+Priority B-1 is complete only when:
+
+- `iana-rdap-public` is registered in the shared collection runtime and maps to immutable sanitized RawObservations plus Lot 16 passive snapshots;
+- the checked-in RDAP target registry is empty and the checked-in schedule is disabled;
+- only explicit organization-bound domain, globally routable IPv4/IPv6 and ASN targets are accepted;
+- the first hop is restricted by Source Governance to IANA RFC 9224 bootstrap data under `data.iana.org/rdap/`;
+- the second hop is an HTTPS authoritative base URL selected from the matching IANA bootstrap service and cannot be supplied by a user or redirect;
+- domain suffix, IP longest-prefix and ASN narrowest-range matching are deterministic;
+- authoritative RDAP responses are revalidated to cover the exact requested domain/IP/ASN before persistence;
+- RDAP entities, vCards, emails, telephone numbers and other contact/person fields are not materialized into the provider schema or RawObservation;
+- nonpublic RDAP/RDRS access and authenticated enumeration remain outside scope;
+- registration/allocation evidence is `review_required` passive correlation and never proves current operational ownership, deployment, exposure or compromise;
+- incremental and historical backfill reuse the existing Lot 16 transactional persistence path;
+- deterministic registry/adapter/runtime/reconciliation tests and full repository CI pass on one exact final SHA;
+- `live_tested` remains false until separately authorized controlled provider validation is evidenced.
 
 ## SA-03 completion boundary
 

--- a/policies/collection_schedules.passive_infrastructure.yml
+++ b/policies/collection_schedules.passive_infrastructure.yml
@@ -24,3 +24,15 @@ schedules:
       max_delay_seconds: 3600
       circuit_failure_threshold: 3
       circuit_reset_seconds: 3600
+
+  - source_id: iana-rdap-public
+    adapter_id: iana-bootstrap-rdap
+    enabled: false
+    interval_seconds: 86400
+    lease_seconds: 180
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 300
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600

--- a/policies/rdap_targets.yml
+++ b/policies/rdap_targets.yml
@@ -1,0 +1,2 @@
+version: 1
+targets: []

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -267,6 +267,14 @@ sources:
     requires_schedule: false
     stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
+  - source_id: iana-rdap-public
+    display_name: IANA-bootstrapped public RDAP
+    category: passive_exposure
+    disposition: active
+    activation_wave: Priority-B
+    requires_schedule: false
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
+
   - source_id: official-vendor-psirt
     display_name: Official Vendor PSIRT Advisories
     category: vulnerability_advisory

--- a/policies/source_portfolio.passive_infrastructure.yml
+++ b/policies/source_portfolio.passive_infrastructure.yml
@@ -93,6 +93,7 @@ sources:
       contact_materialization: forbidden
       authoritative_endpoint_must_match_iana_bootstrap: true
       active_probe: forbidden
+      direct_asset_connection: forbidden
       authenticated_enumeration: forbidden
       vulnerability_applicability: not_assessed
       exposure_verification: forbidden

--- a/policies/source_portfolio.passive_infrastructure.yml
+++ b/policies/source_portfolio.passive_infrastructure.yml
@@ -73,3 +73,42 @@ sources:
       supports_retractions: false
       max_page_size: 100
       cost_per_request: 0
+
+  - source_id: iana-rdap-public
+    display_name: IANA-bootstrapped public RDAP
+    canonical_url: https://data.iana.org/rdap/
+    category: passive_exposure
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases:
+      - passive_registration_context
+      - organization_research
+    candidate_origin: Priority-B
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      target_registry_required: true
+      public_fields_only: true
+      contact_materialization: forbidden
+      authoritative_endpoint_must_match_iana_bootstrap: true
+      active_probe: forbidden
+      authenticated_enumeration: forbidden
+      vulnerability_applicability: not_assessed
+      exposure_verification: forbidden
+      organization_compromise_inference: forbidden
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: iana-bootstrap-rdap
+      adapter_version: "1"
+      provider_schema_version: rdap-public-minimal-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - passive_asset
+        - passive_observation_snapshot
+      supports_corrections: false
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 1
+      cost_per_request: 0

--- a/policies/sources.passive_infrastructure.yml
+++ b/policies/sources.passive_infrastructure.yml
@@ -1,5 +1,5 @@
 version: 1
-reviewed_at: 2026-08-09
+reviewed_at: 2026-08-10
 
 sources:
   - id: cloudflare-doh
@@ -76,3 +76,41 @@ sources:
     notes: >-
       Production execution requires connected Provider Onboarding with secret reference api_token.
       Certificate issuance is passive CT metadata and never verifies endpoint deployment or exposure.
+
+  - id: iana-rdap-public
+    name: IANA-bootstrapped public RDAP
+    base_url: https://data.iana.org/rdap/
+    status: enabled
+    source_type: api
+    owner: IANA bootstrap / authoritative RDAP operators
+    terms_url: https://www.icann.org/en/contracted-parties/registry-operators/resources/registration-data-access-protocol
+    licence: Public query-based RDAP; public fields only; RFC 9224 bootstrap discovery
+    allowed_data_categories: [technology_observation]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 6
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/PRIORITY_B_RDAP_AUTHORIZATION.md
+      reviewed_at: "2026-08-10T10:40:00+00:00"
+      expires_at: null
+      approved_hosts: [data.iana.org]
+      approved_path_prefixes: [/rdap/]
+      approved_purposes: [passive-infrastructure-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: high
+    notes: >-
+      Explicit domain/IP/ASN targets only. The policy-authorized first hop is IANA bootstrap.
+      A second HTTPS request is permitted only to an exact authoritative base URL selected from
+      that matching bootstrap response. The materialized schema excludes RDAP entities, vCards,
+      email addresses, telephone numbers and nonpublic-data access. Registration/allocation
+      metadata never proves current operational ownership, deployment, exposure or compromise.

--- a/src/cip/adapters/sources/passive_exposure_catalogs/schemas.py
+++ b/src/cip/adapters/sources/passive_exposure_catalogs/schemas.py
@@ -23,6 +23,7 @@ class ProviderObservationKind(StrEnum):
     PASSIVE_DNS = "passive_dns"
     CERTIFICATE = "certificate"
     ASN = "asn"
+    REGISTRATION = "registration"
     CLOUD = "cloud"
     SERVICE = "service"
     PORT = "port"

--- a/src/cip/adapters/sources/passive_infrastructure/rdap_registry.py
+++ b/src/cip/adapters/sources/passive_infrastructure/rdap_registry.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from pathlib import Path
+from uuid import UUID
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from cip.modules.passive_exposure.domain.normalization import normalize_domain
+
+
+class RdapTargetKind(StrEnum):
+    DOMAIN = "domain"
+    IPV4 = "ipv4"
+    IPV6 = "ipv6"
+    ASN = "asn"
+
+
+class RdapTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    target_id: str = Field(min_length=1, max_length=200)
+    organization_id: UUID
+    kind: RdapTargetKind
+    value: str = Field(min_length=1, max_length=253)
+    enabled: bool = False
+
+    @model_validator(mode="after")
+    def normalize_value(self) -> RdapTarget:
+        if self.kind is RdapTargetKind.DOMAIN:
+            self.value = _domain(self.value)
+        elif self.kind is RdapTargetKind.IPV4:
+            self.value = str(_ip(self.value, IPv4Address))
+        elif self.kind is RdapTargetKind.IPV6:
+            self.value = str(_ip(self.value, IPv6Address))
+        else:
+            self.value = _asn(self.value)
+        return self
+
+
+class RdapTargetFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    targets: list[RdapTarget] = Field(default_factory=list, max_length=500)
+
+
+def load_rdap_targets(path: Path) -> tuple[RdapTarget, ...]:
+    parsed = RdapTargetFile.model_validate(yaml.safe_load(path.read_text(encoding="utf-8")))
+    targets = tuple(parsed.targets)
+    target_ids = [target.target_id for target in targets]
+    identities = [(target.kind, target.value) for target in targets]
+    if len(target_ids) != len(set(target_ids)):
+        raise ValueError("duplicate RDAP target_id")
+    if len(identities) != len(set(identities)):
+        raise ValueError("duplicate RDAP target resource")
+    return targets
+
+
+def _domain(value: str) -> str:
+    candidate = value.rstrip(".")
+    try:
+        ip_address(candidate)
+    except ValueError:
+        return normalize_domain(candidate)
+    raise ValueError("RDAP domain target cannot be an IP literal")
+
+
+def _ip(value: str, expected: type[IPv4Address] | type[IPv6Address]):
+    parsed = ip_address(value)
+    if not isinstance(parsed, expected):
+        raise ValueError(f"RDAP target must be {expected.__name__}")
+    if not parsed.is_global:
+        raise ValueError("RDAP IP target must be globally routable")
+    return parsed
+
+
+def _asn(value: str) -> str:
+    candidate = value.upper().removeprefix("AS")
+    if not candidate.isdigit():
+        raise ValueError("RDAP ASN target must be an AS number")
+    number = int(candidate)
+    if not 1 <= number <= 4_294_967_295:
+        raise ValueError("RDAP ASN target is outside the 32-bit AS number range")
+    return f"AS{number}"

--- a/src/cip/adapters/sources/passive_infrastructure/rdap_registry.py
+++ b/src/cip/adapters/sources/passive_infrastructure/rdap_registry.py
@@ -68,7 +68,10 @@ def _domain(value: str) -> str:
     raise ValueError("RDAP domain target cannot be an IP literal")
 
 
-def _ip(value: str, expected: type[IPv4Address] | type[IPv6Address]):
+def _ip(
+    value: str,
+    expected: type[IPv4Address] | type[IPv6Address],
+) -> IPv4Address | IPv6Address:
     parsed = ip_address(value)
     if not isinstance(parsed, expected):
         raise ValueError(f"RDAP target must be {expected.__name__}")

--- a/src/cip/adapters/sources/passive_infrastructure/rdap_schemas.py
+++ b/src/cip/adapters/sources/passive_infrastructure/rdap_schemas.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class IanaRdapBootstrap(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    version: str = Field(min_length=1, max_length=20)
+    publication: datetime
+    services: list[tuple[list[str], list[str]]] = Field(max_length=20_000)
+
+    @model_validator(mode="after")
+    def validate_services(self) -> IanaRdapBootstrap:
+        for keys, urls in self.services:
+            if not keys or not urls:
+                raise ValueError("IANA RDAP bootstrap service entries cannot be empty")
+            if len(keys) > 20_000 or len(urls) > 20:
+                raise ValueError("IANA RDAP bootstrap service entry exceeds bounds")
+        return self
+
+
+class RdapEvent(BaseModel):
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    eventAction: str = Field(min_length=1, max_length=100)
+    eventDate: datetime
+
+
+class PublicRdapObject(BaseModel):
+    """Strict minimal public subset; entity/vCard/contact data is never materialized."""
+
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    objectClassName: str = Field(min_length=1, max_length=100)
+    handle: str | None = Field(default=None, max_length=500)
+    ldhName: str | None = Field(default=None, max_length=253)
+    name: str | None = Field(default=None, max_length=500)
+    type: str | None = Field(default=None, max_length=100)
+    startAddress: str | None = Field(default=None, max_length=64)
+    endAddress: str | None = Field(default=None, max_length=64)
+    ipVersion: str | None = Field(default=None, max_length=20)
+    startAutnum: int | None = Field(default=None, ge=0, le=4_294_967_295)
+    endAutnum: int | None = Field(default=None, ge=0, le=4_294_967_295)
+    status: list[str] = Field(default_factory=list, max_length=100)
+    events: list[RdapEvent] = Field(default_factory=list, max_length=200)

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -7,6 +7,7 @@ from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
 from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
 from cip.adapters.sources.lever.registry import LeverSite
 from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.adapters.sources.passive_infrastructure.rdap_registry import RdapTarget
 from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.smartrecruiters.registry import SmartRecruitersCompany
@@ -55,6 +56,7 @@ class AdapterCompositionInputs:
     search_templates: tuple[SearchQueryTemplate, ...]
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
+    rdap_targets: tuple[RdapTarget, ...]
     sec_incident_targets: tuple[SecIncidentTarget, ...]
 
 
@@ -102,6 +104,7 @@ def build_runtime_adapters(
         adapters,
         entries_by_id,
         inputs.passive_infrastructure_targets,
+        inputs.rdap_targets,
         certspotter_token_provider=certspotter_token_provider,
         timeout_seconds=timeout_seconds,
     )

--- a/src/cip/modules/collection_orchestration/application/passive_infrastructure_registration.py
+++ b/src/cip/modules/collection_orchestration/application/passive_infrastructure_registration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from cip.adapters.sources.passive_infrastructure.rdap_registry import RdapTarget
 from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
 from cip.modules.collection_orchestration.application.certspotter_adapter import (
     CertSpotterAdapter,
@@ -10,6 +11,7 @@ from cip.modules.collection_orchestration.application.cloudflare_dns_adapter imp
     CloudflareDnsAdapter,
 )
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.collection_orchestration.application.rdap_adapter import IanaRdapAdapter
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
 
@@ -17,6 +19,7 @@ def register_passive_infrastructure_adapters(
     adapters: dict[tuple[str, str], CollectionAdapter],
     entries_by_id: dict[str, SourceRegistryEntry],
     targets: tuple[PassiveInfrastructureTarget, ...],
+    rdap_targets: tuple[RdapTarget, ...],
     *,
     certspotter_token_provider: Callable[[], str | None],
     timeout_seconds: float,
@@ -40,6 +43,17 @@ def register_passive_infrastructure_adapters(
                 certspotter_entry,
                 targets,
                 token_provider=certspotter_token_provider,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    rdap_entry = entries_by_id.get(IanaRdapAdapter.source_id)
+    if rdap_entry is not None:
+        _register(
+            adapters,
+            IanaRdapAdapter(
+                rdap_entry,
+                rdap_targets,
                 timeout_seconds=timeout_seconds,
             ),
         )

--- a/src/cip/modules/collection_orchestration/application/rdap_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/rdap_adapter.py
@@ -264,12 +264,22 @@ def _validate_record_identity(record: PublicRdapObject, target: RdapTarget) -> N
     if record.objectClassName.casefold() != _EXPECTED_OBJECT_CLASSES[target.kind]:
         raise _identity_error()
     if target.kind is RdapTargetKind.DOMAIN:
-        if record.ldhName is None or normalize_domain(record.ldhName) != target.value:
-            raise _identity_error()
+        _validate_domain_record(record, target.value)
     elif target.kind in {RdapTargetKind.IPV4, RdapTargetKind.IPV6}:
         _validate_ip_record(record, target.value)
     else:
         _validate_asn_record(record, target.value)
+
+
+def _validate_domain_record(record: PublicRdapObject, value: str) -> None:
+    if record.ldhName is None:
+        raise _identity_error()
+    try:
+        normalized = normalize_domain(record.ldhName)
+    except ValueError as exc:
+        raise _identity_error() from exc
+    if normalized != value:
+        raise _identity_error()
 
 
 def _validate_ip_record(record: PublicRdapObject, value: str) -> None:

--- a/src/cip/modules/collection_orchestration/application/rdap_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/rdap_adapter.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from ipaddress import ip_address, ip_network
+from urllib.parse import quote, urljoin, urlsplit
+from uuid import UUID
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.passive_infrastructure.rdap_registry import (
+    RdapTarget,
+    RdapTargetKind,
+)
+from cip.adapters.sources.passive_infrastructure.rdap_schemas import (
+    IanaRdapBootstrap,
+    PublicRdapObject,
+)
+from cip.modules.collection_orchestration.application.passive_adapter_support import (
+    PassiveObservationContext,
+    authorize_passive_request,
+    get_json,
+    raw_passive_observation,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.passive_exposure.domain.models import (
+    AttributionRisk,
+    OrganizationLink,
+    OrganizationLinkMethod,
+    OrganizationLinkStatus,
+    PassiveAsset,
+    PassiveAssetKind,
+    PassiveObservationKind,
+    PassiveObservationSnapshot,
+    PassiveObservationState,
+)
+from cip.modules.passive_exposure.domain.normalization import normalize_domain
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_BOOTSTRAP_FILES = {
+    RdapTargetKind.DOMAIN: "dns.json",
+    RdapTargetKind.IPV4: "ipv4.json",
+    RdapTargetKind.IPV6: "ipv6.json",
+    RdapTargetKind.ASN: "asn.json",
+}
+_ASSET_KINDS = {
+    RdapTargetKind.DOMAIN: PassiveAssetKind.DOMAIN,
+    RdapTargetKind.IPV4: PassiveAssetKind.IPV4,
+    RdapTargetKind.IPV6: PassiveAssetKind.IPV6,
+    RdapTargetKind.ASN: PassiveAssetKind.ASN,
+}
+_EXPECTED_OBJECT_CLASSES = {
+    RdapTargetKind.DOMAIN: "domain",
+    RdapTargetKind.IPV4: "ip network",
+    RdapTargetKind.IPV6: "ip network",
+    RdapTargetKind.ASN: "autnum",
+}
+
+
+class IanaRdapAdapter:
+    source_id = "iana-rdap-public"
+    adapter_id = "iana-bootstrap-rdap"
+    adapter_version = "1"
+    data_category = DataCategory.TECHNOLOGY_OBSERVATION
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[RdapTarget, ...],
+        *,
+        timeout_seconds: float = 20.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("RDAP adapter requires iana-rdap-public policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None:
+            return _empty_batch()
+        bootstrap_url = urljoin(
+            self._entry.policy.base_url,
+            _BOOTSTRAP_FILES[target.kind],
+        )
+        authorize_passive_request(
+            self._entry,
+            target_url=bootstrap_url,
+            collected_at=collected_at,
+        )
+        with httpx.Client(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            bootstrap = _fetch_bootstrap(client, bootstrap_url)
+            base_url = _authoritative_base_url(bootstrap, target)
+            rdap_url = _rdap_url(base_url, target)
+            record = _fetch_public_object(client, rdap_url)
+        _validate_record_identity(record, target)
+        context = PassiveObservationContext(
+            source_id=self.source_id,
+            adapter_id=self.adapter_id,
+            adapter_version=self.adapter_version,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        snapshot = _map_record(record, target=target, source_url=rdap_url, now=collected_at)
+        observation = raw_passive_observation(
+            record,
+            context=context,
+            source_url=rdap_url,
+            source_record_key=snapshot.source_record_key,
+            source_record_type="public-rdap-registration",
+            observed_at=collected_at,
+        )
+        return AdapterCollectionBatch(
+            observations=(observation,),
+            passive_exposure_projections=(snapshot,),
+            checkpoint_payload={"target_index": next_index},
+            not_modified=False,
+        )
+
+
+def _fetch_bootstrap(client: httpx.Client, url: str) -> IanaRdapBootstrap:
+    body = get_json(client, url, params={})
+    try:
+        return IanaRdapBootstrap.model_validate_json(body)
+    except ValidationError as exc:
+        raise AdapterExecutionError(
+            "IANA RDAP bootstrap schema changed",
+            error_code="source_schema_drift",
+            retryable=False,
+        ) from exc
+
+
+def _fetch_public_object(client: httpx.Client, url: str) -> PublicRdapObject:
+    body = get_json(
+        client,
+        url,
+        params={},
+        headers={"accept": "application/rdap+json, application/json"},
+    )
+    try:
+        return PublicRdapObject.model_validate_json(body)
+    except ValidationError as exc:
+        raise AdapterExecutionError(
+            "authoritative RDAP response schema changed",
+            error_code="source_schema_drift",
+            retryable=False,
+        ) from exc
+
+
+def _authoritative_base_url(bootstrap: IanaRdapBootstrap, target: RdapTarget) -> str:
+    candidates = _matching_services(bootstrap, target)
+    if not candidates:
+        raise _bootstrap_error("no authoritative RDAP service for target")
+    for _specificity, urls in sorted(candidates, reverse=True):
+        for url in urls:
+            parsed = urlsplit(url)
+            if parsed.scheme == "https" and parsed.hostname and not parsed.username:
+                return url if url.endswith("/") else f"{url}/"
+    raise _bootstrap_error("authoritative RDAP service has no HTTPS endpoint")
+
+
+def _matching_services(
+    bootstrap: IanaRdapBootstrap,
+    target: RdapTarget,
+) -> list[tuple[int, tuple[str, ...]]]:
+    matches: list[tuple[int, tuple[str, ...]]] = []
+    for keys, urls in bootstrap.services:
+        specificity = _service_specificity(keys, target)
+        if specificity >= 0:
+            matches.append((specificity, tuple(urls)))
+    return matches
+
+
+def _service_specificity(keys: list[str], target: RdapTarget) -> int:
+    if target.kind is RdapTargetKind.DOMAIN:
+        return _domain_specificity(keys, target.value)
+    if target.kind in {RdapTargetKind.IPV4, RdapTargetKind.IPV6}:
+        return _ip_specificity(keys, target.value)
+    return _asn_specificity(keys, target.value)
+
+
+def _domain_specificity(keys: list[str], domain: str) -> int:
+    best = -1
+    for key in keys:
+        suffix = key.casefold().strip(".")
+        if suffix == "":
+            best = max(best, 0)
+        elif domain == suffix or domain.endswith(f".{suffix}"):
+            best = max(best, suffix.count(".") + 1)
+    return best
+
+
+def _ip_specificity(keys: list[str], value: str) -> int:
+    address = ip_address(value)
+    best = -1
+    for key in keys:
+        try:
+            network = ip_network(key, strict=False)
+        except ValueError:
+            continue
+        if network.version == address.version and address in network:
+            best = max(best, network.prefixlen)
+    return best
+
+
+def _asn_specificity(keys: list[str], value: str) -> int:
+    number = int(value.removeprefix("AS"))
+    for key in keys:
+        start_text, separator, end_text = key.partition("-")
+        if not separator or not start_text.isdigit() or not end_text.isdigit():
+            continue
+        start, end = int(start_text), int(end_text)
+        if start <= number <= end:
+            return end - start + 1
+    return -1
+
+
+def _rdap_url(base_url: str, target: RdapTarget) -> str:
+    resource = target.value
+    if target.kind is RdapTargetKind.DOMAIN:
+        path = f"domain/{quote(resource, safe='.-')}"
+    elif target.kind in {RdapTargetKind.IPV4, RdapTargetKind.IPV6}:
+        path = f"ip/{quote(resource, safe=':.')}"
+    else:
+        path = f"autnum/{resource.removeprefix('AS')}"
+    url = urljoin(base_url, path)
+    parsed = urlsplit(url)
+    base = urlsplit(base_url)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != base.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise _bootstrap_error("derived RDAP URL escaped authoritative HTTPS endpoint")
+    return url
+
+
+def _validate_record_identity(record: PublicRdapObject, target: RdapTarget) -> None:
+    if record.objectClassName.casefold() != _EXPECTED_OBJECT_CLASSES[target.kind]:
+        raise _identity_error()
+    if target.kind is RdapTargetKind.DOMAIN:
+        if record.ldhName is None or normalize_domain(record.ldhName) != target.value:
+            raise _identity_error()
+    elif target.kind in {RdapTargetKind.IPV4, RdapTargetKind.IPV6}:
+        _validate_ip_record(record, target.value)
+    else:
+        _validate_asn_record(record, target.value)
+
+
+def _validate_ip_record(record: PublicRdapObject, value: str) -> None:
+    if record.startAddress is None or record.endAddress is None:
+        raise _identity_error()
+    address = ip_address(value)
+    start, end = ip_address(record.startAddress), ip_address(record.endAddress)
+    if start.version != address.version or end.version != address.version:
+        raise _identity_error()
+    if not int(start) <= int(address) <= int(end):
+        raise _identity_error()
+
+
+def _validate_asn_record(record: PublicRdapObject, value: str) -> None:
+    if record.startAutnum is None or record.endAutnum is None:
+        raise _identity_error()
+    number = int(value.removeprefix("AS"))
+    if not record.startAutnum <= number <= record.endAutnum:
+        raise _identity_error()
+
+
+def _map_record(
+    record: PublicRdapObject,
+    *,
+    target: RdapTarget,
+    source_url: str,
+    now: datetime,
+) -> PassiveObservationSnapshot:
+    risks = _attribution_risks(target.kind)
+    asset = PassiveAsset(kind=_ASSET_KINDS[target.kind], value=target.value)
+    key_part = record.handle or record.ldhName or record.name or target.value
+    return PassiveObservationSnapshot(
+        source_id=IanaRdapAdapter.source_id,
+        source_record_key=f"{target.kind.value}:{target.value}:{key_part}"[:500],
+        source_url=source_url,
+        asset=asset,
+        observation_kind=PassiveObservationKind.REGISTRATION,
+        state=PassiveObservationState.CURRENT,
+        observed_at=now,
+        published_at=now,
+        modified_at=now,
+        confidence=0.75,
+        independence_key=f"rdap:{target.kind.value}:{target.value}",
+        organization_link=OrganizationLink(
+            status=OrganizationLinkStatus.REVIEW_REQUIRED,
+            method=OrganizationLinkMethod.PASSIVE_CORRELATION,
+            confidence=0.65,
+            organization_id=target.organization_id,
+            reasons=(
+                "RDAP registration or allocation metadata does not prove current operational ownership",
+            ),
+            attribution_risks=risks,
+        ),
+    )
+
+
+def _attribution_risks(kind: RdapTargetKind) -> tuple[AttributionRisk, ...]:
+    if kind is RdapTargetKind.DOMAIN:
+        return (AttributionRisk.ABANDONED_DOMAIN,)
+    if kind in {RdapTargetKind.IPV4, RdapTargetKind.IPV6}:
+        return (AttributionRisk.REASSIGNED_ADDRESS,)
+    return (AttributionRisk.RESELLER,)
+
+
+def _next_target(
+    targets: tuple[RdapTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[RdapTarget | None, int]:
+    if not targets:
+        return None, 0
+    value = 0 if payload is None else payload.get("target_index", 0)
+    if not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            "invalid RDAP target checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(targets)
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _bootstrap_error(message: str) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        message,
+        error_code="rdap_bootstrap_error",
+        retryable=False,
+    )
+
+
+def _identity_error() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "RDAP response identity does not cover requested target",
+        error_code="source_identity_mismatch",
+        retryable=False,
+    )
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        passive_exposure_projections=(),
+        checkpoint_payload={"target_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/rdap_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/rdap_adapter.py
@@ -317,7 +317,8 @@ def _map_record(
             confidence=0.65,
             organization_id=target.organization_id,
             reasons=(
-                "RDAP registration or allocation metadata does not prove current operational ownership",
+                "RDAP registration or allocation metadata does not prove current "
+                "operational ownership",
             ),
             attribution_risks=risks,
         ),

--- a/src/cip/modules/collection_orchestration/application/rdap_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/rdap_adapter.py
@@ -60,6 +60,7 @@ _EXPECTED_OBJECT_CLASSES = {
     RdapTargetKind.IPV6: "ip network",
     RdapTargetKind.ASN: "autnum",
 }
+_ASN_SPACE = 4_294_967_296
 
 
 class IanaRdapAdapter:
@@ -227,14 +228,15 @@ def _ip_specificity(keys: list[str], value: str) -> int:
 
 def _asn_specificity(keys: list[str], value: str) -> int:
     number = int(value.removeprefix("AS"))
+    best = -1
     for key in keys:
         start_text, separator, end_text = key.partition("-")
         if not separator or not start_text.isdigit() or not end_text.isdigit():
             continue
         start, end = int(start_text), int(end_text)
         if start <= number <= end:
-            return end - start + 1
-    return -1
+            best = max(best, _ASN_SPACE - (end - start))
+    return best
 
 
 def _rdap_url(base_url: str, target: RdapTarget) -> str:

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -16,6 +16,7 @@ from cip.adapters.sources.lever.registry import load_lever_sites
 from cip.adapters.sources.organization_identity.registry import (
     load_organization_identity_targets,
 )
+from cip.adapters.sources.passive_infrastructure.rdap_registry import load_rdap_targets
 from cip.adapters.sources.passive_infrastructure.registry import (
     load_passive_infrastructure_targets,
 )
@@ -192,6 +193,7 @@ def _load_adapter_inputs(
         passive_infrastructure_targets=load_passive_infrastructure_targets(
             settings.passive_infrastructure_target_registry_path
         ),
+        rdap_targets=load_rdap_targets(settings.rdap_target_registry_path),
         sec_incident_targets=load_sec_incident_targets(
             settings.sec_incident_target_registry_path
         ),

--- a/src/cip/modules/passive_exposure/domain/enums.py
+++ b/src/cip/modules/passive_exposure/domain/enums.py
@@ -17,6 +17,7 @@ class PassiveObservationKind(StrEnum):
     PASSIVE_DNS = "passive_dns"
     CERTIFICATE = "certificate"
     ASN = "asn"
+    REGISTRATION = "registration"
     CLOUD = "cloud"
     SERVICE = "service"
     PORT = "port"

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -95,6 +95,7 @@ class Settings(BaseSettings):
     passive_infrastructure_target_registry_path: Path = Path(
         "policies/passive_infrastructure_targets.yml"
     )
+    rdap_target_registry_path: Path = Path("policies/rdap_targets.yml")
     sec_incident_target_registry_path: Path = Path("policies/sec_incident_targets.yml")
     retention_policy_path: Path = Path("policies/retention.yml")
     collection_schedule_path: Path = Path("policies/collection_schedules.yml")

--- a/tests/unit/adapters/test_rdap_registry_and_schema.py
+++ b/tests/unit/adapters/test_rdap_registry_and_schema.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from cip.adapters.sources.passive_infrastructure.rdap_registry import (
+    RdapTarget,
+    RdapTargetFile,
+    RdapTargetKind,
+    load_rdap_targets,
+)
+from cip.adapters.sources.passive_infrastructure.rdap_schemas import PublicRdapObject
+
+ORG_ID = UUID("00000000-0000-0000-0000-000000000811")
+
+
+def test_rdap_target_normalizes_supported_resource_kinds() -> None:
+    domain = _target(RdapTargetKind.DOMAIN, "Example.COM.")
+    ipv4 = _target(RdapTargetKind.IPV4, "8.8.8.8")
+    ipv6 = _target(RdapTargetKind.IPV6, "2606:4700:4700::1111")
+    asn = _target(RdapTargetKind.ASN, "64497")
+
+    assert domain.value == "example.com"
+    assert ipv4.value == "8.8.8.8"
+    assert ipv6.value == "2606:4700:4700::1111"
+    assert asn.value == "AS64497"
+
+
+@pytest.mark.parametrize(
+    ("kind", "value"),
+    [
+        (RdapTargetKind.DOMAIN, "8.8.8.8"),
+        (RdapTargetKind.IPV4, "10.0.0.1"),
+        (RdapTargetKind.IPV6, "2001:db8::1"),
+        (RdapTargetKind.ASN, "AS0"),
+        (RdapTargetKind.ASN, "not-an-asn"),
+    ],
+)
+def test_rdap_target_rejects_wrong_or_non_global_resources(
+    kind: RdapTargetKind,
+    value: str,
+) -> None:
+    with pytest.raises(ValueError):
+        _target(kind, value)
+
+
+def test_rdap_target_file_rejects_duplicate_resource(tmp_path: Path) -> None:
+    path = tmp_path / "rdap.yml"
+    path.write_text(
+        """version: 1
+targets:
+  - target_id: one
+    organization_id: 00000000-0000-0000-0000-000000000811
+    kind: domain
+    value: example.com
+    enabled: false
+  - target_id: two
+    organization_id: 00000000-0000-0000-0000-000000000811
+    kind: domain
+    value: EXAMPLE.COM.
+    enabled: false
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate RDAP target resource"):
+        load_rdap_targets(path)
+
+
+def test_public_rdap_schema_drops_entities_and_vcards() -> None:
+    record = PublicRdapObject.model_validate(
+        {
+            "objectClassName": "domain",
+            "handle": "EXAMPLE",
+            "ldhName": "example.com",
+            "entities": [
+                {
+                    "handle": "private-person",
+                    "vcardArray": [
+                        "vcard",
+                        [["email", {}, "text", "private@example.com"]],
+                    ],
+                }
+            ],
+        }
+    )
+
+    serialized = record.model_dump_json()
+    assert "entities" not in serialized
+    assert "private-person" not in serialized
+    assert "private@example.com" not in serialized
+
+
+def test_checked_in_rdap_registry_is_empty_by_default() -> None:
+    parsed = RdapTargetFile.model_validate(
+        {"version": 1, "targets": list(load_rdap_targets(Path("policies/rdap_targets.yml")))}
+    )
+    assert parsed.targets == []
+
+
+def _target(kind: RdapTargetKind, value: str) -> RdapTarget:
+    return RdapTarget(
+        target_id=f"target-{kind.value}",
+        organization_id=ORG_ID,
+        kind=kind,
+        value=value,
+        enabled=False,
+    )

--- a/tests/unit/collection_orchestration/test_priority_b_rdap_governance.py
+++ b/tests/unit/collection_orchestration/test_priority_b_rdap_governance.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from cip.adapters.sources.passive_infrastructure.rdap_registry import load_rdap_targets
+from cip.adapters.sources.passive_infrastructure.registry import (
+    load_passive_infrastructure_targets,
+)
+from cip.modules.collection_orchestration.application.passive_infrastructure_registration import (
+    register_passive_infrastructure_adapters,
+)
+from cip.modules.collection_orchestration.application.rdap_adapter import IanaRdapAdapter
+from cip.modules.collection_orchestration.infrastructure.schedule_bundle import (
+    load_collection_schedule_bundle,
+)
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_portfolio.domain.models import CatalogStatus
+from cip.modules.source_portfolio.infrastructure.registry import load_source_portfolio
+
+SOURCE_PATH = Path("policies/sources.passive_infrastructure.yml")
+PORTFOLIO_PATH = Path("policies/source_portfolio.passive_infrastructure.yml")
+SCHEDULE_PATH = Path("policies/collection_schedules.passive_infrastructure.yml")
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+RDAP_TARGET_PATH = Path("policies/rdap_targets.yml")
+PASSIVE_TARGET_PATH = Path("policies/passive_infrastructure_targets.yml")
+
+
+def test_rdap_governance_portfolio_schedule_and_activation_agree() -> None:
+    sources = {entry.policy.id: entry for entry in load_source_registry(SOURCE_PATH)}
+    portfolio = {
+        entry.source_id: entry for entry in load_source_portfolio(PORTFOLIO_PATH)
+    }
+    schedules = load_collection_schedule_bundle(SCHEDULE_PATH)
+    activation = yaml.safe_load(ACTIVATION_PATH.read_text(encoding="utf-8"))
+    activation_by_id = {
+        item["source_id"]: item for item in activation["sources"]
+    }
+
+    source = sources[IanaRdapAdapter.source_id]
+    assert source.policy.status is SourceStatus.ENABLED
+    assert source.authorization.automated_collection_allowed is True
+    assert source.authorization.approved_hosts == frozenset({"data.iana.org"})
+
+    catalog = portfolio[IanaRdapAdapter.source_id]
+    assert catalog.status is CatalogStatus.EXECUTABLE
+    assert catalog.executable is True
+    assert catalog.adapter is not None
+    assert catalog.adapter.adapter_id == IanaRdapAdapter.adapter_id
+
+    rdap_schedules = [
+        schedule for schedule in schedules if schedule.source_id == IanaRdapAdapter.source_id
+    ]
+    assert len(rdap_schedules) == 1
+    assert rdap_schedules[0].enabled is False
+
+    truth = activation_by_id[IanaRdapAdapter.source_id]
+    assert truth["disposition"] == "active"
+    assert truth["requires_schedule"] is False
+    assert "executable" in truth["stages"]
+    assert "scheduled" not in truth["stages"]
+    assert "live_tested" not in truth["stages"]
+
+
+def test_rdap_adapter_is_registered_even_with_empty_checked_in_targets() -> None:
+    entries = load_source_registry(SOURCE_PATH)
+    entries_by_id = {entry.policy.id: entry for entry in entries}
+    adapters = {}
+
+    register_passive_infrastructure_adapters(
+        adapters,
+        entries_by_id,
+        load_passive_infrastructure_targets(PASSIVE_TARGET_PATH),
+        load_rdap_targets(RDAP_TARGET_PATH),
+        certspotter_token_provider=lambda: None,
+        timeout_seconds=1.0,
+    )
+
+    assert (IanaRdapAdapter.source_id, IanaRdapAdapter.adapter_id) in adapters

--- a/tests/unit/collection_orchestration/test_rdap_adapter.py
+++ b/tests/unit/collection_orchestration/test_rdap_adapter.py
@@ -97,17 +97,17 @@ def test_ipv4_rdap_chooses_longest_prefix_bootstrap_match() -> None:
             return _json(
                 _bootstrap_services(
                     [
-                        [["203.0.0.0/8"], ["https://broad.example.test/"]],
-                        [["203.0.113.0/24"], ["https://specific.example.test/rdap/"]],
+                        [["8.0.0.0/8"], ["https://broad.example.test/"]],
+                        [["8.8.8.0/24"], ["https://specific.example.test/rdap/"]],
                     ]
                 )
             )
         return _json(
             {
                 "objectClassName": "ip network",
-                "handle": "NET-203-0-113-0-1",
-                "startAddress": "203.0.113.0",
-                "endAddress": "203.0.113.255",
+                "handle": "NET-8-8-8-0-1",
+                "startAddress": "8.8.8.0",
+                "endAddress": "8.8.8.255",
                 "ipVersion": "v4",
             },
             content_type="application/rdap+json",
@@ -115,13 +115,13 @@ def test_ipv4_rdap_chooses_longest_prefix_bootstrap_match() -> None:
 
     adapter = IanaRdapAdapter(
         _entry(),
-        (_target(RdapTargetKind.IPV4, "203.0.113.8"),),
+        (_target(RdapTargetKind.IPV4, "8.8.8.8"),),
         transport=httpx.MockTransport(handler),
     )
     batch = _collect(adapter)
 
     assert requests[1].url.host == "specific.example.test"
-    assert requests[1].url.path == "/rdap/ip/203.0.113.8"
+    assert requests[1].url.path == "/rdap/ip/8.8.8.8"
     snapshot = batch.passive_exposure_projections[0]
     assert snapshot.asset.kind is PassiveAssetKind.IPV4
     assert snapshot.organization_link.attribution_risks == (

--- a/tests/unit/collection_orchestration/test_rdap_adapter.py
+++ b/tests/unit/collection_orchestration/test_rdap_adapter.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+import httpx
+import pytest
+
+from cip.adapters.sources.passive_infrastructure.rdap_registry import (
+    RdapTarget,
+    RdapTargetKind,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.collection_orchestration.application.rdap_adapter import IanaRdapAdapter
+from cip.modules.passive_exposure.domain.models import (
+    AttributionRisk,
+    OrganizationLinkStatus,
+    PassiveAssetKind,
+    PassiveObservationKind,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+NOW = datetime(2026, 8, 10, 10, 45, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+JOB_ID = UUID("00000000-0000-0000-0000-000000000801")
+ORG_ID = UUID("00000000-0000-0000-0000-000000000802")
+POLICY_PATH = Path("policies/sources.passive_infrastructure.yml")
+
+
+def test_empty_rdap_targets_perform_no_network() -> None:
+    adapter = IanaRdapAdapter(
+        _entry(),
+        (),
+        transport=httpx.MockTransport(_fail_network),
+    )
+
+    batch = _collect(adapter)
+
+    assert batch.not_modified is True
+    assert batch.passive_exposure_projections == ()
+
+
+def test_domain_rdap_uses_iana_bootstrap_and_excludes_contact_semantics() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.host == "data.iana.org":
+            return _json(_bootstrap([["com"], ["https://rdap.registry.test/"]]))
+        return _json(
+            {
+                "objectClassName": "domain",
+                "handle": "EXAMPLE-COM",
+                "ldhName": "example.com",
+                "status": ["active"],
+                "entities": [
+                    {
+                        "handle": "private-person",
+                        "vcardArray": ["vcard", [["email", {}, "text", "private@example.com"]]],
+                    }
+                ],
+            },
+            content_type="application/rdap+json",
+        )
+
+    adapter = IanaRdapAdapter(
+        _entry(),
+        (_target(RdapTargetKind.DOMAIN, "example.com"),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert [request.url.host for request in requests] == [
+        "data.iana.org",
+        "rdap.registry.test",
+    ]
+    assert requests[1].url.path == "/domain/example.com"
+    snapshot = batch.passive_exposure_projections[0]
+    assert snapshot.asset.kind is PassiveAssetKind.DOMAIN
+    assert snapshot.asset.value == "example.com"
+    assert snapshot.observation_kind is PassiveObservationKind.REGISTRATION
+    assert snapshot.organization_link.status is OrganizationLinkStatus.REVIEW_REQUIRED
+    assert snapshot.organization_link.attribution_risks == (
+        AttributionRisk.ABANDONED_DOMAIN,
+    )
+    assert batch.observations[0].source_url == "https://rdap.registry.test/domain/example.com"
+
+
+def test_ipv4_rdap_chooses_longest_prefix_bootstrap_match() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.host == "data.iana.org":
+            return _json(
+                _bootstrap_services(
+                    [
+                        [["203.0.0.0/8"], ["https://broad.example.test/"]],
+                        [["203.0.113.0/24"], ["https://specific.example.test/rdap/"]],
+                    ]
+                )
+            )
+        return _json(
+            {
+                "objectClassName": "ip network",
+                "handle": "NET-203-0-113-0-1",
+                "startAddress": "203.0.113.0",
+                "endAddress": "203.0.113.255",
+                "ipVersion": "v4",
+            },
+            content_type="application/rdap+json",
+        )
+
+    adapter = IanaRdapAdapter(
+        _entry(),
+        (_target(RdapTargetKind.IPV4, "203.0.113.8"),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert requests[1].url.host == "specific.example.test"
+    assert requests[1].url.path == "/rdap/ip/203.0.113.8"
+    snapshot = batch.passive_exposure_projections[0]
+    assert snapshot.asset.kind is PassiveAssetKind.IPV4
+    assert snapshot.organization_link.attribution_risks == (
+        AttributionRisk.REASSIGNED_ADDRESS,
+    )
+
+
+def test_asn_rdap_uses_matching_range_and_validates_response_range() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "data.iana.org":
+            return _json(
+                _bootstrap([["64496-64510"], ["https://rir.example.test/rdap/"]])
+            )
+        return _json(
+            {
+                "objectClassName": "autnum",
+                "handle": "AS64497",
+                "startAutnum": 64496,
+                "endAutnum": 64510,
+                "name": "EXAMPLE-NET",
+            },
+            content_type="application/rdap+json",
+        )
+
+    adapter = IanaRdapAdapter(
+        _entry(),
+        (_target(RdapTargetKind.ASN, "AS64497"),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    snapshot = batch.passive_exposure_projections[0]
+    assert snapshot.asset.kind is PassiveAssetKind.ASN
+    assert snapshot.asset.value == "AS64497"
+    assert snapshot.organization_link.attribution_risks == (AttributionRisk.RESELLER,)
+
+
+def test_rdap_rejects_non_https_bootstrap_endpoint_before_second_hop() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _json(_bootstrap([["com"], ["http://unsafe.example.test/rdap/"]]))
+
+    adapter = IanaRdapAdapter(
+        _entry(),
+        (_target(RdapTargetKind.DOMAIN, "example.com"),),
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        _collect(adapter)
+
+    assert error.value.error_code == "rdap_bootstrap_error"
+    assert len(requests) == 1
+
+
+def test_rdap_rejects_response_that_does_not_cover_target() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "data.iana.org":
+            return _json(_bootstrap([["com"], ["https://rdap.registry.test/"]]))
+        return _json(
+            {"objectClassName": "domain", "ldhName": "other.example"},
+            content_type="application/rdap+json",
+        )
+
+    adapter = IanaRdapAdapter(
+        _entry(),
+        (_target(RdapTargetKind.DOMAIN, "example.com"),),
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(AdapterExecutionError) as error:
+        _collect(adapter)
+
+    assert error.value.error_code == "source_identity_mismatch"
+
+
+def _collect(adapter: IanaRdapAdapter):
+    return adapter.collect(
+        collection_job_id=JOB_ID,
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _entry():
+    entries = load_source_registry(POLICY_PATH)
+    return {entry.policy.id: entry for entry in entries}[IanaRdapAdapter.source_id]
+
+
+def _target(kind: RdapTargetKind, value: str) -> RdapTarget:
+    return RdapTarget(
+        target_id=f"target-{kind.value}",
+        organization_id=ORG_ID,
+        kind=kind,
+        value=value,
+        enabled=True,
+    )
+
+
+def _bootstrap(service: list[list[str]]) -> dict[str, object]:
+    return _bootstrap_services([service])
+
+
+def _bootstrap_services(services: list[list[list[str]]]) -> dict[str, object]:
+    return {
+        "version": "1.0",
+        "publication": "2026-08-10T00:00:00Z",
+        "services": services,
+    }
+
+
+def _json(payload: object, *, content_type: str = "application/json") -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": content_type},
+        content=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _fail_network(_request: httpx.Request) -> httpx.Response:
+    raise AssertionError("network must not run")

--- a/tests/unit/test_passive_infrastructure_source_registries.py
+++ b/tests/unit/test_passive_infrastructure_source_registries.py
@@ -16,7 +16,7 @@ from cip.modules.source_portfolio.infrastructure.registry import load_source_por
 SOURCE_PATH = Path("policies/sources.passive_infrastructure.yml")
 PORTFOLIO_PATH = Path("policies/source_portfolio.passive_infrastructure.yml")
 SCHEDULE_PATH = Path("policies/collection_schedules.passive_infrastructure.yml")
-EXPECTED_IDS = {"cloudflare-doh", "certspotter-ct"}
+EXPECTED_IDS = {"cloudflare-doh", "certspotter-ct", "iana-rdap-public"}
 
 
 def test_passive_sources_are_governed_without_active_validation_authority() -> None:
@@ -63,5 +63,6 @@ def test_passive_schedules_are_checked_in_but_disabled_until_deployment_activati
     assert {(item.source_id, item.adapter_id) for item in schedules} == {
         ("cloudflare-doh", "cloudflare-dns-json"),
         ("certspotter-ct", "certspotter-issuances-api"),
+        ("iana-rdap-public", "iana-bootstrap-rdap"),
     }
     assert all(schedule.enabled is False for schedule in schedules)


### PR DESCRIPTION
Closes #78
Parent completion issue: #77

## Priority B-1 — governed public RDAP

Clean base: SA-04 squash `16a8e1f9cd53990d48e0539fcae2765a5b320ec1`.

### Implemented
- explicit organization-bound domain / globally routable IPv4 / globally routable IPv6 / ASN target registry;
- IANA RFC 9224 bootstrap via `dns.json`, `ipv4.json`, `ipv6.json`, `asn.json`;
- domain most-specific suffix, IP longest-prefix and ASN narrowest-range authoritative service selection;
- authoritative second hop restricted to an HTTPS base URL returned by the matching IANA bootstrap entry, no redirects/user-supplied host;
- response identity revalidation for exact domain, containing IP allocation and containing ASN range;
- strict minimal public RDAP schema: entity/vCard/email/phone/contact fields are not materialized before RawObservation creation;
- Lot 16 `PassiveObservationKind.REGISTRATION` plus existing `PassiveObservationSnapshot` persistence path;
- organization links remain `review_required` / passive correlation with explicit abandoned-domain, reassigned-address or reseller attribution risk;
- checked-in RDAP target registry empty and schedule disabled by default;
- governance, portfolio, activation truth, source coverage matrix and deterministic runtime/provider tests.

### Explicit exclusions
No RDRS/nonpublic registration access, authenticated enumeration, registrant/contact harvesting, active probing, direct asset connection, vulnerability applicability, exposure verification, compromise inference, signal/need/opportunity creation or outreach.

### Exact final validation
Head SHA: `d0e9d1872f97245872c9436719b2cda32eea3d8a`
CI run: #1552
- dependency consistency/audit: PASS
- Ruff: PASS
- Mypy strict: PASS
- Architecture/release contracts: PASS — 36 tests
- Alembic upgrade/downgrade/upgrade: PASS
- Full pytest: PASS — 1126 tests, 0 failed, 0 skipped
- aggregate branch-aware coverage: 90.06%
- line coverage: 93.21%
- frontend audit/typecheck/build: PASS
- PR reviews: no blocking reviews or unresolved threads

No content change is permitted after this exact-head validation without rerunning the complete CI.