### PR TITLE
Priority B-3: governed feeds, security.txt and bounded public documents

### DIFF
--- a/docs/source_activation/PRIORITY_B_03_PUBLIC_WEB_COMPLETION.md
+++ b/docs/source_activation/PRIORITY_B_03_PUBLIC_WEB_COMPLETION.md
@@ -1,0 +1,92 @@
+# Priority B-3 — Public Feeds, security.txt and Bounded Documents
+
+## Objective
+
+Complete the existing Lot 12 governed public-web capability without creating a second crawler or a general-purpose browsing runtime.
+
+Priority B-3 adds three bounded discovery and parsing paths to the existing target-driven public-web collector:
+
+- explicitly configured RSS 2.0 and Atom feeds;
+- optional RFC 9116 `/.well-known/security.txt` discovery;
+- bounded public PDF text extraction for already approved in-scope document URLs.
+
+All traffic remains subject to Source Governance, explicit organization targets, robots rules, host/path allowlists, page and byte budgets, redirect limits, MIME validation, retention and the shared collection scheduler/worker.
+
+## Runtime path
+
+```text
+explicit approved organization target
+  -> robots.txt
+  -> configured sitemap and/or configured feed
+  -> bounded same-origin discovery
+  -> optional exact /.well-known/security.txt
+  -> approved page/document fetch
+  -> bounded parser
+  -> sanitized PublicResource/PublicResourceVersion
+  -> optional target-content claims only where content semantics support them
+  -> existing Lot 12 persistence
+```
+
+No page view triggers collection. No unrestricted recursive crawler is introduced.
+
+## Feed boundary
+
+RSS and Atom feeds are discovery lineage. A feed entry can identify a public page or document to retrieve through the same approved target path. The feed and its linked target are not independent corroboration merely because both exist.
+
+Feed parsing must:
+
+- reject DTD/entity declarations and malformed XML;
+- enforce byte and entry-count bounds;
+- accept only configured feed URLs;
+- canonicalize and deduplicate links;
+- reject links outside the approved target origin/scope before retrieval;
+- never retain raw feed bodies beyond bounded processing.
+
+## security.txt boundary
+
+`security.txt` is an optional exact-path capability at `/.well-known/security.txt` for an explicitly enabled public-web target.
+
+It is treated as a public security-disclosure/contact route, not as evidence that an organization is vulnerable, breached, exposed, or currently buying cybersecurity services. It must not create an automatic CommercialSignal, NeedHypothesis, score, opportunity or outreach action.
+
+The parser accepts bounded UTF-8 `text/plain`, requires at least one valid `Contact` field, validates any `Canonical` URL, and ignores unsupported fields rather than interpreting them as commercial evidence.
+
+## PDF/document boundary
+
+PDF extraction applies only to already approved public URLs returned by the bounded target discovery paths. Documents are never executed.
+
+The parser must:
+
+- require an allowed PDF MIME type and bounded response size before parsing;
+- reject malformed or encrypted documents it cannot safely process;
+- enforce page-count and extracted-text bounds;
+- extract text only, ignoring scripts, embedded files, annotations and active content;
+- keep only hashes, bounded excerpts/claims and provenance in canonical persistence rather than storing the raw document body.
+
+## Non-goals
+
+Priority B-3 does not add:
+
+- arbitrary URL fetching;
+- recursive site-wide crawling;
+- authentication, private portals, CAPTCHA/MFA/paywall bypass;
+- browser automation;
+- downloads initiated by analyst page views;
+- archive execution or embedded-object extraction;
+- credential/private-message/victim-file collection;
+- automatic opportunity or outreach generation.
+
+## Completion gate
+
+B-3 is complete only when:
+
+- the existing Lot 12 public-web target schema supports explicit feed URLs and optional security.txt discovery;
+- the same PublicWebClient/collector enforces all host/path/robots/redirect/page/byte controls for the new paths;
+- RSS/Atom and security.txt parsers are deterministic and fail closed on malformed or unsafe input;
+- PDF extraction is bounded and does not persist raw document bodies;
+- feed-linked pages and documents reuse the existing PublicResource/PublicResourceVersion model;
+- feed lineage does not count as independent corroboration of its linked content;
+- security.txt creates no vulnerability, exposure or commercial-need inference;
+- deterministic parser, target-registry, client, collector and persistence tests pass;
+- Source Activation truth and the Source Coverage Matrix describe the delivered capability accurately;
+- one exact final SHA passes the complete backend and frontend CI;
+- `live_tested` remains false until separately authorized controlled validation is evidenced.

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -29,7 +29,7 @@ Symbols:
 | BODACC identity | target activation | Y | Y | - | - | N/A | - | paused until explicit French SIREN target |
 | Synthetic reference | test reference | Y | Y | Y | Y | N/A | Y | fully integrated test capability |
 | OSINT Framework import | SA-00 | - | - | - | - | N/A | - | catalogue normalization implemented; no execution authority |
-| public-web target path | SA-02 | Y | Y | - | - | - | - | adapter exists; checked-in example target remains disabled/unauthorized |
+| public-web target path | SA-02 / Priority B-3 | Y | Y | - | - | - | - | bounded sitemap + RSS/Atom + security.txt + public-document capability; checked-in example remains disabled/unauthorized |
 | NVD | SA-01 | Y | Y | Y | Y | Y | - | governed paginated adapter; live proof outstanding |
 | FIRST EPSS | SA-01 | Y | Y | Y | Y | N/A | - | bounded explicit-CVE lookup; live proof outstanding |
 | GitHub Global Advisories | SA-01 | Y | Y | Y | Y | Y | - | governed paginated adapter; live proof outstanding |
@@ -76,6 +76,26 @@ SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote onl
 Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA/Priority-B increment.
 
 OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10 closes.
+
+## Priority B-3 public web/feed/document completion boundary
+
+Priority B-3 is complete only when:
+
+- the existing Lot 12 bounded public-web collector remains the single implementation and gains RSS 2.0, Atom, `/.well-known/security.txt`, public PDF and bounded plain-text support without a parallel crawler;
+- every feed URL is explicitly configured on an organization-bound target, same-origin, path-scoped and subject to the existing robots, page, byte and redirect budgets;
+- feed XML is byte-bounded before parsing, rejects DTD/entities, accepts only RSS 2.0 or Atom and emits only canonical in-scope links;
+- feed entries are discovery lineage only and are never counted as independent corroboration for their linked pages;
+- `security.txt` is fetched only from the canonical well-known path, requires at least one supported `Contact`, validates any `Canonical` field against that exact target path and remains a disclosure/contact resource rather than vulnerability or commercial-need evidence;
+- public PDF extraction is byte- and page-bounded, rejects malformed and encrypted documents, never executes document content and only emits bounded text/title metadata into the existing Public Footprint mapping;
+- plain-text extraction is byte-bounded, UTF-8 only and rejects NUL content;
+- sitemap-, feed-, direct- and document-discovered resources reuse the existing Lot 12 `PublicResource` / `PublicResourceVersion` / provenance path and the existing collection runtime, worker and persistence path;
+- the checked-in public-web example remains disabled and unauthorized; B-3 extends the adapter capability but does not manufacture authorization or `live_tested` status;
+- no crawl-on-page-view, authentication bypass, CAPTCHA/MFA handling, private portal access, arbitrary user URL fetch, active probing or raw-body retention is introduced;
+- `security.txt`, feed metadata and document presence do not directly create commercial signals, need hypotheses, scores, opportunities, contact targets or outreach;
+- deterministic XML entity/size, malformed/oversize PDF, target-registry, client-policy, runtime/provenance and Source Activation reconciliation tests pass;
+- Source Activation truth and this matrix continue to agree that the checked-in public-web example is mapped/adapter-present but not authorized/executable;
+- the complete repository backend and frontend CI pass on one exact final SHA;
+- `live_tested` remains false until separately authorized controlled provider validation is evidenced.
 
 ## Priority B-2 developer ecosystem completion boundary
 

--- a/policies/public_web_targets.yml
+++ b/policies/public_web_targets.yml
@@ -9,6 +9,8 @@ targets:
     base_url: https://example.com
     sitemap_urls:
       - https://example.com/sitemap.xml
+    feed_urls: []
+    discover_security_txt: false
     allowed_path_prefixes:
       - /public
     enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "psycopg[binary]==3.2.9",
   "pydantic==2.11.7",
   "pydantic-settings==2.10.1",
+  "pypdf==6.14.2",
   "PyYAML==6.0.2",
   "SQLAlchemy==2.0.43",
   "starlette==1.3.1",
