### PR TITLE
Priority B-4: terminal passive provider dispositions

### DIFF
--- a/docs/source_activation/PRIORITY_B_04_PASSIVE_PROVIDER_DECISIONS.md
+++ b/docs/source_activation/PRIORITY_B_04_PASSIVE_PROVIDER_DECISIONS.md
@@ -1,0 +1,146 @@
+# Priority B-4 — Passive provider-specific dispositions
+
+Status: implementation decision record for issue #82 / parent #77.
+
+Reviewed on: 2026-08-10.
+
+## Purpose
+
+Priority B-4 closes the six named passive technology/exposure providers at provider/product level. A named provider is not considered integrated merely because an API exists or a free/community plan can return data. For this standalone customer-facing commercial product, execution is allowed only when the repository can prove a compatible commercial entitlement, onboarding/secrets, collection boundaries, canonical mapping and a governed runtime path.
+
+All six providers below add potentially useful passive evidence, but the repository currently has no contract or written entitlement proving that their data may be incorporated into this product for customer-facing use. They therefore remain fail-closed and are handed to SA-07 as licensed dependencies. B-4 intentionally does not create fake adapters, schedules, secrets or `live_tested` state.
+
+## Common non-negotiable boundary
+
+- Provider datasets may be consumed only through an authorized documented API/export under a compatible contract.
+- No provider scanning, probe submission, active host discovery or prospect-directed measurement is authorized by this lot.
+- No scraping of provider web interfaces, quota evasion, account rotation or bypass of product controls.
+- Provider observations remain passive evidence. They do not by themselves prove organization ownership, deployment, vulnerability applicability, exposure, compromise or a commercial need.
+- Person/contact fields are outside the B-4 mapping even if a provider can return them.
+- A future activation must use Provider Onboarding, Source Governance, portfolio/quota controls, the shared collection runtime and the existing canonical passive-exposure/public-footprint projections.
+
+## Provider decisions
+
+### Censys
+
+**Provider record:** `censys-platform-passive`
+
+**Relevant product/API path:** Censys Platform/Search data through authorized Censys APIs. Only passive provider-returned host/certificate/service observations are in scope.
+
+**Commercial entitlement finding:** Censys' published Terms of Service state that Free and Researcher access is non-commercial. Paying plans permit their own commercial purposes subject to restrictions, while incorporation of Censys Data into software/products/services made available to third parties requires an Enterprise account. Current Censys customer terms also restrict ordinary service use to internal business operations unless separately agreed.
+
+**Authentication/onboarding:** provider account/API credentials and a contract entitlement explicitly covering incorporation in this customer-facing product. Secrets must be held through Provider Onboarding, never policy files.
+
+**Prohibited methods:** provider UI crawling/scraping, bypass, active scanning/probing, using a free/research plan for this product, or exposing raw Censys data as a standalone dataset.
+
+**Canonical mapping if activated:** Lot 16 passive asset/observation records with provider provenance, observation time, bounded service/technology/certificate metadata and `REVIEW_REQUIRED` organization links. Existing Cloudflare DNS, Cert Spotter CT and RDAP remain independent source families; Censys would add provider-observed internet service context, not replace them.
+
+**Disposition:** `blocked`, owned by `SA-07`, pending an Enterprise or written product-integration entitlement and deployment onboarding.
+
+### Shodan
+
+**Provider record:** `shodan-passive-data`
+
+**Relevant product/API path:** Shodan Search/Host passive indexed-data APIs only. Scan/submission endpoints are out of scope.
+
+**Commercial entitlement finding:** Shodan's published terms prohibit reproducing, selling, trading or reselling the Services unless separately agreed in writing. Academic/Research access is expressly non-commercial. The repository contains no separate Shodan agreement covering incorporation into this product.
+
+**Authentication/onboarding:** paid/commercial account plus written entitlement appropriate to customer-facing product use; API key through Provider Onboarding.
+
+**Prohibited methods:** Shodan scan APIs, prospect-directed scanning, provider UI scraping, account/quota evasion, research/academic entitlements for commercial execution, resale of provider data.
+
+**Canonical mapping if activated:** Lot 16 passive service/banner-derived observation metadata after strict field allowlisting and provenance preservation. A Shodan observation remains provider-observed context and cannot become verified exposure or vulnerability applicability without independent applicability logic/evidence.
+
+**Disposition:** `blocked`, owned by `SA-07`, pending a separate compatible commercial agreement and deployment onboarding.
+
+### SecurityTrails
+
+**Provider record:** `securitytrails-passive-data`
+
+**Relevant product/API path:** read-only SecurityTrails REST API under `api.securitytrails.com/v1`, using exact organization-bound domain/IP targets. DNS/WHOIS/company/passive metadata can be technically queried through the documented API.
+
+**Commercial entitlement finding:** current public API documentation proves authentication, subscription quotas and technical API behavior, but the repository review did not establish public licence text granting redistribution/incorporation rights for this standalone customer-facing product. Technical availability is not treated as commercial authorization.
+
+**Authentication/onboarding:** SecurityTrails subscription, `APIKEY`, quota configuration and a contract/order form or provider confirmation explicitly covering the intended product use.
+
+**Prohibited methods:** execution before entitlement review, UI scraping, quota circumvention, person/contact harvesting, and any active measurement not supplied as an existing passive provider dataset.
+
+**Canonical mapping if activated:** existing Lot 16 DNS/domain/IP passive observations and organization-link review candidates. Unique value would be provider historical/passive DNS and enrichment beyond the active public DoH/RDAP/CT paths; it must not overwrite those independent sources.
+
+**Disposition:** `blocked`, owned by `SA-07`, pending contract/licence evidence and deployment onboarding.
+
+### urlscan
+
+**Provider record:** `urlscan-passive-search`
+
+**Relevant product/API path:** urlscan Search/Result API over already-existing scans only. Submission/automatic scan APIs are explicitly excluded for prospect collection.
+
+**Commercial entitlement finding:** urlscan's public terms say commercial use requires approval/permission, and its FAQ specifically asks customers integrating urlscan data into a commercial offering to contact the provider to determine acceptable use or a commercial agreement.
+
+**Authentication/onboarding:** commercial agreement or written permission covering product integration, API key, quotas and attribution/data-use requirements.
+
+**Prohibited methods:** submitting prospect URLs for scans, automatic submissions, scraping/mirroring the service outside authorized API use, bypassing quotas, or redistributing provider content beyond the agreed rights.
+
+**Canonical mapping if activated:** Lot 16 passive web/service observations from historical existing scans, plus bounded source/provenance metadata. The linked site remains the underlying third-party subject; urlscan search metadata is not independent proof of compromise or a commercial need.
+
+**Disposition:** `blocked`, owned by `SA-07`, pending written commercial product-integration permission and deployment onboarding.
+
+### Wappalyzer
+
+**Provider record:** `wappalyzer-technographics`
+
+**Relevant product/API path:** Wappalyzer technology lookup/API with only website/technology fields required for passive technographic context. Contact/person enrichment is excluded.
+
+**Commercial entitlement finding:** Wappalyzer's current terms state that commercial-service data is licensed and may not be sublicensed, resold, published, embedded in a customer-facing product or otherwise shared without explicit written permission. Its FAQ points Enterprise users needing broader licensing to the provider.
+
+**Authentication/onboarding:** Enterprise/custom written terms permitting customer-facing embedding, API key/credits, quotas and approved field set.
+
+**Prohibited methods:** customer-facing embedding under self-serve/free rights, resale/sharing, contact harvesting, provider crawling, or treating technology detection as production deployment/vulnerability applicability.
+
+**Canonical mapping if activated:** Lot 16 technology observations attached to an organization-bound public web asset with source timestamp and confidence/provenance. This is potentially richer technography than the existing bounded public-web parser but remains an independent provider observation.
+
+**Disposition:** `blocked`, owned by `SA-07`, pending explicit written Enterprise/custom embedding rights and deployment onboarding.
+
+### BuiltWith
+
+**Provider record:** `builtwith-technographics`
+
+**Relevant product/API path:** BuiltWith Domain API/technology detection for exact organization-bound domains only.
+
+**Commercial entitlement finding:** BuiltWith's Terms of Use (updated 2026-03-06) describe the standard licence as internal business use and prohibit resale, redistribution, sublicensing, commercial exploitation and building/enhancing a competing product. BuiltWith API documentation also says APIs may enhance a product provided data is not resold as-is and the product does not duplicate BuiltWith functionality. Because those public statements leave material ambiguity for this platform's customer-facing technographic use, the repository must not infer permission.
+
+**Authentication/onboarding:** paid API entitlement plus written provider/contract confirmation that the exact customer-facing use, retained fields and derived analytics are permitted; API key through Provider Onboarding.
+
+**Prohibited methods:** database reconstruction, bulk extraction beyond licensed endpoints, provider UI scraping, resale/redistribution, competing BuiltWith-like functionality, and technology-to-vulnerability inference without separate applicability evidence.
+
+**Canonical mapping if activated:** Lot 16 technology observations for explicit canonical organization/domain targets, preserving source timestamp and confidence/provenance. BuiltWith adds provider technography but does not replace the bounded first-party public-web evidence path.
+
+**Disposition:** `blocked`, owned by `SA-07`, pending written entitlement resolving customer-facing/product-use ambiguity and deployment onboarding.
+
+## B-4 terminal-state contract
+
+B-4 is complete only when all six provider records:
+
+1. exist in `policies/source_activation.yml`;
+2. are `blocked` with `activation_wave: SA-07`, a non-empty provider-specific reason and no `adapter_present`, `authorized`, `executable`, `scheduled` or `live_tested` stage;
+3. are represented consistently in `SOURCE_COVERAGE_MATRIX.md`;
+4. have deterministic reconciliation tests preventing a future generic/unknown state;
+5. remain network-inert: B-4 adds no adapters, credentials, schedules or outbound provider calls;
+6. pass the complete backend and frontend CI on one exact final SHA.
+
+A later SA-07 change may reopen one provider only after contract/entitlement evidence is reviewed and the complete adapter/governance/onboarding/runtime/test chain is implemented.
+
+## Official references reviewed
+
+- Censys Terms of Service: https://censys.com/terms-of-service
+- Censys Terms and Conditions: https://censys.com/terms-and-conditions/
+- Shodan Terms: https://static.shodan.io/legal/terms.html
+- SecurityTrails API overview: https://docs.securitytrails.com/docs/overview
+- SecurityTrails quotas and rate limits: https://docs.securitytrails.com/docs/quotas-rate-limits
+- urlscan Terms of Service: https://api.urlscan.io/terms/
+- urlscan FAQ / commercial use: https://api.urlscan.io/docs/faq/
+- urlscan API documentation: https://urlscan.io/docs/api/
+- Wappalyzer Terms of Service: https://www.wappalyzer.com/terms/
+- Wappalyzer API FAQ: https://www.wappalyzer.com/faq/api/
+- BuiltWith Terms of Use: https://builtwith.com/terms
+- BuiltWith Domain API: https://api.builtwith.com/domain-api

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -46,6 +46,12 @@ Symbols:
 | PyPI public package metadata | Priority B-2 | Y | Y | Y | Y | N/A | - | exact configured project metadata only; no distributions downloaded; live proof outstanding |
 | npm public package metadata | Priority B-2 | Y | Y | Y | Y | N/A | - | exact configured package metadata only; no tarballs downloaded; live proof outstanding |
 | Maven Central public artifact metadata | Priority B-2 | Y | Y | Y | Y | N/A | - | exact configured group/artifact metadata only; no JAR/POM downloads; live proof outstanding |
