### PR TITLE
SA-06: reconcile corporate change and relationship source families

### DIFF
--- a/docs/source_activation/SA_06_CORPORATE_RELATIONSHIP_ACTIVATION.md
+++ b/docs/source_activation/SA_06_CORPORATE_RELATIONSHIP_ACTIVATION.md
@@ -1,0 +1,47 @@
+# SA-06 — Corporate change and relationship source activation
+
+Status: implementation/reconciliation contract for issue #89.
+
+## Reuse boundary
+
+SA-06 does not introduce another crawler. Public discovery reuses the already-governed SA-02 / Priority-B-3 paths (Brave Search metadata, Internet Archive CDX, bounded public-web sitemap/feed/security/document collection). Canonical interpretation reuses Lot 18 `corporate_changes` and Lot 19 `relationship_intelligence` schemas/mappers.
+
+A discovered page, feed item, certificate, partner page or case study is source material only. It is not automatically a material-change event, an independent corroborating source, a current contract, an incumbent provider, a service need or an opportunity.
+
+## Terminal dispositions
+
+### Official corporate disclosures
+
+`official-corporate-disclosures` is `manual` / SA-06. Analysts may ingest or approve bounded first-party company disclosures found through the governed public-web/search/archive paths. The existing Lot 18 official-change mapper is the canonical path once the disclosure has been reviewed and structured. Generic automatic interpretation is not authorized because each company publishes different structures and semantics.
+
+### Official regulatory change notices
+
+`official-regulatory-change-notices` is `manual` / SA-06. Approved regulator notices may be discovered by the existing bounded web/search paths and mapped as regulator evidence only after source-specific review. A regulator mention does not become a company-confirmed event without the appropriate evidence class.
+
+### Licensed corporate news
+
+`licensed-corporate-news-metadata` is `blocked` and owned by SA-07 until a concrete provider, commercial/customer-facing licence, fields, attribution/retention conditions, credentials, quotas and runtime adapter are reviewed. A generic licensed family is not executable.
+
+### Official relationship disclosures
+
+`official-relationship-disclosures` is `manual` / SA-06. First-party statements can become Lot 19 relationship evidence after analyst review. Marketing language is `claimed` evidence and never silently becomes `contracted` or active incumbency.
+
+### Public partner directories
+
+`public-partner-directory-metadata` is `manual` / SA-06. A public directory entry is review-required relationship metadata. Directory presence does not prove a current commercial contract.
+
+### Public case studies
+
+`public-case-study-metadata` is `manual` / SA-06. Case studies are bounded public evidence and may be historical. They do not prove current incumbency, renewal timing or current product deployment.
+
+### Public certificate relationship metadata
+
+`public-certificate-relationship-metadata` is `manual` / SA-06. Certificate material can support a review candidate only when relationship semantics are explicit and independently reviewed. Certificate issuance alone never proves a provider/customer relationship; SA-03 certificate telemetry remains a separate evidence source.
+
+## Safety and evidence boundary
+
+SA-06 adds no autonomous page interpretation, no paywall/auth/CAPTCHA/MFA bypass, no private portals, no contact harvesting, no active probing and no outreach. Search-result metadata and the linked page share one discovery lineage. Syndicated copies remain one lineage. Historical relationships remain historical.
+
+## Completion gate
+
+SA-06 closes only when all seven modeled source families have explicit dispositions and owner waves, Source Activation truth and the Coverage Matrix agree, no generic family becomes executable, and the complete repository backend/frontend CI passes on one exact SHA. SA-07 may begin only after the squash merge.

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -67,6 +67,13 @@ Symbols:
 | Generic company incident source family | SA-10 | Y | - | - | - | - | - | provider-specific decomposition required after SEC path |
 | Generic regulator/CERT incident family | SA-10 | Y | - | - | - | - | - | concrete official endpoints and authorizations required |
 | Generic vendor/Linux/package advisory families | SA-10 | Y | - | - | - | - | - | provider/ecosystem-specific decomposition required |
+| Official corporate disclosures `official-corporate-disclosures` | SA-06 | Y | - | - | - | N/A | - | MANUAL bounded first-party acquisition + Lot 18 analyst-reviewed mapping |
+| Official regulatory change notices `official-regulatory-change-notices` | SA-06 | Y | - | - | - | N/A | - | MANUAL source-specific regulator review + Lot 18 evidence classification |
+| Licensed corporate news `licensed-corporate-news-metadata` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete licensed provider, customer-facing rights and runtime onboarding |
+| Official relationship disclosures `official-relationship-disclosures` | SA-06 | Y | - | - | - | N/A | - | MANUAL Lot 19 review; marketing claim is not contracted/current incumbency evidence |
+| Public partner directories `public-partner-directory-metadata` | SA-06 | Y | - | - | - | N/A | - | MANUAL review-required relationship metadata; no current-contract inference |
+| Public case studies `public-case-study-metadata` | SA-06 | Y | - | - | - | N/A | - | MANUAL bounded historical-capable evidence; no current-incumbency inference |
+| Public certificate relationship metadata `public-certificate-relationship-metadata` | SA-06 | Y | - | - | - | N/A | - | MANUAL only where relationship semantics are explicit; issuance alone proves nothing |
 | Sherlock `sherlock-local` | SA-05 | Y | Y | - | - | N/A | - | MANUAL governed local adapter; empty target registry; deployment binary/version + analyst-reviewed sites/target required |
 | OWASP Amass `amass-local` | SA-05 | Y | - | - | - | N/A | - | BLOCKED as blanket executor; passive modules require provider-specific governance and active enumeration/probing is prohibited |
 | theHarvester `theharvester-local` | SA-05 | Y | - | - | - | N/A | - | BLOCKED as blanket executor; each search/API upstream requires separate authorization |