@@ -53,35 +54,75 @@ markers = [
 branch = true
 source = ["cip"]
 omit = [
-  "*/__init__.py",
+  "src/cip/apps/*",
+  "src/cip/cli.py",
+  "src/cip/shared/persistence/*",
+  "src/cip/shared/telemetry/*",
 ]
 
 [tool.coverage.report]
 fail_under = 90
 show_missing = true
 skip_covered = false
-precision = 2
-exclude_also = [
-  "if TYPE_CHECKING:",
-  "if __name__ == .__main__.:",
-  "raise NotImplementedError",
-  "@overload",
-]
 
 [tool.ruff]
 target-version = "py312"
 line-length = 100
-src = ["src", "tests"]
+src = ["src"]
+exclude = ["alembic/versions"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "B", "UP", "SIM", "RUF"]
+select = [
+  "A",
+  "ARG",
+  "ASYNC",
+  "B",
+  "BLE",
+  "C4",
+  "DTZ",
+  "E",
+  "F",
+  "FAST",
+  "FLY",
+  "FURB",
+  "I",
+  "LOG",
+  "N",
+  "PERF",
+  "PIE",
+  "PL",
+  "PTH",
+  "PYI",
+  "RET",
+  "RUF",
+  "S",
+  "SIM",
+  "SLF",
+  "T20",
+  "TRY",
+  "UP",
+  "W",
+]
+ignore = [
+  "S101",
+  "TRY003",
+]
 
 [tool.ruff.lint.per-file-ignores]
-"infra/migrations/versions/*.py" = ["I001"]
-"tests/unit/source_governance/test_policy.py" = ["E501"]
+"tests/**/*.py" = ["ARG001", "ARG002", "S105", "S106", "S311", "SLF001"]
 
 [tool.mypy]
 python_version = "3.12"
 strict = true
-packages = ["cip"]
 mypy_path = "src"
+files = ["src", "tests"]
+exclude = ["^alembic/versions/"]
+plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = "pypdf.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "yaml"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,75 +54,35 @@ markers = [
 branch = true
 source = ["cip"]
 omit = [
-  "src/cip/apps/*",
-  "src/cip/cli.py",
-  "src/cip/shared/persistence/*",
-  "src/cip/shared/telemetry/*",
+  "*/__init__.py",
 ]
 
 [tool.coverage.report]
 fail_under = 90
 show_missing = true
 skip_covered = false
+precision = 2
+exclude_also = [
+  "if TYPE_CHECKING:",
+  "if __name__ == .__main__.:",
+  "raise NotImplementedError",
+  "@overload",
+]
 
 [tool.ruff]
 target-version = "py312"
 line-length = 100
-src = ["src"]
-exclude = ["alembic/versions"]
+src = ["src", "tests"]
 
 [tool.ruff.lint]
-select = [
-  "A",
-  "ARG",
-  "ASYNC",
-  "B",
-  "BLE",
-  "C4",
-  "DTZ",
-  "E",
-  "F",
-  "FAST",
-  "FLY",
-  "FURB",
-  "I",
-  "LOG",
-  "N",
-  "PERF",
-  "PIE",
-  "PL",
-  "PTH",
-  "PYI",
-  "RET",
-  "RUF",
-  "S",
-  "SIM",
-  "SLF",
-  "T20",
-  "TRY",
-  "UP",
-  "W",
-]
-ignore = [
-  "S101",
-  "TRY003",
-]
+select = ["E", "F", "I", "B", "UP", "SIM", "RUF"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ARG001", "ARG002", "S105", "S106", "S311", "SLF001"]
+"infra/migrations/versions/*.py" = ["I001"]
+"tests/unit/source_governance/test_policy.py" = ["E501"]
 
 [tool.mypy]
 python_version = "3.12"
 strict = true
+packages = ["cip"]
 mypy_path = "src"
-files = ["src", "tests"]
-exclude = ["^alembic/versions/"]
-plugins = ["pydantic.mypy"]
-
-[[tool.mypy.overrides]]
-module = "pypdf.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "yaml"
-ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "psycopg[binary]==3.2.9",
   "pydantic==2.11.7",
   "pydantic-settings==2.10.1",
-  "pypdf==6.14.2",
+  "pypdf==6.15.0",
   "PyYAML==6.0.2",
   "SQLAlchemy==2.0.43",
   "starlette==1.3.1",

--- a/src/cip/adapters/sources/public_web/client.py
+++ b/src/cip/adapters/sources/public_web/client.py
@@ -20,6 +20,12 @@ _REDIRECT_STATUSES = {
     httpx.codes.PERMANENT_REDIRECT,
 }
 _TOMBSTONE_STATUSES = {httpx.codes.NOT_FOUND, httpx.codes.GONE}
+_FEED_MIME_TYPES = {
+    "application/atom+xml",
+    "application/rss+xml",
+    "application/xml",
+    "text/xml",
+}
 
 
 class PublicWebResponseError(RuntimeError):
@@ -56,6 +62,7 @@ class RobotsRules:
 class PublicWebClient:
     ROBOTS_MAX_BYTES = 256_000
     SITEMAP_MAX_BYTES = 1_000_000
+    FEED_MAX_BYTES = 1_000_000
 
     def __init__(self, client: httpx.Client) -> None:
         self._client = client
@@ -126,6 +133,45 @@ class PublicWebClient:
             requested_url=canonical,
             fetched_url=canonical,
             body=_bounded_body(response, max_bytes=self.SITEMAP_MAX_BYTES),
+            mime_type=mime_type,
+            etag=_header(response, "etag"),
+            last_modified=_header(response, "last-modified"),
+            redirects=0,
+            status_code=response.status_code,
+        )
+
+    def fetch_feed(
+        self,
+        target: PublicWebTarget,
+        feed_url: str,
+        robots: RobotsRules,
+    ) -> PublicWebFetchResult:
+        canonical = CanonicalUrl(feed_url).value
+        if canonical not in target.feed_urls:
+            raise PublicWebPolicyDeniedError("feed URL is not explicitly configured")
+        if not robots.allows(canonical):
+            raise PublicWebPolicyDeniedError("robots.txt denied feed collection")
+        response = self._client.get(
+            canonical,
+            headers={
+                "Accept": (
+                    "application/rss+xml,application/atom+xml,"
+                    "application/xml;q=0.9,text/xml;q=0.9"
+                ),
+                "User-Agent": _USER_AGENT,
+            },
+            follow_redirects=False,
+        )
+        if response.status_code in _REDIRECT_STATUSES:
+            raise PublicWebResponseError("feed redirects are not followed")
+        response.raise_for_status()
+        mime_type = _content_type(response)
+        if mime_type not in _FEED_MIME_TYPES:
+            raise PublicWebResponseError("feed returned an unexpected content type")
+        return PublicWebFetchResult(
+            requested_url=canonical,
+            fetched_url=canonical,
+            body=_bounded_body(response, max_bytes=self.FEED_MAX_BYTES),
             mime_type=mime_type,
             etag=_header(response, "etag"),
             last_modified=_header(response, "last-modified"),

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -4,14 +4,23 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.client import (
+    PublicWebClient,
+    PublicWebFetchResult,
+    RobotsRules,
+)
+from cip.adapters.sources.public_web.feed_parsing import parse_public_feed
 from cip.adapters.sources.public_web.mapper import (
+    MappedPublicPage,
     PreviousPageState,
     map_public_page,
 )
 from cip.adapters.sources.public_web.parsing import parse_sitemap
 from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.adapters.sources.public_web.security_txt import parse_security_txt
+from cip.adapters.sources.public_web.security_txt_mapper import map_security_txt
 from cip.modules.public_footprint.domain import (
+    DiscoveryMethod,
     PublicFootprintProjection,
     PublicResourceKind,
 )
@@ -51,6 +60,14 @@ class PublicWebCollectionBatch:
     not_modified: bool
 
 
+@dataclass(frozen=True, slots=True)
+class PublicWebDiscoveryCandidate:
+    url: str
+    discovery_method: DiscoveryMethod
+    source_locator: str | None = None
+    security_txt: bool = False
+
+
 def collect_public_web_target(
     client: PublicWebClient,
     entry: SourceRegistryEntry,
@@ -68,76 +85,47 @@ def collect_public_web_target(
         raise PublicWebCollectionDeniedError("target_authorization_inactive")
     _authorize(entry, target.robots_url, now=collected)
     robots = client.fetch_robots(target)
-    total_bytes = robots.bytes_fetched
-    if total_bytes > target.max_total_bytes:
-        raise PublicWebCollectionDeniedError("total_byte_budget_exceeded")
-    discovered_urls: list[str] = []
-    seen_urls: set[str] = set()
-    for sitemap_url in target.sitemap_urls:
-        _authorize(entry, sitemap_url, now=collected)
-        sitemap = client.fetch_sitemap(target, sitemap_url, robots)
-        total_bytes += len(sitemap.body)
-        if total_bytes > target.max_total_bytes:
-            raise PublicWebCollectionDeniedError("total_byte_budget_exceeded")
-        remaining = target.max_pages - len(discovered_urls)
-        if remaining <= 0:
-            break
-        for sitemap_entry in parse_sitemap(
-            sitemap.body,
-            target,
-            max_entries=remaining,
-        ):
-            if sitemap_entry.url in seen_urls:
-                continue
-            seen_urls.add(sitemap_entry.url)
-            discovered_urls.append(sitemap_entry.url)
-    usage = CrawlUsage(bytes_fetched=total_bytes)
+    candidates, discovery_bytes = _discover_candidates(
+        client,
+        entry,
+        target,
+        robots,
+        now=collected,
+        initial_bytes=robots.bytes_fetched,
+    )
+    usage = CrawlUsage(bytes_fetched=discovery_bytes)
     previous_pages = checkpoint.pages if checkpoint is not None else {}
     next_pages = dict(previous_pages)
     observations: list[RawObservation] = []
     projections: list[PublicFootprintProjection] = []
-    for url in discovered_urls:
-        _authorize(entry, url, now=collected)
-        fetched = client.fetch_page(target, url, robots, usage=usage)
-        previous = previous_pages.get(url)
-        mapped = map_public_page(
+    for candidate in candidates:
+        _authorize(entry, candidate.url, now=collected)
+        fetched = client.fetch_page(target, candidate.url, robots, usage=usage)
+        usage = CrawlUsage(
+            pages_fetched=usage.pages_fetched + 1,
+            bytes_fetched=usage.bytes_fetched + len(fetched.body),
+        )
+        if candidate.security_txt and fetched.status_code in {404, 410}:
+            continue
+        previous = previous_pages.get(candidate.url)
+        mapped = _map_candidate(
             target,
+            candidate,
             fetched,
             collection_job_id=collection_job_id,
             collected_at=collected,
             retention_until=retention_until,
-            previous=(
-                PreviousPageState(
-                    content_hash_sha256=previous.content_hash_sha256,
-                    version_id=previous.version_id,
-                    canonical_url=previous.canonical_url,
-                    resource_kind=previous.resource_kind,
-                )
-                if previous is not None
-                else None
-            ),
+            previous=previous,
         )
         if mapped.observation is not None:
             observations.append(mapped.observation)
         projections.append(mapped.projection)
-        unchanged = bool(
-            previous is not None
-            and previous.content_hash_sha256 == mapped.content_hash_sha256
-            and previous.canonical_url == fetched.fetched_url
-        )
-        if unchanged and previous is not None:
-            checkpoint_version_id = previous.version_id
-        else:
-            checkpoint_version_id = mapped.projection.version.id
-        next_pages[url] = PageCheckpoint(
+        checkpoint_version_id = _checkpoint_version_id(previous, mapped, fetched)
+        next_pages[candidate.url] = PageCheckpoint(
             content_hash_sha256=mapped.content_hash_sha256,
             version_id=checkpoint_version_id,
             canonical_url=fetched.fetched_url,
             resource_kind=mapped.projection.resource.kind,
-        )
-        usage = CrawlUsage(
-            pages_fetched=usage.pages_fetched + 1,
-            bytes_fetched=usage.bytes_fetched + len(fetched.body),
         )
     return PublicWebCollectionBatch(
         observations=tuple(observations),
@@ -145,6 +133,151 @@ def collect_public_web_target(
         checkpoint=PublicWebCheckpoint(next_pages),
         not_modified=not observations,
     )
+
+
+def _discover_candidates(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    *,
+    now: datetime,
+    initial_bytes: int,
+) -> tuple[tuple[PublicWebDiscoveryCandidate, ...], int]:
+    candidates: list[PublicWebDiscoveryCandidate] = []
+    seen: set[str] = set()
+    total_bytes = _checked_total_bytes(target, initial_bytes)
+    if target.discover_security_txt:
+        _append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=target.security_txt_url,
+                discovery_method=DiscoveryMethod.DIRECT,
+                security_txt=True,
+            ),
+            max_pages=target.max_pages,
+        )
+    for sitemap_url in target.sitemap_urls:
+        if len(candidates) >= target.max_pages:
+            break
+        _authorize(entry, sitemap_url, now=now)
+        sitemap = client.fetch_sitemap(target, sitemap_url, robots)
+        total_bytes = _checked_total_bytes(target, total_bytes + len(sitemap.body))
+        remaining = target.max_pages - len(candidates)
+        for sitemap_entry in parse_sitemap(sitemap.body, target, max_entries=remaining):
+            _append_candidate(
+                candidates,
+                seen,
+                PublicWebDiscoveryCandidate(
+                    url=sitemap_entry.url,
+                    discovery_method=DiscoveryMethod.SITEMAP,
+                ),
+                max_pages=target.max_pages,
+            )
+    for feed_url in target.feed_urls:
+        if len(candidates) >= target.max_pages:
+            break
+        _authorize(entry, feed_url, now=now)
+        feed = client.fetch_feed(target, feed_url, robots)
+        total_bytes = _checked_total_bytes(target, total_bytes + len(feed.body))
+        remaining = target.max_pages - len(candidates)
+        for feed_entry in parse_public_feed(feed.body, target, max_entries=remaining):
+            _append_candidate(
+                candidates,
+                seen,
+                PublicWebDiscoveryCandidate(
+                    url=feed_entry.url,
+                    discovery_method=DiscoveryMethod.FEED,
+                    source_locator=feed_url,
+                ),
+                max_pages=target.max_pages,
+            )
+    return tuple(candidates), total_bytes
+
+
+def _append_candidate(
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    candidate: PublicWebDiscoveryCandidate,
+    *,
+    max_pages: int,
+) -> None:
+    if len(candidates) >= max_pages or candidate.url in seen:
+        return
+    seen.add(candidate.url)
+    candidates.append(candidate)
+
+
+def _map_candidate(
+    target: PublicWebTarget,
+    candidate: PublicWebDiscoveryCandidate,
+    fetched: PublicWebFetchResult,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    previous: PageCheckpoint | None,
+) -> MappedPublicPage:
+    previous_state = _previous_state(previous)
+    if candidate.security_txt:
+        if fetched.mime_type != "text/plain":
+            raise PublicWebCollectionDeniedError(
+                "security.txt must be served as text/plain"
+            )
+        document = parse_security_txt(fetched.body, target)
+        return map_security_txt(
+            target,
+            fetched,
+            document,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+            previous=previous_state,
+        )
+    return map_public_page(
+        target,
+        fetched,
+        collection_job_id=collection_job_id,
+        collected_at=collected_at,
+        retention_until=retention_until,
+        previous=previous_state,
+        discovery_method=candidate.discovery_method,
+        discovery_source_url=candidate.source_locator,
+        allow_claims=True,
+    )
+
+
+def _previous_state(previous: PageCheckpoint | None) -> PreviousPageState | None:
+    if previous is None:
+        return None
+    return PreviousPageState(
+        content_hash_sha256=previous.content_hash_sha256,
+        version_id=previous.version_id,
+        canonical_url=previous.canonical_url,
+        resource_kind=previous.resource_kind,
+    )
+
+
+def _checkpoint_version_id(
+    previous: PageCheckpoint | None,
+    mapped: MappedPublicPage,
+    fetched: PublicWebFetchResult,
+) -> UUID:
+    unchanged = bool(
+        previous is not None
+        and previous.content_hash_sha256 == mapped.content_hash_sha256
+        and previous.canonical_url == fetched.fetched_url
+    )
+    if unchanged and previous is not None:
+        return previous.version_id
+    return mapped.projection.version.id
+
+
+def _checked_total_bytes(target: PublicWebTarget, value: int) -> int:
+    if value > target.max_total_bytes:
+        raise PublicWebCollectionDeniedError("total_byte_budget_exceeded")
+    return value
 
 
 def _authorize(entry: SourceRegistryEntry, target_url: str, *, now: datetime) -> None:

--- a/src/cip/adapters/sources/public_web/content_extraction.py
+++ b/src/cip/adapters/sources/public_web/content_extraction.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cip.adapters.sources.public_web.client import PublicWebFetchResult
+from cip.adapters.sources.public_web.document_parsing import (
+    ExtractedDocument,
+    extract_pdf_text,
+    extract_plain_text,
+)
+from cip.adapters.sources.public_web.parsing import ExtractedHtml, extract_html
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractedPublicContent:
+    title: str | None
+    language: str | None
+    text: str
+    excerpt: str | None
+    noindex: bool
+
+
+def extract_public_content(
+    result: PublicWebFetchResult,
+    *,
+    quarantined: bool,
+    tombstoned: bool,
+) -> ExtractedPublicContent | None:
+    if quarantined or tombstoned:
+        return None
+    if result.mime_type == "text/html":
+        return _from_html(extract_html(result.body))
+    if result.mime_type == "application/pdf":
+        return _from_document(extract_pdf_text(result.body))
+    if result.mime_type == "text/plain":
+        return _from_document(extract_plain_text(result.body))
+    return None
+
+
+def _from_html(extracted: ExtractedHtml) -> ExtractedPublicContent:
+    return ExtractedPublicContent(
+        title=extracted.title,
+        language=extracted.language,
+        text=extracted.text,
+        excerpt=extracted.excerpt,
+        noindex=extracted.noindex,
+    )
+
+
+def _from_document(extracted: ExtractedDocument) -> ExtractedPublicContent:
+    return ExtractedPublicContent(
+        title=extracted.title,
+        language=extracted.language,
+        text=extracted.text,
+        excerpt=extracted.excerpt,
+        noindex=False,
+    )

--- a/src/cip/adapters/sources/public_web/document_parsing.py
+++ b/src/cip/adapters/sources/public_web/document_parsing.py
@@ -6,13 +6,15 @@ from io import BytesIO
 from pypdf import PdfReader
 from pypdf.errors import PdfReadError
 
+from cip.adapters.sources.public_web.parsing import PublicWebParseError
+
 _MAX_PDF_BYTES = 5_000_000
 _MAX_PDF_PAGES = 50
 _MAX_EXTRACTED_CHARS = 100_000
 _MAX_PLAIN_TEXT_BYTES = 1_000_000
 
 
-class PublicDocumentParseError(RuntimeError):
+class PublicDocumentParseError(PublicWebParseError):
     """A bounded public document could not be parsed safely."""
 
 

--- a/src/cip/adapters/sources/public_web/document_parsing.py
+++ b/src/cip/adapters/sources/public_web/document_parsing.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import BytesIO
+
+from pypdf import PdfReader
+from pypdf.errors import PdfReadError
+
+_MAX_PDF_BYTES = 5_000_000
+_MAX_PDF_PAGES = 50
+_MAX_EXTRACTED_CHARS = 100_000
+_MAX_PLAIN_TEXT_BYTES = 1_000_000
+
+
+class PublicDocumentParseError(RuntimeError):
+    """A bounded public document could not be parsed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractedDocument:
+    title: str | None
+    language: str | None
+    text: str
+
+    @property
+    def excerpt(self) -> str | None:
+        return self.text[:1_000] or None
+
+
+def extract_pdf_text(body: bytes) -> ExtractedDocument:
+    if not body.startswith(b"%PDF-"):
+        raise PublicDocumentParseError("PDF response does not contain a PDF header")
+    if not body or len(body) > _MAX_PDF_BYTES:
+        raise PublicDocumentParseError("PDF exceeds the parser byte limit")
+    try:
+        reader = PdfReader(BytesIO(body), strict=True)
+    except (PdfReadError, ValueError, OSError) as exc:
+        raise PublicDocumentParseError("PDF could not be parsed safely") from exc
+    if reader.is_encrypted:
+        raise PublicDocumentParseError("encrypted PDFs are not processed")
+    page_count = len(reader.pages)
+    if page_count > _MAX_PDF_PAGES:
+        raise PublicDocumentParseError("PDF exceeds the parser page limit")
+    parts: list[str] = []
+    remaining = _MAX_EXTRACTED_CHARS
+    try:
+        for page in reader.pages:
+            if remaining <= 0:
+                break
+            text = page.extract_text() or ""
+            normalized = " ".join(text.split())
+            if not normalized:
+                continue
+            bounded = normalized[:remaining]
+            parts.append(bounded)
+            remaining -= len(bounded)
+    except (PdfReadError, ValueError, TypeError, KeyError) as exc:
+        raise PublicDocumentParseError("PDF text extraction failed") from exc
+    metadata = reader.metadata
+    title = None
+    if metadata is not None and metadata.title:
+        title = " ".join(str(metadata.title).split())[:1_000] or None
+    return ExtractedDocument(
+        title=title,
+        language=None,
+        text=" ".join(parts)[:_MAX_EXTRACTED_CHARS],
+    )
+
+
+def extract_plain_text(body: bytes) -> ExtractedDocument:
+    if not body or len(body) > _MAX_PLAIN_TEXT_BYTES:
+        raise PublicDocumentParseError("text response is empty or exceeds the parser byte limit")
+    try:
+        decoded = body.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise PublicDocumentParseError("text response must be valid UTF-8") from exc
+    if "\x00" in decoded:
+        raise PublicDocumentParseError("text response contains a NUL byte")
+    normalized = " ".join(decoded.split())[:_MAX_EXTRACTED_CHARS]
+    return ExtractedDocument(title=None, language=None, text=normalized)

--- a/src/cip/adapters/sources/public_web/feed_parsing.py
+++ b/src/cip/adapters/sources/public_web/feed_parsing.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from xml.etree import ElementTree
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.public_footprint.domain.scope import CrawlUsage
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+
+_MAX_FEED_BYTES = 1_000_000
+_FORBIDDEN_XML_MARKERS = (b"<!DOCTYPE", b"<!ENTITY")
+
+
+class PublicFeedParseError(RuntimeError):
+    """A configured public RSS/Atom feed could not be parsed safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class FeedEntry:
+    url: str
+    title: str | None
+    published_at: datetime | None
+
+
+def parse_public_feed(
+    body: bytes,
+    target: PublicWebTarget,
+    *,
+    max_entries: int,
+) -> tuple[FeedEntry, ...]:
+    if not 1 <= max_entries <= target.max_pages:
+        raise ValueError("feed entry limit must fit the target page budget")
+    if not body or len(body) > _MAX_FEED_BYTES:
+        raise PublicFeedParseError("feed body is empty or exceeds the parser byte limit")
+    upper = body.upper()
+    if any(marker in upper for marker in _FORBIDDEN_XML_MARKERS):
+        raise PublicFeedParseError("feed DTD and entities are not allowed")
+    try:
+        root = ElementTree.fromstring(body)
+    except ElementTree.ParseError as exc:
+        raise PublicFeedParseError("invalid feed XML") from exc
+    root_name = _local_name(root.tag)
+    if root_name == "rss":
+        candidates = _rss_entries(root)
+    elif root_name == "feed":
+        candidates = _atom_entries(root)
+    else:
+        raise PublicFeedParseError("only RSS 2.0 and Atom feeds are supported")
+    return _bounded_entries(candidates, target, max_entries=max_entries)
+
+
+def _rss_entries(root: ElementTree.Element) -> tuple[FeedEntry, ...]:
+    channel = next((node for node in root if _local_name(node.tag) == "channel"), None)
+    if channel is None:
+        raise PublicFeedParseError("RSS feed is missing channel")
+    entries: list[FeedEntry] = []
+    for item in channel:
+        if _local_name(item.tag) != "item":
+            continue
+        url = _child_text(item, "link")
+        if url is None:
+            continue
+        entries.append(
+            FeedEntry(
+                url=url,
+                title=_child_text(item, "title"),
+                published_at=_parse_time(_child_text(item, "pubDate")),
+            )
+        )
+    return tuple(entries)
+
+
+def _atom_entries(root: ElementTree.Element) -> tuple[FeedEntry, ...]:
+    entries: list[FeedEntry] = []
+    for item in root:
+        if _local_name(item.tag) != "entry":
+            continue
+        url = _atom_link(item)
+        if url is None:
+            continue
+        published = _child_text(item, "published") or _child_text(item, "updated")
+        entries.append(
+            FeedEntry(
+                url=url,
+                title=_child_text(item, "title"),
+                published_at=_parse_time(published),
+            )
+        )
+    return tuple(entries)
+
+
+def _atom_link(item: ElementTree.Element) -> str | None:
+    for child in item:
+        if _local_name(child.tag) != "link":
+            continue
+        rel = (child.attrib.get("rel") or "alternate").casefold()
+        href = child.attrib.get("href")
+        if rel == "alternate" and href:
+            normalized = href.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def _bounded_entries(
+    candidates: tuple[FeedEntry, ...],
+    target: PublicWebTarget,
+    *,
+    max_entries: int,
+) -> tuple[FeedEntry, ...]:
+    entries: list[FeedEntry] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            canonical = CanonicalUrl(candidate.url).value
+        except ValueError:
+            continue
+        decision = target.crawl_scope.evaluate_target(
+            canonical,
+            depth=1,
+            redirects=0,
+            usage=CrawlUsage(pages_fetched=len(entries)),
+        )
+        if not decision.allowed or canonical in seen:
+            continue
+        seen.add(canonical)
+        entries.append(
+            FeedEntry(
+                url=canonical,
+                title=_bounded_text(candidate.title, 1_000),
+                published_at=candidate.published_at,
+            )
+        )
+        if len(entries) == max_entries:
+            break
+    return tuple(entries)
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1].casefold()
+
+
+def _child_text(node: ElementTree.Element, name: str) -> str | None:
+    for child in node:
+        if _local_name(child.tag) == name and child.text:
+            return _bounded_text(child.text, 4_000)
+    return None
+
+
+def _bounded_text(value: str | None, maximum: int) -> str | None:
+    if value is None:
+        return None
+    normalized = " ".join(value.split())[:maximum]
+    return normalized or None
+
+
+def _parse_time(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    candidate = value.strip()
+    try:
+        parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError:
+        return _parse_rfc822(candidate)
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _parse_rfc822(value: str) -> datetime | None:
+    from email.utils import parsedate_to_datetime
+
+    try:
+        parsed = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/src/cip/adapters/sources/public_web/feed_parsing.py
+++ b/src/cip/adapters/sources/public_web/feed_parsing.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from xml.etree import ElementTree
 
+from cip.adapters.sources.public_web.parsing import PublicWebParseError
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.public_footprint.domain.scope import CrawlUsage
 from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
@@ -12,7 +14,7 @@ _MAX_FEED_BYTES = 1_000_000
 _FORBIDDEN_XML_MARKERS = (b"<!DOCTYPE", b"<!ENTITY")
 
 
-class PublicFeedParseError(RuntimeError):
+class PublicFeedParseError(PublicWebParseError):
     """A configured public RSS/Atom feed could not be parsed safely."""
 
 
@@ -169,8 +171,6 @@ def _parse_time(value: str | None) -> datetime | None:
 
 
 def _parse_rfc822(value: str) -> datetime | None:
-    from email.utils import parsedate_to_datetime
-
     try:
         parsed = parsedate_to_datetime(value)
     except (TypeError, ValueError):

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -6,11 +6,11 @@ from hashlib import sha256
 from uuid import UUID
 
 from cip.adapters.sources.public_web.client import PublicWebFetchResult
-from cip.adapters.sources.public_web.parsing import (
-    ExtractedHtml,
-    contains_credential_marker,
-    extract_html,
+from cip.adapters.sources.public_web.content_extraction import (
+    ExtractedPublicContent,
+    extract_public_content,
 )
+from cip.adapters.sources.public_web.parsing import contains_credential_marker
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.public_footprint.domain import (
     ClaimEvidenceBasis,
@@ -75,12 +75,19 @@ def map_public_page(
     collected_at: datetime,
     retention_until: datetime,
     previous: PreviousPageState | None,
+    discovery_method: DiscoveryMethod = DiscoveryMethod.SITEMAP,
+    discovery_source_url: str | None = None,
+    allow_claims: bool = True,
 ) -> MappedPublicPage:
     tombstoned = _is_tombstone(result)
     content_hash = _content_hash(result)
     quarantined = not tombstoned and contains_credential_marker(result.body)
     unchanged = _is_unchanged(previous, result, content_hash)
-    extracted = _extracted_html(result, quarantined=quarantined, tombstoned=tombstoned)
+    extracted = extract_public_content(
+        result,
+        quarantined=quarantined,
+        tombstoned=tombstoned,
+    )
     indexable_text = _indexable_text(extracted)
     resource = _resource(
         target,
@@ -91,6 +98,8 @@ def map_public_page(
         tombstoned=tombstoned,
         unchanged=unchanged,
         extracted=extracted,
+        discovery_method=discovery_method,
+        discovery_source_url=discovery_source_url,
     )
     version = _version(
         resource,
@@ -103,7 +112,11 @@ def map_public_page(
         extracted=extracted,
         tombstoned=tombstoned,
     )
-    claims = () if tombstoned else _claims(target, resource, version, indexable_text)
+    claims = (
+        ()
+        if tombstoned or not allow_claims
+        else _claims(target, resource, version, indexable_text)
+    )
     projection = PublicFootprintProjection(resource=resource, version=version, claims=claims)
     observation = (
         None
@@ -117,6 +130,7 @@ def map_public_page(
             content_hash=content_hash,
             extracted=extracted,
             tombstoned=tombstoned,
+            include_technology_category=allow_claims,
         )
     )
     return MappedPublicPage(
@@ -135,7 +149,9 @@ def _resource(
     quarantined: bool,
     tombstoned: bool,
     unchanged: bool,
-    extracted: ExtractedHtml | None,
+    extracted: ExtractedPublicContent | None,
+    discovery_method: DiscoveryMethod,
+    discovery_source_url: str | None,
 ) -> PublicResource:
     kind = _resource_kind(result, previous)
     return PublicResource(
@@ -143,9 +159,9 @@ def _resource(
         source_id=target.id,
         source_record_key=result.requested_url,
         canonical_url=result.fetched_url,
-        source_url=result.requested_url,
+        source_url=discovery_source_url or result.requested_url,
         kind=kind,
-        discovery_method=DiscoveryMethod.SITEMAP,
+        discovery_method=discovery_method,
         first_discovered_at=collected_at,
         last_seen_at=collected_at,
         access_state=(
@@ -172,7 +188,7 @@ def _version(
     unchanged: bool,
     content_hash: str,
     indexable_text: str,
-    extracted: ExtractedHtml | None,
+    extracted: ExtractedPublicContent | None,
     tombstoned: bool,
 ) -> PublicResourceVersion:
     excerpt = (
@@ -212,11 +228,12 @@ def _observation(
     collected_at: datetime,
     retention_until: datetime,
     content_hash: str,
-    extracted: ExtractedHtml | None,
+    extracted: ExtractedPublicContent | None,
     tombstoned: bool,
+    include_technology_category: bool,
 ) -> RawObservation:
     categories = {DataCategory.OFFICIAL_DOCUMENT_DISCOVERY}
-    if not tombstoned:
+    if not tombstoned and include_technology_category:
         categories.add(DataCategory.TECHNOLOGY_OBSERVATION)
     return RawObservation(
         source_id=target.id,
@@ -263,18 +280,7 @@ def _is_unchanged(
     )
 
 
-def _extracted_html(
-    result: PublicWebFetchResult,
-    *,
-    quarantined: bool,
-    tombstoned: bool,
-) -> ExtractedHtml | None:
-    if result.mime_type != "text/html" or quarantined or tombstoned:
-        return None
-    return extract_html(result.body)
-
-
-def _indexable_text(extracted: ExtractedHtml | None) -> str:
+def _indexable_text(extracted: ExtractedPublicContent | None) -> str:
     if extracted is None or extracted.noindex:
         return ""
     return extracted.text
@@ -286,7 +292,7 @@ def _resource_kind(
 ) -> PublicResourceKind:
     if _is_tombstone(result) and previous is not None:
         return previous.resource_kind
-    if result.mime_type == "application/pdf":
+    if result.mime_type in {"application/pdf", "text/plain"}:
         return PublicResourceKind.DOCUMENT
     return PublicResourceKind.WEB_PAGE
 

--- a/src/cip/adapters/sources/public_web/registry.py
+++ b/src/cip/adapters/sources/public_web/registry.py
@@ -20,6 +20,7 @@ _NON_PUBLIC_HOST_SUFFIXES = (
     ".local",
     ".localhost",
 )
+_SECURITY_TXT_PATH = "/.well-known/security.txt"
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,6 +36,8 @@ class PublicWebTarget:
     authorization_reviewed_at: datetime | None
     authorization_expires_at: datetime | None = None
     terms_url: str | None = None
+    feed_urls: tuple[str, ...] = ()
+    discover_security_txt: bool = False
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -47,11 +50,10 @@ class PublicWebTarget:
             raise ValueError("public web target id and canonical_name are required")
         base = CanonicalUrl(self.base_url)
         _validate_public_hostname(base.host)
-        sitemaps = tuple(CanonicalUrl(value).value for value in self.sitemap_urls)
-        if not sitemaps:
-            raise ValueError("public web target requires at least one sitemap URL")
-        if any(not same_origin(base, sitemap) for sitemap in sitemaps):
-            raise ValueError("public web sitemap URLs must share the target origin")
+        sitemaps = _same_origin_urls(base, self.sitemap_urls, label="sitemap")
+        feeds = _same_origin_urls(base, self.feed_urls, label="feed")
+        if not sitemaps and not feeds and not self.discover_security_txt:
+            raise ValueError("public web target requires an explicit discovery path")
         reviewed_at = _optional_time(
             self.authorization_reviewed_at,
             field_name="authorization_reviewed_at",
@@ -66,9 +68,12 @@ class PublicWebTarget:
         if self.enabled and (reference is None or reviewed_at is None):
             raise ValueError("enabled public web target requires reviewed authorization")
         terms_url = CanonicalUrl(self.terms_url).value if self.terms_url else None
+        prefixes = self.allowed_path_prefixes
+        if self.discover_security_txt and _SECURITY_TXT_PATH not in prefixes:
+            prefixes = (*prefixes, _SECURITY_TXT_PATH)
         scope = CrawlScope(
             allowed_hosts=frozenset({base.host}),
-            allowed_path_prefixes=self.allowed_path_prefixes,
+            allowed_path_prefixes=prefixes,
             max_depth=1,
             max_pages=self.max_pages,
             max_total_bytes=self.max_total_bytes,
@@ -79,6 +84,7 @@ class PublicWebTarget:
         object.__setattr__(self, "canonical_name", name)
         object.__setattr__(self, "base_url", base.value)
         object.__setattr__(self, "sitemap_urls", sitemaps)
+        object.__setattr__(self, "feed_urls", feeds)
         object.__setattr__(self, "allowed_path_prefixes", scope.allowed_path_prefixes)
         object.__setattr__(self, "authorization_reference", reference)
         object.__setattr__(self, "authorization_reviewed_at", reviewed_at)
@@ -92,6 +98,10 @@ class PublicWebTarget:
     @property
     def robots_url(self) -> str:
         return f"{CanonicalUrl(self.base_url).origin}/robots.txt"
+
+    @property
+    def security_txt_url(self) -> str:
+        return f"{CanonicalUrl(self.base_url).origin}{_SECURITY_TXT_PATH}"
 
     @property
     def crawl_scope(self) -> CrawlScope:
@@ -151,7 +161,9 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
         organization_id=UUID(_required_string(payload, "organization_id")),
         canonical_name=_required_string(payload, "canonical_name"),
         base_url=_required_string(payload, "base_url"),
-        sitemap_urls=_string_tuple(payload, "sitemap_urls", minimum=1),
+        sitemap_urls=_string_tuple(payload, "sitemap_urls", minimum=0),
+        feed_urls=_string_tuple(payload, "feed_urls", minimum=0),
+        discover_security_txt=_optional_bool(payload, "discover_security_txt", default=False),
         allowed_path_prefixes=_string_tuple(
             payload,
             "allowed_path_prefixes",
@@ -186,6 +198,20 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
         ),
         max_redirects=_bounded_int(limits, "max_redirects", minimum=0, maximum=10),
     )
+
+
+def _same_origin_urls(
+    base: CanonicalUrl,
+    values: tuple[str, ...],
+    *,
+    label: str,
+) -> tuple[str, ...]:
+    urls = tuple(CanonicalUrl(value).value for value in values)
+    if any(not same_origin(base, url) for url in urls):
+        raise ValueError(f"public web {label} URLs must share the target origin")
+    if len(set(urls)) != len(urls):
+        raise ValueError(f"public web {label} URLs must be unique")
+    return urls
 
 
 def _validate_public_hostname(host: str) -> None:
@@ -241,13 +267,20 @@ def _required_bool(payload: dict[str, Any], key: str) -> bool:
     return value
 
 
+def _optional_bool(payload: dict[str, Any], key: str, *, default: bool) -> bool:
+    value = payload.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
 def _string_tuple(
     payload: dict[str, Any],
     key: str,
     *,
     minimum: int,
 ) -> tuple[str, ...]:
-    value = payload.get(key)
+    value = payload.get(key, [])
     if not isinstance(value, list) or len(value) < minimum:
         raise ValueError(f"{key} must contain at least {minimum} item(s)")
     result: list[str] = []

--- a/src/cip/adapters/sources/public_web/security_txt.py
+++ b/src/cip/adapters/sources/public_web/security_txt.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from urllib.parse import urlsplit
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+
+_MAX_SECURITY_TXT_BYTES = 64_000
+_MAX_FIELDS = 200
+_SUPPORTED_CONTACT_SCHEMES = frozenset({"https", "mailto"})
+
+
+class SecurityTxtParseError(RuntimeError):
+    """A configured RFC 9116 security.txt file failed bounded validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class SecurityTxtDocument:
+    contacts: tuple[str, ...]
+    canonical_urls: tuple[str, ...]
+    expires_at: datetime | None
+    preferred_languages: tuple[str, ...]
+
+
+def parse_security_txt(body: bytes, target: PublicWebTarget) -> SecurityTxtDocument:
+    if not body or len(body) > _MAX_SECURITY_TXT_BYTES:
+        raise SecurityTxtParseError("security.txt is empty or exceeds the parser byte limit")
+    try:
+        text = body.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise SecurityTxtParseError("security.txt must be valid UTF-8") from exc
+    if "\x00" in text:
+        raise SecurityTxtParseError("security.txt contains a NUL byte")
+    fields = _fields(text)
+    contacts = tuple(
+        value
+        for name, value in fields
+        if name == "contact" and _valid_contact(value)
+    )
+    if not contacts:
+        raise SecurityTxtParseError("security.txt requires at least one valid Contact field")
+    canonical_urls = _canonical_urls(fields, target)
+    expires_at = _expires_at(fields)
+    languages = _preferred_languages(fields)
+    return SecurityTxtDocument(
+        contacts=contacts,
+        canonical_urls=canonical_urls,
+        expires_at=expires_at,
+        preferred_languages=languages,
+    )
+
+
+def bounded_security_txt_excerpt(
+    document: SecurityTxtDocument,
+    *,
+    maximum: int = 1_000,
+) -> str:
+    if not 1 <= maximum <= 4_000:
+        raise ValueError("security.txt excerpt bound must be between 1 and 4000")
+    parts = [*(f"Contact: {value}" for value in document.contacts)]
+    parts.extend(f"Canonical: {value}" for value in document.canonical_urls)
+    if document.expires_at is not None:
+        parts.append(f"Expires: {document.expires_at.isoformat()}")
+    if document.preferred_languages:
+        parts.append(f"Preferred-Languages: {', '.join(document.preferred_languages)}")
+    return "\n".join(parts)[:maximum]
+
+
+def _fields(text: str) -> tuple[tuple[str, str], ...]:
+    result: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if len(result) >= _MAX_FIELDS:
+            raise SecurityTxtParseError("security.txt contains too many fields")
+        name, separator, raw_value = stripped.partition(":")
+        if not separator:
+            continue
+        normalized_name = name.strip().casefold()
+        value = raw_value.strip()
+        if normalized_name and value:
+            result.append((normalized_name, value[:4_000]))
+    return tuple(result)
+
+
+def _valid_contact(value: str) -> bool:
+    parsed = urlsplit(value)
+    if parsed.scheme.casefold() not in _SUPPORTED_CONTACT_SCHEMES:
+        return False
+    if parsed.scheme.casefold() == "mailto":
+        address = parsed.path.strip()
+        return "@" in address and not any(char.isspace() for char in address)
+    try:
+        CanonicalUrl(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _canonical_urls(
+    fields: tuple[tuple[str, str], ...],
+    target: PublicWebTarget,
+) -> tuple[str, ...]:
+    expected = CanonicalUrl(target.security_txt_url).value
+    values: list[str] = []
+    for name, value in fields:
+        if name != "canonical":
+            continue
+        try:
+            canonical = CanonicalUrl(value).value
+        except ValueError as exc:
+            raise SecurityTxtParseError("security.txt Canonical field is invalid") from exc
+        if canonical != expected:
+            raise SecurityTxtParseError(
+                "security.txt Canonical field does not match the configured exact path"
+            )
+        if canonical not in values:
+            values.append(canonical)
+    return tuple(values)
+
+
+def _expires_at(fields: tuple[tuple[str, str], ...]) -> datetime | None:
+    value = next((value for name, value in fields if name == "expires"), None)
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise SecurityTxtParseError("security.txt Expires field is invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SecurityTxtParseError("security.txt Expires field requires a timezone")
+    return parsed.astimezone(UTC)
+
+
+def _preferred_languages(
+    fields: tuple[tuple[str, str], ...],
+) -> tuple[str, ...]:
+    raw = next((value for name, value in fields if name == "preferred-languages"), None)
+    if raw is None:
+        return ()
+    languages = tuple(
+        token.strip().casefold()
+        for token in raw.split(",")
+        if token.strip()
+    )
+    return languages[:20]

--- a/src/cip/adapters/sources/public_web/security_txt.py
+++ b/src/cip/adapters/sources/public_web/security_txt.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from urllib.parse import urlsplit
 
+from cip.adapters.sources.public_web.parsing import PublicWebParseError
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
 
@@ -12,7 +13,7 @@ _MAX_FIELDS = 200
 _SUPPORTED_CONTACT_SCHEMES = frozenset({"https", "mailto"})
 
 
-class SecurityTxtParseError(RuntimeError):
+class SecurityTxtParseError(PublicWebParseError):
     """A configured RFC 9116 security.txt file failed bounded validation."""
 
 

--- a/src/cip/adapters/sources/public_web/security_txt_mapper.py
+++ b/src/cip/adapters/sources/public_web/security_txt_mapper.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID
+
+from cip.adapters.sources.public_web.client import PublicWebFetchResult
+from cip.adapters.sources.public_web.mapper import MappedPublicPage, PreviousPageState
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.adapters.sources.public_web.security_txt import (
+    SecurityTxtDocument,
+    bounded_security_txt_excerpt,
+)
+from cip.modules.public_footprint.domain.models import (
+    DiscoveryMethod,
+    PublicFootprintProjection,
+    PublicResource,
+    PublicResourceKind,
+    PublicResourceVersion,
+    ResourceAccessState,
+    ResourceRetrievalState,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import DataCategory
+
+
+def map_security_txt(
+    target: PublicWebTarget,
+    result: PublicWebFetchResult,
+    document: SecurityTxtDocument,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    previous: PreviousPageState | None,
+) -> MappedPublicPage:
+    content_hash = sha256(result.body).hexdigest()
+    unchanged = bool(
+        previous is not None
+        and previous.content_hash_sha256 == content_hash
+        and previous.canonical_url == result.fetched_url
+    )
+    excerpt = bounded_security_txt_excerpt(document)
+    resource = PublicResource(
+        organization_id=target.organization_id,
+        source_id=target.id,
+        source_record_key=result.requested_url,
+        canonical_url=result.fetched_url,
+        source_url=result.requested_url,
+        kind=PublicResourceKind.DOCUMENT,
+        discovery_method=DiscoveryMethod.DIRECT,
+        first_discovered_at=collected_at,
+        last_seen_at=collected_at,
+        access_state=ResourceAccessState.PUBLIC,
+        retrieval_state=_retrieval_state(previous, unchanged=unchanged),
+        title="security.txt",
+    )
+    version = PublicResourceVersion(
+        resource_key=resource.identity_key,
+        source_url=result.fetched_url,
+        content_hash_sha256=content_hash,
+        fetched_at=collected_at,
+        mime_type=result.mime_type,
+        byte_size=len(result.body),
+        title="security.txt",
+        extracted_text_hash_sha256=sha256(excerpt.encode()).hexdigest(),
+        excerpt=excerpt,
+        source_locator=result.fetched_url,
+        supersedes_version_id=(
+            previous.version_id
+            if previous is not None
+            and not unchanged
+            and previous.canonical_url == result.fetched_url
+            else None
+        ),
+    )
+    projection = PublicFootprintProjection(resource=resource, version=version, claims=())
+    observation = None
+    if not unchanged:
+        observation = RawObservation(
+            source_id=target.id,
+            adapter_id="public-web-sitemap",
+            adapter_version="1",
+            collection_job_id=collection_job_id,
+            source_record_type="public_security_txt",
+            source_record_key=result.requested_url,
+            source_url=result.fetched_url,
+            payload_hash_sha256=content_hash,
+            data_categories=frozenset({DataCategory.OFFICIAL_DOCUMENT_DISCOVERY}),
+            collected_at=collected_at,
+            observed_at=collected_at,
+            source_updated_at=collected_at,
+            schema_fingerprint="public-security-txt-v1",
+            retention_until=retention_until,
+        )
+    return MappedPublicPage(
+        projection=projection,
+        observation=observation,
+        content_hash_sha256=content_hash,
+    )
+
+
+def _retrieval_state(
+    previous: PreviousPageState | None,
+    *,
+    unchanged: bool,
+) -> ResourceRetrievalState:
+    if unchanged:
+        return ResourceRetrievalState.NOT_MODIFIED
+    if previous is not None:
+        return ResourceRetrievalState.CHANGED
+    return ResourceRetrievalState.FETCHED

--- a/tests/unit/adapters/test_public_web_b3_collector.py
+++ b/tests/unit/adapters/test_public_web_b3_collector.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
+from uuid import UUID
+
+import httpx
+from pypdf import PdfWriter
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.public_footprint.domain.models import (
+    DiscoveryMethod,
+    PublicResourceKind,
+)
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    DataCategory,
+    SourceAuthorization,
+    SourcePolicy,
+    SourceStatus,
+    SourceType,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+NOW = datetime(2026, 8, 10, 12, 0, tzinfo=UTC)
+ORG_ID = UUID("00000000-0000-0000-0000-000000000841")
+JOB_ID = UUID("00000000-0000-0000-0000-000000000842")
+
+
+def test_feed_security_txt_and_pdf_share_existing_public_web_collector() -> None:
+    pdf_body = _pdf()
+    requested_paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        if request.url.path == "/robots.txt":
+            return _response("text/plain", b"User-agent: *\nAllow: /\n")
+        if request.url.path == "/public/feed.xml":
+            return _response(
+                "application/rss+xml",
+                b"<rss version='2.0'><channel><item>"
+                b"<link>https://example.com/public/report.pdf</link>"
+                b"</item></channel></rss>",
+            )
+        if request.url.path == "/.well-known/security.txt":
+            return _response(
+                "text/plain",
+                b"Contact: mailto:security@example.com\n"
+                b"Canonical: https://example.com/.well-known/security.txt\n",
+            )
+        if request.url.path == "/public/report.pdf":
+            return _response("application/pdf", pdf_body)
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    target = _target()
+    entry = _entry()
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            entry,
+            target,
+            collection_job_id=JOB_ID,
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+    assert requested_paths == [
+        "/robots.txt",
+        "/public/feed.xml",
+        "/.well-known/security.txt",
+        "/public/report.pdf",
+    ]
+    assert len(batch.projections) == 2
+    security, report = batch.projections
+    assert security.resource.kind is PublicResourceKind.DOCUMENT
+    assert security.resource.discovery_method is DiscoveryMethod.DIRECT
+    assert security.claims == ()
+    assert security.version.excerpt is not None
+    assert "security@example.com" in security.version.excerpt
+    assert report.resource.kind is PublicResourceKind.DOCUMENT
+    assert report.resource.discovery_method is DiscoveryMethod.FEED
+    assert report.resource.source_url == "https://example.com/public/feed.xml"
+    assert len(batch.observations) == 2
+    assert batch.not_modified is False
+
+
+def _target() -> PublicWebTarget:
+    return PublicWebTarget(
+        id="public-web-test",
+        organization_id=ORG_ID,
+        canonical_name="Example",
+        base_url="https://example.com",
+        sitemap_urls=(),
+        feed_urls=("https://example.com/public/feed.xml",),
+        discover_security_txt=True,
+        allowed_path_prefixes=("/public",),
+        enabled=True,
+        authorization_reference="test-authorization",
+        authorization_reviewed_at=NOW - timedelta(days=1),
+        max_pages=10,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=2,
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    policy = SourcePolicy(
+        id="public-web-test",
+        name="Public web test",
+        base_url="https://example.com",
+        status=SourceStatus.ENABLED,
+        source_type=SourceType.STATIC_HTTP,
+        owner="Example",
+        allowed_data_categories=frozenset({DataCategory.OFFICIAL_DOCUMENT_DISCOVERY}),
+        prohibited_data_categories=frozenset(
+            {
+                DataCategory.CREDENTIAL,
+                DataCategory.VICTIM_FILE,
+                DataCategory.PRIVATE_COMMUNICATION,
+                DataCategory.PRIVATE_PERSONAL_DATA,
+                DataCategory.RESTRICTED_CONTENT,
+            }
+        ),
+        terms_url="https://example.com/terms",
+        raw_content_storage=False,
+        human_review_required=False,
+    )
+    authorization = SourceAuthorization(
+        status=AuthorizationStatus.APPROVED,
+        document_reference="test-authorization",
+        reviewed_at=NOW - timedelta(days=1),
+        approved_hosts=frozenset({"example.com"}),
+        approved_path_prefixes=(
+            "/robots.txt",
+            "/public",
+            "/.well-known/security.txt",
+        ),
+        approved_purposes=frozenset({"corporate-public-footprint"}),
+        automated_collection_allowed=True,
+        raw_storage_allowed=False,
+    )
+    return SourceRegistryEntry(policy=policy, authorization=authorization, economics={})
+
+
+def _pdf() -> bytes:
+    writer = PdfWriter()
+    writer.add_blank_page(width=100, height=100)
+    writer.add_metadata({"/Title": "Cloud security roadmap"})
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def _response(content_type: str, body: bytes) -> httpx.Response:
+    return httpx.Response(200, headers={"content-type": content_type}, content=body)

--- a/tests/unit/adapters/test_public_web_b3_edge_cases.py
+++ b/tests/unit/adapters/test_public_web_b3_edge_cases.py
@@ -244,16 +244,20 @@ def test_fetch_feed_fails_closed_on_configuration_robots_redirect_and_mime() -> 
     def redirect(_: httpx.Request) -> httpx.Response:
         return httpx.Response(302, headers={"location": FEED_URL})
 
-    with httpx.Client(transport=httpx.MockTransport(redirect)) as http_client:
-        with pytest.raises(PublicWebResponseError, match="redirects"):
-            PublicWebClient(http_client).fetch_feed(target, FEED_URL, allowed)
+    with (
+        httpx.Client(transport=httpx.MockTransport(redirect)) as http_client,
+        pytest.raises(PublicWebResponseError, match="redirects"),
+    ):
+        PublicWebClient(http_client).fetch_feed(target, FEED_URL, allowed)
 
     def wrong_mime(_: httpx.Request) -> httpx.Response:
         return httpx.Response(200, headers={"content-type": "text/html"}, content=b"<html/>")
 
-    with httpx.Client(transport=httpx.MockTransport(wrong_mime)) as http_client:
-        with pytest.raises(PublicWebResponseError, match="content type"):
-            PublicWebClient(http_client).fetch_feed(target, FEED_URL, allowed)
+    with (
+        httpx.Client(transport=httpx.MockTransport(wrong_mime)) as http_client,
+        pytest.raises(PublicWebResponseError, match="content type"),
+    ):
+        PublicWebClient(http_client).fetch_feed(target, FEED_URL, allowed)
 
 
 def test_fetch_feed_rejects_invalid_or_oversized_content_length() -> None:
@@ -267,9 +271,11 @@ def test_fetch_feed_rejects_invalid_or_oversized_content_length() -> None:
             content=b"<rss/>",
         )
 
-    with httpx.Client(transport=httpx.MockTransport(invalid_length)) as http_client:
-        with pytest.raises(PublicWebResponseError, match="invalid Content-Length"):
-            PublicWebClient(http_client).fetch_feed(target, FEED_URL, robots)
+    with (
+        httpx.Client(transport=httpx.MockTransport(invalid_length)) as http_client,
+        pytest.raises(PublicWebResponseError, match="invalid Content-Length"),
+    ):
+        PublicWebClient(http_client).fetch_feed(target, FEED_URL, robots)
 
     def oversized_length(_: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -278,9 +284,11 @@ def test_fetch_feed_rejects_invalid_or_oversized_content_length() -> None:
             content=b"<rss/>",
         )
 
-    with httpx.Client(transport=httpx.MockTransport(oversized_length)) as http_client:
-        with pytest.raises(PublicWebResponseError, match="size limit"):
-            PublicWebClient(http_client).fetch_feed(target, FEED_URL, robots)
+    with (
+        httpx.Client(transport=httpx.MockTransport(oversized_length)) as http_client,
+        pytest.raises(PublicWebResponseError, match="size limit"),
+    ):
+        PublicWebClient(http_client).fetch_feed(target, FEED_URL, robots)
 
 
 def test_target_rejects_missing_discovery_off_origin_feed_and_unreviewed_enablement() -> None:

--- a/tests/unit/adapters/test_public_web_b3_edge_cases.py
+++ b/tests/unit/adapters/test_public_web_b3_edge_cases.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from urllib.robotparser import RobotFileParser
+from uuid import UUID
+
+import httpx
+import pytest
+from pypdf import PdfWriter
+
+from cip.adapters.sources.public_web.client import (
+    PublicWebClient,
+    PublicWebPolicyDeniedError,
+    PublicWebResponseError,
+    RobotsRules,
+)
+from cip.adapters.sources.public_web.document_parsing import (
+    PublicDocumentParseError,
+    extract_pdf_text,
+    extract_plain_text,
+)
+from cip.adapters.sources.public_web.feed_parsing import (
+    PublicFeedParseError,
+    parse_public_feed,
+)
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.adapters.sources.public_web.security_txt import (
+    SecurityTxtParseError,
+    bounded_security_txt_excerpt,
+    parse_security_txt,
+)
+
+ORG_ID = UUID("00000000-0000-0000-0000-000000000851")
+NOW = datetime(2026, 8, 10, 12, 0, tzinfo=UTC)
+FEED_URL = "https://example.com/public/feed.xml"
+
+
+def test_feed_rejects_invalid_limits_empty_malformed_and_unknown_xml() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+
+    with pytest.raises(ValueError, match="entry limit"):
+        parse_public_feed(b"<rss/>", target, max_entries=0)
+    with pytest.raises(ValueError, match="entry limit"):
+        parse_public_feed(b"<rss/>", target, max_entries=target.max_pages + 1)
+    with pytest.raises(PublicFeedParseError, match="empty"):
+        parse_public_feed(b"", target, max_entries=1)
+    with pytest.raises(PublicFeedParseError, match="invalid feed XML"):
+        parse_public_feed(b"<rss>", target, max_entries=1)
+    with pytest.raises(PublicFeedParseError, match="RSS 2.0 and Atom"):
+        parse_public_feed(b"<catalog/>", target, max_entries=1)
+
+
+def test_rss_requires_channel_and_skips_missing_or_invalid_links() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+
+    with pytest.raises(PublicFeedParseError, match="missing channel"):
+        parse_public_feed(b"<rss/>", target, max_entries=5)
+
+    body = b"""<rss version='2.0'><channel>
+      <item><title>No link</title></item>
+      <item><link>not a valid absolute URL</link></item>
+      <item><link>https://example.com/private/nope</link></item>
+    </channel></rss>"""
+    assert parse_public_feed(body, target, max_entries=5) == ()
+
+
+def test_feed_deduplicates_caps_entries_and_bounds_titles() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+    long_title = "x" * 1_500
+    body = (
+        "<rss version='2.0'><channel>"
+        f"<item><title>{long_title}</title><link>https://example.com/public/a</link></item>"
+        "<item><link>https://example.com/public/a</link></item>"
+        "<item><link>https://example.com/public/b</link></item>"
+        "</channel></rss>"
+    ).encode()
+
+    entries = parse_public_feed(body, target, max_entries=1)
+
+    assert len(entries) == 1
+    assert entries[0].url == "https://example.com/public/a"
+    assert entries[0].title == "x" * 1_000
+
+
+def test_atom_skips_non_alternate_links_and_parses_supported_dates() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+    body = b"""<feed xmlns='http://www.w3.org/2005/Atom'>
+      <entry><link rel='self' href='https://example.com/public/self'/></entry>
+      <entry><link rel='alternate'/></entry>
+      <entry>
+        <link href='https://example.com/public/iso'/>
+        <published>2026-08-10T10:30:00Z</published>
+      </entry>
+      <entry>
+        <link href='https://example.com/public/rfc'/>
+        <updated>Sun, 10 Aug 2026 11:30:00 +0000</updated>
+      </entry>
+      <entry>
+        <link href='https://example.com/public/bad-date'/>
+        <updated>not-a-date</updated>
+      </entry>
+    </feed>"""
+
+    entries = parse_public_feed(body, target, max_entries=10)
+
+    assert tuple(entry.url for entry in entries) == (
+        "https://example.com/public/iso",
+        "https://example.com/public/rfc",
+        "https://example.com/public/bad-date",
+    )
+    assert entries[0].published_at == datetime(2026, 8, 10, 10, 30, tzinfo=UTC)
+    assert entries[1].published_at is not None
+    assert entries[1].published_at.tzinfo is not None
+    assert entries[2].published_at is None
+
+
+def test_feed_normalizes_naive_iso_timestamp_to_utc() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+    body = b"""<feed xmlns='http://www.w3.org/2005/Atom'><entry>
+      <link href='https://example.com/public/naive'/>
+      <updated>2026-08-10T10:30:00</updated>
+    </entry></feed>"""
+
+    entries = parse_public_feed(body, target, max_entries=5)
+
+    assert entries[0].published_at == datetime(2026, 8, 10, 10, 30, tzinfo=UTC)
+
+
+def test_security_txt_rejects_empty_invalid_utf8_nul_and_field_overflow() -> None:
+    target = _target(discover_security_txt=True)
+
+    with pytest.raises(SecurityTxtParseError, match="empty"):
+        parse_security_txt(b"", target)
+    with pytest.raises(SecurityTxtParseError, match="UTF-8"):
+        parse_security_txt(b"Contact: mailto:security@example.com\n\xff", target)
+    with pytest.raises(SecurityTxtParseError, match="NUL"):
+        parse_security_txt(b"Contact: mailto:security@example.com\x00", target)
+
+    lines = ["Contact: mailto:security@example.com"]
+    lines.extend(f"Policy-{index}: value" for index in range(200))
+    with pytest.raises(SecurityTxtParseError, match="too many fields"):
+        parse_security_txt("\n".join(lines).encode(), target)
+
+
+def test_security_txt_rejects_unsupported_contact_and_invalid_canonical() -> None:
+    target = _target(discover_security_txt=True)
+
+    with pytest.raises(SecurityTxtParseError, match="valid Contact"):
+        parse_security_txt(b"Contact: ftp://example.com/security", target)
+    with pytest.raises(SecurityTxtParseError, match="Canonical field is invalid"):
+        parse_security_txt(
+            b"Contact: mailto:security@example.com\nCanonical: not-a-url",
+            target,
+        )
+
+
+def test_security_txt_validates_expires_and_supports_https_contact() -> None:
+    target = _target(discover_security_txt=True)
+
+    with pytest.raises(SecurityTxtParseError, match="Expires field is invalid"):
+        parse_security_txt(
+            b"Contact: https://example.com/public/security\nExpires: tomorrow",
+            target,
+        )
+    with pytest.raises(SecurityTxtParseError, match="requires a timezone"):
+        parse_security_txt(
+            b"Contact: https://example.com/public/security\nExpires: 2027-01-01T00:00:00",
+            target,
+        )
+
+    document = parse_security_txt(
+        b"# comment\nIgnored line\n"
+        b"Contact: https://example.com/public/security\n"
+        b"Canonical: https://example.com/.well-known/security.txt\n"
+        b"Canonical: https://example.com/.well-known/security.txt\n",
+        target,
+    )
+    assert document.contacts == ("https://example.com/public/security",)
+    assert document.canonical_urls == (
+        "https://example.com/.well-known/security.txt",
+    )
+    assert document.expires_at is None
+    assert document.preferred_languages == ()
+
+
+def test_security_txt_language_and_excerpt_bounds_are_deterministic() -> None:
+    target = _target(discover_security_txt=True)
+    languages = ", ".join(f"x-{index}" for index in range(25))
+    body = (
+        "Contact: mailto:security@example.com\n"
+        "Expires: 2027-01-01T00:00:00Z\n"
+        f"Preferred-Languages: {languages}\n"
+    ).encode()
+
+    document = parse_security_txt(body, target)
+    excerpt = bounded_security_txt_excerpt(document, maximum=80)
+
+    assert len(document.preferred_languages) == 20
+    assert document.expires_at == datetime(2027, 1, 1, tzinfo=UTC)
+    assert len(excerpt) <= 80
+    assert excerpt.startswith("Contact: mailto:security@example.com")
+    with pytest.raises(ValueError, match="excerpt bound"):
+        bounded_security_txt_excerpt(document, maximum=0)
+
+
+def test_plain_text_parser_accepts_bounded_text_and_rejects_unsafe_shapes() -> None:
+    extracted = extract_plain_text(b"  Security\n  roadmap\t2027  ")
+    assert extracted.text == "Security roadmap 2027"
+    assert extracted.excerpt == "Security roadmap 2027"
+    assert extracted.title is None
+
+    with pytest.raises(PublicDocumentParseError, match="empty"):
+        extract_plain_text(b"")
+    with pytest.raises(PublicDocumentParseError, match="byte limit"):
+        extract_plain_text(b"x" * 1_000_001)
+    with pytest.raises(PublicDocumentParseError, match="NUL"):
+        extract_plain_text(b"safe\x00unsafe")
+
+
+def test_pdf_without_title_remains_a_bounded_document() -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=100, height=100)
+    buffer = _write_pdf(writer)
+
+    extracted = extract_pdf_text(buffer)
+
+    assert extracted.title is None
+    assert extracted.text == ""
+    assert extracted.excerpt is None
+
+
+def test_fetch_feed_fails_closed_on_configuration_robots_redirect_and_mime() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+    allowed = _robots(missing=True)
+    denied = _robots(missing=False, lines=("User-agent: *", "Disallow: /public/feed.xml"))
+
+    with httpx.Client(transport=httpx.MockTransport(_ok_feed)) as http_client:
+        client = PublicWebClient(http_client)
+        with pytest.raises(PublicWebPolicyDeniedError, match="explicitly configured"):
+            client.fetch_feed(target, "https://example.com/public/other.xml", allowed)
+        with pytest.raises(PublicWebPolicyDeniedError, match="robots.txt denied"):
+            client.fetch_feed(target, FEED_URL, denied)
+
+    def redirect(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"location": FEED_URL})
+
+    with httpx.Client(transport=httpx.MockTransport(redirect)) as http_client:
+        with pytest.raises(PublicWebResponseError, match="redirects"):
+            PublicWebClient(http_client).fetch_feed(target, FEED_URL, allowed)
+
+    def wrong_mime(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/html"}, content=b"<html/>")
+
+    with httpx.Client(transport=httpx.MockTransport(wrong_mime)) as http_client:
+        with pytest.raises(PublicWebResponseError, match="content type"):
+            PublicWebClient(http_client).fetch_feed(target, FEED_URL, allowed)
+
+
+def test_fetch_feed_rejects_invalid_or_oversized_content_length() -> None:
+    target = _target(feed_urls=(FEED_URL,))
+    robots = _robots(missing=True)
+
+    def invalid_length(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/rss+xml", "content-length": "invalid"},
+            content=b"<rss/>",
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(invalid_length)) as http_client:
+        with pytest.raises(PublicWebResponseError, match="invalid Content-Length"):
+            PublicWebClient(http_client).fetch_feed(target, FEED_URL, robots)
+
+    def oversized_length(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/rss+xml", "content-length": "1000001"},
+            content=b"<rss/>",
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(oversized_length)) as http_client:
+        with pytest.raises(PublicWebResponseError, match="size limit"):
+            PublicWebClient(http_client).fetch_feed(target, FEED_URL, robots)
+
+
+def test_target_rejects_missing_discovery_off_origin_feed_and_unreviewed_enablement() -> None:
+    with pytest.raises(ValueError, match="explicit discovery path"):
+        _target()
+    with pytest.raises(ValueError, match="share the target origin"):
+        _target(feed_urls=("https://other.example/public/feed.xml",))
+    with pytest.raises(ValueError, match="reviewed authorization"):
+        _target(feed_urls=(FEED_URL,), enabled=True)
+
+
+def test_target_expired_authorization_is_not_executable() -> None:
+    target = _target(
+        feed_urls=(FEED_URL,),
+        enabled=True,
+        authorization_reference="review-1",
+        authorization_reviewed_at=NOW - timedelta(days=2),
+        authorization_expires_at=NOW - timedelta(days=1),
+    )
+
+    assert target.executable_at(NOW) is False
+
+
+def _target(
+    *,
+    feed_urls: tuple[str, ...] = (),
+    discover_security_txt: bool = False,
+    enabled: bool = False,
+    authorization_reference: str | None = None,
+    authorization_reviewed_at: datetime | None = None,
+    authorization_expires_at: datetime | None = None,
+) -> PublicWebTarget:
+    return PublicWebTarget(
+        id="public-web-edge-test",
+        organization_id=ORG_ID,
+        canonical_name="Example",
+        base_url="https://example.com",
+        sitemap_urls=(),
+        feed_urls=feed_urls,
+        discover_security_txt=discover_security_txt,
+        allowed_path_prefixes=("/public",),
+        enabled=enabled,
+        authorization_reference=authorization_reference,
+        authorization_reviewed_at=authorization_reviewed_at,
+        authorization_expires_at=authorization_expires_at,
+        max_pages=25,
+        max_total_bytes=5_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=2,
+    )
+
+
+def _robots(*, missing: bool, lines: tuple[str, ...] = ()) -> RobotsRules:
+    parser = RobotFileParser()
+    parser.set_url("https://example.com/robots.txt")
+    parser.parse(list(lines))
+    return RobotsRules(
+        parser=parser,
+        source_url="https://example.com/robots.txt",
+        missing=missing,
+        bytes_fetched=0,
+    )
+
+
+def _ok_feed(_: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        headers={"content-type": "application/rss+xml"},
+        content=b"<rss version='2.0'><channel/></rss>",
+    )
+
+
+def _write_pdf(writer: PdfWriter) -> bytes:
+    from io import BytesIO
+
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()

--- a/tests/unit/adapters/test_public_web_b3_parsers.py
+++ b/tests/unit/adapters/test_public_web_b3_parsers.py
@@ -54,6 +54,14 @@ def test_feed_rejects_dtd_and_entities() -> None:
         parse_public_feed(body, target, max_entries=10)
 
 
+def test_feed_rejects_oversized_xml_before_parsing() -> None:
+    target = _target(feed_urls=("https://example.com/public/feed.xml",))
+    body = b"<rss>" + (b"x" * 1_000_000) + b"</rss>"
+
+    with pytest.raises(PublicFeedParseError, match="byte limit"):
+        parse_public_feed(body, target, max_entries=10)
+
+
 def test_security_txt_requires_valid_contact_and_exact_canonical() -> None:
     target = _target(discover_security_txt=True)
     body = b"\n".join(
@@ -86,6 +94,14 @@ def test_security_txt_rejects_wrong_canonical_and_missing_contact() -> None:
         parse_security_txt(b"Expires: 2027-01-01T00:00:00Z", target)
 
 
+def test_security_txt_rejects_oversized_body() -> None:
+    target = _target(discover_security_txt=True)
+    body = b"Contact: mailto:security@example.com\n" + (b"#" * 64_000)
+
+    with pytest.raises(SecurityTxtParseError, match="byte limit"):
+        parse_security_txt(body, target)
+
+
 def test_pdf_parser_accepts_bounded_plain_pdf_and_rejects_encrypted_pdf() -> None:
     writer = PdfWriter()
     writer.add_blank_page(width=100, height=100)
@@ -105,6 +121,20 @@ def test_pdf_parser_accepts_bounded_plain_pdf_and_rejects_encrypted_pdf() -> Non
     encrypted_writer.write(encrypted_buffer)
     with pytest.raises(PublicDocumentParseError, match="encrypted"):
         extract_pdf_text(encrypted_buffer.getvalue())
+
+
+def test_pdf_parser_rejects_byte_and_page_limit_overflow() -> None:
+    oversized_body = b"%PDF-1.7\n" + (b"x" * 5_000_000)
+    with pytest.raises(PublicDocumentParseError, match="byte limit"):
+        extract_pdf_text(oversized_body)
+
+    writer = PdfWriter()
+    for _ in range(51):
+        writer.add_blank_page(width=100, height=100)
+    buffer = BytesIO()
+    writer.write(buffer)
+    with pytest.raises(PublicDocumentParseError, match="page limit"):
+        extract_pdf_text(buffer.getvalue())
 
 
 def test_document_parser_rejects_malformed_pdf_and_invalid_utf8() -> None:

--- a/tests/unit/adapters/test_public_web_b3_parsers.py
+++ b/tests/unit/adapters/test_public_web_b3_parsers.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from io import BytesIO
+from uuid import UUID
+
+import pytest
+from pypdf import PdfWriter
+
+from cip.adapters.sources.public_web.document_parsing import (
+    PublicDocumentParseError,
+    extract_pdf_text,
+    extract_plain_text,
+)
+from cip.adapters.sources.public_web.feed_parsing import (
+    PublicFeedParseError,
+    parse_public_feed,
+)
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.adapters.sources.public_web.security_txt import (
+    SecurityTxtParseError,
+    parse_security_txt,
+)
+
+ORG_ID = UUID("00000000-0000-0000-0000-000000000831")
+REVIEWED_AT = datetime(2026, 8, 10, 10, 0, tzinfo=UTC)
+
+
+def test_rss_and_atom_only_emit_in_scope_links() -> None:
+    target = _target(feed_urls=("https://example.com/public/feed.xml",))
+    rss = b"""<?xml version='1.0'?>
+<rss version='2.0'><channel>
+  <item><title>Allowed</title><link>https://example.com/public/a</link></item>
+  <item><title>Outside path</title><link>https://example.com/private/a</link></item>
+  <item><title>Outside host</title><link>https://evil.example/public/a</link></item>
+</channel></rss>"""
+    atom = b"""<?xml version='1.0'?>
+<feed xmlns='http://www.w3.org/2005/Atom'>
+  <entry><title>Allowed</title><link rel='alternate' href='https://example.com/public/b'/></entry>
+</feed>"""
+
+    rss_entries = parse_public_feed(rss, target, max_entries=10)
+    atom_entries = parse_public_feed(atom, target, max_entries=10)
+
+    assert tuple(item.url for item in rss_entries) == ("https://example.com/public/a",)
+    assert tuple(item.url for item in atom_entries) == ("https://example.com/public/b",)
+
+
+def test_feed_rejects_dtd_and_entities() -> None:
+    target = _target(feed_urls=("https://example.com/public/feed.xml",))
+    body = b"<!DOCTYPE rss [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]><rss/>"
+
+    with pytest.raises(PublicFeedParseError, match="DTD and entities"):
+        parse_public_feed(body, target, max_entries=10)
+
+
+def test_security_txt_requires_valid_contact_and_exact_canonical() -> None:
+    target = _target(discover_security_txt=True)
+    body = b"\n".join(
+        (
+            b"Contact: mailto:security@example.com",
+            b"Canonical: https://example.com/.well-known/security.txt",
+            b"Expires: 2027-01-01T00:00:00Z",
+            b"Preferred-Languages: fr, en",
+        )
+    )
+
+    document = parse_security_txt(body, target)
+
+    assert document.contacts == ("mailto:security@example.com",)
+    assert document.canonical_urls == (
+        "https://example.com/.well-known/security.txt",
+    )
+    assert document.preferred_languages == ("fr", "en")
+
+
+def test_security_txt_rejects_wrong_canonical_and_missing_contact() -> None:
+    target = _target(discover_security_txt=True)
+
+    with pytest.raises(SecurityTxtParseError, match="Canonical field"):
+        parse_security_txt(
+            b"Contact: mailto:security@example.com\nCanonical: https://example.com/public/security.txt",
+            target,
+        )
+    with pytest.raises(SecurityTxtParseError, match="Contact"):
+        parse_security_txt(b"Expires: 2027-01-01T00:00:00Z", target)
+
+
+def test_pdf_parser_accepts_bounded_plain_pdf_and_rejects_encrypted_pdf() -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=100, height=100)
+    writer.add_metadata({"/Title": "Security architecture"})
+    plain_buffer = BytesIO()
+    writer.write(plain_buffer)
+
+    extracted = extract_pdf_text(plain_buffer.getvalue())
+
+    assert extracted.title == "Security architecture"
+    assert extracted.text == ""
+
+    encrypted_writer = PdfWriter()
+    encrypted_writer.add_blank_page(width=100, height=100)
+    encrypted_writer.encrypt("secret")
+    encrypted_buffer = BytesIO()
+    encrypted_writer.write(encrypted_buffer)
+    with pytest.raises(PublicDocumentParseError, match="encrypted"):
+        extract_pdf_text(encrypted_buffer.getvalue())
+
+
+def test_document_parser_rejects_malformed_pdf_and_invalid_utf8() -> None:
+    with pytest.raises(PublicDocumentParseError):
+        extract_pdf_text(b"%PDF-1.7\nnot-a-valid-document")
+    with pytest.raises(PublicDocumentParseError, match="UTF-8"):
+        extract_plain_text(b"\xff\xfe")
+
+
+def test_target_can_be_feed_only_and_security_path_is_explicitly_bounded() -> None:
+    feed_only = _target(feed_urls=("https://example.com/public/feed.xml",))
+    security = _target(discover_security_txt=True)
+
+    assert feed_only.sitemap_urls == ()
+    assert feed_only.feed_urls == ("https://example.com/public/feed.xml",)
+    assert "/.well-known/security.txt" in security.allowed_path_prefixes
+    assert security.security_txt_url == "https://example.com/.well-known/security.txt"
+
+
+def _target(
+    *,
+    feed_urls: tuple[str, ...] = (),
+    discover_security_txt: bool = False,
+) -> PublicWebTarget:
+    return PublicWebTarget(
+        id="public-web-test",
+        organization_id=ORG_ID,
+        canonical_name="Example",
+        base_url="https://example.com",
+        sitemap_urls=() if feed_urls or discover_security_txt else ("https://example.com/sitemap.xml",),
+        feed_urls=feed_urls,
+        discover_security_txt=discover_security_txt,
+        allowed_path_prefixes=("/public",),
+        enabled=False,
+        authorization_reference=None,
+        authorization_reviewed_at=None,
+        max_pages=25,
+        max_total_bytes=5_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=2,
+    )


### PR DESCRIPTION
Closes #81
Parent: #77

Clean base: Priority B-2 squash `f04a722a77335a663b8ddb9d3dfdb0b7753396b6`.

Extend the existing Lot 12 bounded public-web capability with explicitly configured RSS/Atom feeds, RFC 9116 security.txt discovery, and bounded safe public-document/PDF text extraction. This PR must not introduce a second crawler, page-view-triggered collection, unrestricted recursive browsing, authenticated/private access, raw-content retention, or any direct signal/opportunity inference.

The PR remains draft until parser/runtime/governance/tests/docs are complete and one exact final head passes the full backend and frontend CI.