+| Censys Platform passive data `censys-platform-passive` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending compatible Enterprise/written product-integration entitlement |
+| Shodan passive indexed data `shodan-passive-data` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending separate customer-facing commercial agreement; scan APIs prohibited |
+| SecurityTrails passive data `securitytrails-passive-data` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending contract/licence evidence for customer-facing incorporation |
+| urlscan passive existing-scan search `urlscan-passive-search` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending commercial product-integration permission; scan submission prohibited |
+| Wappalyzer technographics `wappalyzer-technographics` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending explicit written Enterprise/custom embedding rights |
+| BuiltWith technographics `builtwith-technographics` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending written clarification of customer-facing/product-use rights |
 | SEC EDGAR cybersecurity disclosures | SA-04 | Y | Y | Y | Y | N/A | - | targeted Item 1.05 metadata capability; CIK target registry empty and deployment User-Agent required |
 | PhishTank verified online phishing data | SA-04 | Y | Y | Y | Y | N/A | - | global URL telemetry capability; application key/onboarding and deployment User-Agent required |
 | Licensed incident reporting | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
@@ -76,6 +82,23 @@ SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote onl
 Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA/Priority-B increment.
 
 OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10 closes.
+
+## Priority B-4 passive-provider completion boundary
+
+Priority B-4 is complete only when:
+
+- `censys-platform-passive`, `shodan-passive-data`, `securitytrails-passive-data`, `urlscan-passive-search`, `wappalyzer-technographics` and `builtwith-technographics` each have an explicit provider-level activation record;
+- each record identifies its concrete provider/product path, current commercial-entitlement dependency, onboarding/secret model, prohibited methods, unique evidence value and canonical mapping in `PRIORITY_B_04_PASSIVE_PROVIDER_DECISIONS.md`;
+- none is made executable from a free, research, community, trial or ordinary subscription whose rights do not prove customer-facing incorporation into this standalone commercial product;
+- all six remain terminal `blocked` SA-07 licensed dependencies until a compatible written entitlement is reviewed and deployment onboarding exists;
+- no B-4 record has `adapter_present`, `authorized`, `executable`, `scheduled` or `live_tested` while blocked;
+- no provider-specific adapter, credential, schedule, active scan/probe or prospect scan-submission path is created by B-4;
+- Censys/Shodan/SecurityTrails/urlscan are mapped only as potential future passive provider observations, and Wappalyzer/BuiltWith only as potential future passive technographic observations;
+- provider evidence never by itself proves organization ownership, production deployment, vulnerability applicability, verified exposure, compromise or commercial need;
+- activation truth, this matrix and deterministic reconciliation tests agree on all six terminal records;
+- the complete repository backend and frontend CI pass on one exact final SHA.
+
+Any later SA-07 provider activation must separately implement Source Governance, Provider Onboarding, secrets, quotas/cost, portfolio registration, shared runtime integration, canonical projections and controlled live validation before changing the terminal state.
 
 ## Priority B-3 public web/feed/document completion boundary
 

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -315,6 +315,60 @@ sources:
     requires_schedule: false
     stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
 