@@ -104,6 +111,19 @@ SA-05 is complete only when:
 - `live_tested` remains false unless a separately authorized controlled live proof is recorded.
 
 Any future automation of a Sherlock target or a framework module requires a separate reviewed deployment/source activation change. Tool availability alone never grants network authorization.
+
+## SA-06 corporate-change and relationship completion boundary
+
+SA-06 is complete only when:
+
+- `official-corporate-disclosures` and `official-regulatory-change-notices` are terminal `manual` paths through the existing bounded public-web/search/archive acquisition plus Lot 18 review/mapping;
+- `official-relationship-disclosures`, `public-partner-directory-metadata`, `public-case-study-metadata` and `public-certificate-relationship-metadata` are terminal `manual` paths through existing bounded acquisition plus Lot 19 review/mapping;
+- `licensed-corporate-news-metadata` is terminal `blocked` and explicitly owned by SA-07 until a concrete provider and customer-facing commercial entitlement are approved;
+- no generic family gains `adapter_present`, `authorized`, `executable`, `scheduled` or `live_tested` merely because reusable public-web or canonical mapper capabilities exist;
+- a page, feed item, certificate, partner directory entry or case study remains source material and never automatically becomes a confirmed material change, contracted relationship, active incumbent, service need, opportunity or outreach target;
+- first-party marketing statements remain claimed evidence unless stronger evidence exists, historical case studies remain historical-capable, and certificate issuance remains separate from relationship proof;
+- source activation truth, this matrix and deterministic SA-06 reconciliation tests agree on all seven families;
+- the complete repository backend and frontend CI pass on one exact SHA before SA-07 begins.
 
 ## Priority B-4 passive-provider completion boundary
 

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -396,50 +396,64 @@ sources:
   - source_id: official-corporate-disclosures
     display_name: Official Corporate Disclosures
     category: corporate_change_intelligence
-    disposition: planned
+    disposition: manual
     activation_wave: SA-06
+    requires_schedule: false
+    reason: Generic company disclosure structures cannot be safely auto-interpreted; analysts may approve bounded first-party material through the existing public-web/search/archive path and Lot 18 mapper.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-regulatory-change-notices
     display_name: Official Regulatory Change Notices
     category: corporate_change_intelligence
-    disposition: planned
+    disposition: manual
     activation_wave: SA-06
+    requires_schedule: false
+    reason: Regulator notices require concrete source review and evidence-class handling before Lot 18 mapping; the generic family does not grant network authorization.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-corporate-news-metadata
     display_name: Licensed Corporate News Metadata
     category: corporate_change_intelligence
-    disposition: planned
-    activation_wave: SA-06
+    disposition: blocked
+    activation_wave: SA-07
+    requires_schedule: false
+    reason: A concrete licensed provider, customer-facing commercial rights, fields, attribution/retention conditions, credentials, quotas and runtime adapter are required before execution.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-relationship-disclosures
     display_name: Official Relationship Disclosures
     category: relationship_intelligence
-    disposition: planned
+    disposition: manual
     activation_wave: SA-06
+    requires_schedule: false
+    reason: First-party relationship statements require analyst review and Lot 19 evidence classification; marketing claims must not become contracted or active-incumbency evidence automatically.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: public-partner-directory-metadata
     display_name: Public Partner Directory Metadata
     category: relationship_intelligence
-    disposition: planned
+    disposition: manual
     activation_wave: SA-06
+    requires_schedule: false
+    reason: Public directory presence is review-required relationship metadata and does not prove a current contract; acquisition must use an approved bounded public-web source.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: public-case-study-metadata
     display_name: Public Case Study Metadata
     category: relationship_intelligence
-    disposition: planned
+    disposition: manual
     activation_wave: SA-06
+    requires_schedule: false
+    reason: Case studies may be historical and require analyst review before Lot 19 mapping; they do not prove current incumbency, renewal timing or production deployment.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: public-certificate-relationship-metadata
     display_name: Public Certificate Relationship Metadata
     category: relationship_intelligence
-    disposition: planned
+    disposition: manual
     activation_wave: SA-06
+    requires_schedule: false
+    reason: Relationship semantics must be explicit and analyst-reviewed; certificate issuance alone is not provider/customer evidence and SA-03 certificate telemetry remains separate.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: linkedin-official-api