+  - source_id: censys-platform-passive
+    display_name: Censys Platform passive data candidate
+    category: passive_exposure
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: Customer-facing incorporation requires a compatible Enterprise or written product-integration entitlement that is not present in the repository.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: shodan-passive-data
+    display_name: Shodan passive indexed-data candidate
+    category: passive_exposure
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: A separate written commercial agreement permitting this customer-facing product use is not present; active scan/submission capabilities remain prohibited.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: securitytrails-passive-data
+    display_name: SecurityTrails passive data candidate
+    category: passive_exposure
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: Public API documentation proves technical access but repository review has no contract or licence evidence permitting customer-facing incorporation/redistribution.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: urlscan-passive-search
+    display_name: urlscan existing-scan passive search candidate
+    category: passive_exposure
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: Integration of urlscan data into a commercial offering requires provider approval or a commercial agreement that is not present; prospect scan submission is prohibited.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: wappalyzer-technographics
+    display_name: Wappalyzer technographic data candidate
+    category: passive_exposure
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: Customer-facing embedding requires explicit written broader rights; no Enterprise/custom embedding entitlement is present in the repository.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: builtwith-technographics
+    display_name: BuiltWith technographic data candidate
+    category: passive_exposure
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: Public standard terms and API product-use guidance are materially ambiguous for this customer-facing platform; written entitlement confirmation is required before execution.
+    stages: [catalogued, reviewed, mapped]
+
   - source_id: official-vendor-psirt
     display_name: Official Vendor PSIRT Advisories
     category: vulnerability_advisory

--- a/tests/unit/source_activation/test_priority_b4_provider_dispositions.py
+++ b/tests/unit/source_activation/test_priority_b4_provider_dispositions.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationStage,
+)
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+DECISION_PATH = Path("docs/source_activation/PRIORITY_B_04_PASSIVE_PROVIDER_DECISIONS.md")
+MATRIX_PATH = Path("docs/source_activation/SOURCE_COVERAGE_MATRIX.md")
+
+PROVIDER_IDS = {
+    "censys-platform-passive",
+    "shodan-passive-data",
+    "securitytrails-passive-data",
+    "urlscan-passive-search",
+    "wappalyzer-technographics",
+    "builtwith-technographics",
+}
+
+FORBIDDEN_STAGES = {
+    ActivationStage.ADAPTER_PRESENT,
+    ActivationStage.AUTHORIZED,
+    ActivationStage.EXECUTABLE,
+    ActivationStage.SCHEDULED,
+    ActivationStage.LIVE_TESTED,
+}
+
+
+def test_priority_b4_named_providers_are_terminal_fail_closed_sa07_dependencies() -> None:
+    records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
+
+    assert PROVIDER_IDS <= records.keys()
+    for source_id in PROVIDER_IDS:
+        record = records[source_id]
+        assert record.disposition is ActivationDisposition.BLOCKED
+        assert record.activation_wave == "SA-07"
+        assert record.requires_schedule is False
+        assert record.reason is not None
+        assert record.reason.strip()
+        assert record.is_resolved is True
+        assert {
+            ActivationStage.CATALOGUED,
+            ActivationStage.REVIEWED,
+            ActivationStage.MAPPED,
+        } <= record.stages
+        assert record.stages.isdisjoint(FORBIDDEN_STAGES)
+
+
+def test_priority_b4_decision_record_and_matrix_cover_every_named_provider() -> None:
+    decision = DECISION_PATH.read_text(encoding="utf-8")
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+
+    for source_id in PROVIDER_IDS:
+        assert f"`{source_id}`" in decision
+        assert f"`{source_id}`" in matrix
+
+
+def test_priority_b4_does_not_create_provider_runtime_authority() -> None:
+    repository_root = Path("src/cip/adapters/sources")
+    provider_runtime_names = {
+        "censys",
+        "shodan",
+        "securitytrails",
+        "urlscan",
+        "wappalyzer",
+        "builtwith",
+    }
+
+    paths = {path.name.lower() for path in repository_root.rglob("*.py")}
+    for provider_name in provider_runtime_names:
+        assert all(provider_name not in filename for filename in paths)

--- a/tests/unit/source_activation/test_priority_b4_provider_dispositions.py
+++ b/tests/unit/source_activation/test_priority_b4_provider_dispositions.py
@@ -33,7 +33,7 @@ FORBIDDEN_STAGES = {
 def test_priority_b4_named_providers_are_terminal_fail_closed_sa07_dependencies() -> None:
     records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
 
-    assert PROVIDER_IDS <= records.keys()
+    assert records.keys() >= PROVIDER_IDS
     for source_id in PROVIDER_IDS:
         record = records[source_id]
         assert record.disposition is ActivationDisposition.BLOCKED


### PR DESCRIPTION
Closes #82
Parent: #77

Clean base: Priority B-3 squash `27cf0ad3e1a583d05641d4c9b177d70afd4e2922`.

Close Censys, Shodan, SecurityTrails, urlscan, Wappalyzer and BuiltWith at provider/product level. Each provider is mapped to its future passive evidence value but remains fail-closed under `SA-07` because the repository does not contain a compatible customer-facing commercial entitlement. This PR intentionally creates no provider adapter, schedule, credential, active scan/probe path, or live-tested claim.

The PR stays draft until activation truth, coverage matrix, deterministic reconciliation tests, reviews and one exact full backend/frontend CI are green.