--- a/tests/unit/source_activation/test_sa06_corporate_relationship_activation.py
+++ b/tests/unit/source_activation/test_sa06_corporate_relationship_activation.py
@@ -5,6 +5,7 @@ from cip.modules.source_activation.infrastructure.inventory import load_activati
 
 ACTIVATION_PATH = Path("policies/source_activation.yml")
 DOC_PATH = Path("docs/source_activation/SA_06_CORPORATE_RELATIONSHIP_ACTIVATION.md")
+MATRIX_PATH = Path("docs/source_activation/SOURCE_COVERAGE_MATRIX.md")
 
 MANUAL = {
     "official-corporate-disclosures",
@@ -41,6 +42,16 @@ def test_sa06_decision_record_covers_every_family() -> None:
     text = DOC_PATH.read_text(encoding="utf-8")
     for source_id in MANUAL | {LICENSED}:
         assert f"`{source_id}`" in text
+
+
+def test_sa06_coverage_matrix_covers_every_family_and_terminal_state() -> None:
+    text = MATRIX_PATH.read_text(encoding="utf-8")
+    for source_id in MANUAL:
+        assert f"`{source_id}`" in text
+    assert f"`{LICENSED}`" in text
+    assert "## SA-06 corporate-change and relationship completion boundary" in text
+    assert "MANUAL" in text
+    assert "BLOCKED" in text
 
 
 def _records() -> dict[str, ActivationRecord]:

--- a/tests/unit/source_activation/test_sa06_corporate_relationship_activation.py
+++ b/tests/unit/source_activation/test_sa06_corporate_relationship_activation.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from cip.modules.source_activation.domain.models import ActivationDisposition, ActivationRecord
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+DOC_PATH = Path("docs/source_activation/SA_06_CORPORATE_RELATIONSHIP_ACTIVATION.md")
+
+MANUAL = {
+    "official-corporate-disclosures",
+    "official-regulatory-change-notices",
+    "official-relationship-disclosures",
+    "public-partner-directory-metadata",
+    "public-case-study-metadata",
+    "public-certificate-relationship-metadata",
+}
+LICENSED = "licensed-corporate-news-metadata"
+
+
+def test_sa06_public_official_families_are_terminal_manual_review_paths() -> None:
+    records = _records()
+    for source_id in MANUAL:
+        record = records[source_id]
+        assert record.disposition is ActivationDisposition.MANUAL
+        assert record.activation_wave == "SA-06"
+        assert record.reason
+        assert record.is_resolved
+        assert not record.is_executable
+
+
+def test_sa06_licensed_news_is_owned_fail_closed_by_sa07() -> None:
+    record = _records()[LICENSED]
+    assert record.disposition is ActivationDisposition.BLOCKED
+    assert record.activation_wave == "SA-07"
+    assert record.reason
+    assert record.is_resolved
+    assert not record.is_executable
+
+
+def test_sa06_decision_record_covers_every_family() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    for source_id in MANUAL | {LICENSED}:
+        assert f"`{source_id}`" in text
+
+
+def _records() -> dict[str, ActivationRecord]:
+    return {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}

--- a/tests/unit/source_activation/test_sa06_corporate_relationship_activation.py
+++ b/tests/unit/source_activation/test_sa06_corporate_relationship_activation.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from cip.modules.source_activation.domain.models import ActivationDisposition, ActivationRecord
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationRecord,
+    ActivationStage,
+)
 from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
 
 ACTIVATION_PATH = Path("policies/source_activation.yml")
@@ -26,7 +30,7 @@ def test_sa06_public_official_families_are_terminal_manual_review_paths() -> Non
         assert record.activation_wave == "SA-06"
         assert record.reason
         assert record.is_resolved
-        assert not record.is_executable
+        assert ActivationStage.EXECUTABLE not in record.stages
 
 
 def test_sa06_licensed_news_is_owned_fail_closed_by_sa07() -> None:
@@ -35,7 +39,7 @@ def test_sa06_licensed_news_is_owned_fail_closed_by_sa07() -> None:
     assert record.activation_wave == "SA-07"
     assert record.reason
     assert record.is_resolved
-    assert not record.is_executable
+    assert ActivationStage.EXECUTABLE not in record.stages
 
 
 def test_sa06_decision_record_covers_every_family() -> None:


### PR DESCRIPTION
Closes #89

Starts from completed SA-05 squash `aae28ee6a56f4bbfdb9cfb65fcc68b493c262ae6`.

SA-06 reuses the existing bounded SA-02 / Priority-B-3 public-web/search/archive acquisition paths and the Lot 18/19 canonical corporate-change and relationship models. It does not add a second crawler.

The six public/official source families are reconciled to terminal `manual` analyst-reviewed paths. `licensed-corporate-news-metadata` is terminal `blocked` and transferred to SA-07 pending a concrete licensed provider and customer-facing commercial entitlement. Source Activation truth, Coverage Matrix and deterministic tests are synchronized.

No generic family becomes authorized, executable, scheduled or live-tested. Page/feed/certificate/directory/case-study presence never automatically becomes a confirmed material change, contracted/current relationship, commercial need, opportunity or outreach target.

Full exact-head backend + frontend CI is required before merge.