### PR TITLE
SA-07: terminalize licensed and premium provider activation

### DIFF
--- a/docs/source_activation/SA_07_LICENSED_PREMIUM_PROVIDER_DECISIONS.md
+++ b/docs/source_activation/SA_07_LICENSED_PREMIUM_PROVIDER_DECISIONS.md
@@ -1,0 +1,74 @@
+# SA-07 — Licensed, premium, LinkedIn and Discord provider decisions
+
+## Decision
+
+SA-07 closes the repository-level ambiguity around conditional/licensed acquisition without manufacturing a commercial entitlement that the deployment does not possess.
+
+Every source owned by `SA-07` is therefore terminal `blocked` in the checked-in activation truth. A blocked record is not a failed product feature: it means the canonical model/control plane exists, but execution is forbidden until a provider-specific commercial and deployment dossier is approved.
+
+Lot 22 remains the execution gate for any future reopening. A later activation must prove, at minimum, the concrete provider/product, customer-facing incorporation/redistribution rights, approved method and fields, lawful purpose, attribution and retention, onboarding/secret references, quotas/cost, Source Governance policy, Source Portfolio executable state, adapter capability, pause/kill-switch controls and controlled live validation.
+
+## Terminal SA-07 inventory
+
+### Licensed intelligence families
+
+- `licensed-incident-reporting` — blocked until a concrete licensed incident provider and customer-facing rights are approved.
+- `licensed-ransomware-metadata` — blocked; actor portals, victim files and private/leaked content remain prohibited.
+- `licensed-stix-taxii` — blocked until a concrete provider, tenant/collection scope, sharing markings and commercial rights are approved.
+- `licensed-phishing-metadata` — blocked; PhishTank remains the current governed public path.
+- `licensed-passive-dns` — blocked pending a provider-specific contract, permitted fields, retention, quotas and runtime adapter.
+- `licensed-certificate-telemetry` — blocked pending commercial entitlement beyond the governed public certificate path.
+- `licensed-malware-metadata` — blocked; malware binaries/samples/download paths remain outside this source activation.
+- `licensed-passive-exposure` — blocked pending a concrete provider and customer-facing data rights.
+- `licensed-technographic-observations` — blocked pending explicit embedding/redistribution rights.
+- `licensed-cloud-asset-observations` — blocked pending provider-specific commercial and deployment approval.
+- `licensed-corporate-news-metadata` — blocked pending a concrete news provider, permitted fields, attribution/retention and customer-facing rights.
+
+### Priority B-4 providers carried into SA-07
+
+- `censys-platform-passive`
+- `shodan-passive-data`
+- `securitytrails-passive-data`
+- `urlscan-passive-search`
+- `wappalyzer-technographics`
+- `builtwith-technographics`
+
+Their B-4 provider-specific reasons remain authoritative. SA-07 does not add adapters, credentials, schedules, scans or product-data redistribution rights for them.
+
+### Conditional professional/community/premium families
+
+- `linkedin-official-api` — blocked until official/licensed access, provider authorization and a real adapter are approved. Scraping/crawling or copied browser sessions are not substitutes.
+- `discord-authorized-integration` — blocked until an administrator-installed connector or authorized export and exact permitted scope exist. Self-bots, member scraping and private-message collection remain prohibited.
+- `premium-cti-licensed` — blocked until a concrete provider and contract-bound capability are approved.
+- `commercial-data-licensed` — blocked until a concrete dataset, permitted fields, lawful purpose and customer-facing rights are approved.
+
+## Evidence and product boundaries
+
+A paid account, trial, API key, free tier, research account, enterprise sales page or technical endpoint is not itself proof that this standalone customer-facing product may ingest, retain, transform, display or redistribute the provider data.
+
+Likewise, provider data never upgrades the canonical evidence boundary by itself:
+
+```text
+provider result
+!= organization ownership
+!= production deployment
+!= vulnerability applicability
+!= verified exposure
+!= compromise
+!= commercial need
+!= opportunity
+!= outreach authorization
+```
+
+## Completion gate
+
+SA-07 may close only when:
+
+1. every activation record with `activation_wave: SA-07` has a terminal disposition and a non-empty reason;
+2. no SA-07 record remains `planned`;
+3. no blocked SA-07 record contains `adapter_present`, `authorized`, `executable`, `scheduled` or `live_tested` stages;
+4. Source Activation truth and the Source Coverage Matrix enumerate the same SA-07 inventory;
+5. no real provider adapter, secret, schedule, active scan/submission path or browser workaround is introduced by this wave;
+6. deterministic reconciliation tests pass;
+7. one exact final SHA passes the complete backend and frontend CI;
+8. reviews and review threads are clear before squash merge.

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -54,16 +54,16 @@ Symbols:
 | BuiltWith technographics `builtwith-technographics` | Priority B-4 / SA-07 | Y | - | - | - | N/A | - | BLOCKED pending written clarification of customer-facing/product-use rights |
 | SEC EDGAR cybersecurity disclosures | SA-04 | Y | Y | Y | Y | N/A | - | targeted Item 1.05 metadata capability; CIK target registry empty and deployment User-Agent required |
 | PhishTank verified online phishing data | SA-04 | Y | Y | Y | Y | N/A | - | global URL telemetry capability; application key/onboarding and deployment User-Agent required |
-| Licensed incident reporting | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
-| Licensed ransomware metadata | SA-07 | Y | - | - | - | - | - | provider licence/commercial-use path not selected; actor/victim content remains prohibited |
-| Licensed STIX/TAXII | SA-07 | Y | - | - | - | - | - | concrete licensed CTI provider/tenant/marking scope not selected |
-| Licensed phishing metadata | SA-07 | Y | - | - | - | - | - | PhishTank covers current public path; commercial augmentation deferred |
-| Licensed malware metadata | SA-07 | Y | - | - | - | - | - | concrete licensed provider not selected; malware binaries remain prohibited |
-| Licensed passive DNS | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
-| Licensed certificate telemetry | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
-| Licensed passive exposure | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
-| Licensed technography | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
-| Licensed cloud-asset observations | SA-07 | Y | - | - | - | - | - | concrete licensed provider/contract not selected |
+| Licensed incident reporting `licensed-incident-reporting` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete provider, customer-facing rights, approved fields and runtime onboarding |
+| Licensed ransomware metadata `licensed-ransomware-metadata` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending licensed metadata provider; actor/victim/private content remains prohibited |
+| Licensed STIX/TAXII `licensed-stix-taxii` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending provider, tenant/collection scope, markings, commercial rights and adapter |
+| Licensed phishing metadata `licensed-phishing-metadata` | SA-07 | Y | - | - | - | N/A | - | BLOCKED; PhishTank remains the current governed public path |
+| Licensed malware metadata `licensed-malware-metadata` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending licensed metadata provider; binaries/download paths prohibited |
+| Licensed passive DNS `licensed-passive-dns` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending provider contract, permitted fields, retention, quotas and adapter |
+| Licensed certificate telemetry `licensed-certificate-telemetry` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending commercial entitlement beyond the governed public CT path |
+| Licensed passive exposure `licensed-passive-exposure` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending provider-specific customer-facing data rights and onboarding |
+| Licensed technography `licensed-technographic-observations` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending explicit embedding/redistribution rights and onboarding |
+| Licensed cloud-asset observations `licensed-cloud-asset-observations` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete provider, field scope, commercial rights and adapter |
 | Generic company incident source family | SA-10 | Y | - | - | - | - | - | provider-specific decomposition required after SEC path |
 | Generic regulator/CERT incident family | SA-10 | Y | - | - | - | - | - | concrete official endpoints and authorizations required |
 | Generic vendor/Linux/package advisory families | SA-10 | Y | - | - | - | - | - | provider/ecosystem-specific decomposition required |
@@ -80,8 +80,11 @@ Symbols:
 | SpiderFoot `spiderfoot-local` | SA-05 | Y | - | - | - | N/A | - | BLOCKED as blanket executor; mixed passive/active modules require provider-level decomposition |
 | Recon-ng `recon-ng-local` | SA-05 | Y | - | - | - | N/A | - | BLOCKED as blanket executor; marketplace modules are independent acquisition paths |
 | Maltego `maltego-local` | SA-05 | Y | - | - | - | N/A | - | MANUAL analyst visualization/investigation over already authorized evidence; transforms require separate review |
-| LinkedIn official API | SA-07 | - | - | - | - | N/A | - | BLOCKED pending approved official/licensed access and adapter |
-| BrixHub | SA-08 | - | - | - | - | N/A | - | BLOCKED pending access/licence/data review |
+| LinkedIn official API `linkedin-official-api` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending approved official/licensed access and adapter |
+| Discord authorized integration `discord-authorized-integration` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending administrator-installed connector or authorized export and exact scope |
+| Premium CTI `premium-cti-licensed` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete licensed provider, contract-bound scopes and deployment approval |
+| Commercial dataset `commercial-data-licensed` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete dataset, approved fields, lawful purpose and customer-facing rights |
+| BrixHub `brixhub` | SA-08 | Y | - | - | - | N/A | - | BLOCKED pending access/licence/data review |
 
 ## Known broader source families
 
@@ -124,6 +127,21 @@ SA-06 is complete only when:
 - first-party marketing statements remain claimed evidence unless stronger evidence exists, historical case studies remain historical-capable, and certificate issuance remains separate from relationship proof;
 - source activation truth, this matrix and deterministic SA-06 reconciliation tests agree on all seven families;
 - the complete repository backend and frontend CI pass on one exact SHA before SA-07 begins.
+
+## SA-07 licensed and premium provider completion boundary
+
+SA-07 is complete only when:
+
+- every record with `activation_wave: SA-07` is terminal `blocked`, has a non-empty provider/deployment reason and is listed explicitly in this matrix;
+- no SA-07 record remains `planned`;
+- no blocked SA-07 record has `adapter_present`, `authorized`, `executable`, `scheduled` or `live_tested` merely because an API, account, trial, free tier or sales page exists;
+- the eleven generic licensed families, the six Priority B-4 providers, LinkedIn, Discord, premium CTI and commercial data all remain fail-closed until provider-specific commercial rights and deployment onboarding are proven;
+- LinkedIn is limited to official/licensed access and Discord to administrator-installed connectors or authorized exports; scraping, copied browser sessions, self-bots, member scraping and private-message collection are not activation methods;
+- licensed ransomware/malware families do not authorize actor portals, victim/private/leaked content, malware binaries or sample downloads;
+- Lot 22 conditional-provider controls remain the required future execution gate: approval dossier, Provider Onboarding, Source Governance, executable Source Portfolio state, adapter capability, quotas/cost and pause/kill-switch controls;
+- provider evidence never by itself proves organization ownership, deployment, applicability, exposure, compromise, commercial need, opportunity or outreach authorization;
+- activation truth, this matrix, `SA_07_LICENSED_PREMIUM_PROVIDER_DECISIONS.md` and deterministic reconciliation tests agree on the complete SA-07 inventory;
+- the complete repository backend and frontend CI pass on one exact final SHA before SA-08 begins.
 
 ## Priority B-4 passive-provider completion boundary
 

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -179,76 +179,91 @@ sources:
   - source_id: licensed-incident-reporting
     display_name: Licensed Incident Reporting
     category: live_incidents
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
-    reason: Concrete licensed provider, contract, fields, credentials and retention must be selected.
+    requires_schedule: false
+    reason: No concrete licensed provider, customer-facing redistribution/incorporation rights, approved fields, credentials, retention terms or runtime adapter are present.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-ransomware-metadata
     display_name: Licensed Ransomware Claim Metadata
     category: live_incidents
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
-    reason: Licensed provider review is required; threat-actor portals and victim content remain prohibited.
+    requires_schedule: false
+    reason: No concrete licensed metadata provider and commercial-use contract are present; threat-actor portals, victim files and private/leaked content remain prohibited.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-stix-taxii
     display_name: Licensed STIX/TAXII Threat Telemetry
     category: threat_telemetry
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
-    reason: A concrete licensed CTI provider and collection markings/tenant scope are required.
+    requires_schedule: false
+    reason: No concrete licensed CTI provider, tenant scope, TAXII collections, sharing markings, customer-facing rights, credentials or runtime capability are approved.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-phishing-metadata
     display_name: Licensed Phishing Metadata
     category: threat_telemetry
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
-    reason: PhishTank covers the current public path; additional licensed metadata requires a concrete contract.
+    requires_schedule: false
+    reason: PhishTank covers the current public path; no additional commercial phishing provider, permitted fields, redistribution rights or runtime onboarding are approved.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-passive-dns
     display_name: Licensed Passive DNS Metadata
     category: threat_telemetry
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
+    requires_schedule: false
+    reason: No provider-specific passive-DNS contract, customer-facing data rights, retention terms, credentials, quotas or runtime adapter are approved.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-certificate-telemetry
     display_name: Licensed Certificate Telemetry
     category: threat_telemetry
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
+    requires_schedule: false
+    reason: No provider-specific commercial certificate-telemetry entitlement or deployment onboarding exists beyond the governed public Cert Spotter path.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-malware-metadata
     display_name: Licensed Malware Metadata
     category: threat_telemetry
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
-    reason: Concrete licensed provider required; malware binaries and download paths remain prohibited.
+    requires_schedule: false
+    reason: No concrete licensed metadata provider and customer-facing contract are approved; malware binaries, samples and download paths remain prohibited.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-passive-exposure
     display_name: Licensed Passive Exposure Metadata
     category: passive_exposure
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
+    requires_schedule: false
+    reason: No concrete passive-exposure provider has an approved customer-facing commercial entitlement, permitted field set, credentials, quotas or runtime adapter.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-technographic-observations
     display_name: Licensed Passive Technographic Observations
     category: passive_exposure
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
+    requires_schedule: false
+    reason: No technographic provider has approved customer-facing embedding/redistribution rights and deployment onboarding; B-4 provider candidates remain separately blocked.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-cloud-asset-observations
     display_name: Licensed Passive Cloud Asset Observations
     category: passive_exposure
-    disposition: planned
+    disposition: blocked
     activation_wave: SA-07
+    requires_schedule: false
+    reason: No concrete licensed cloud-asset observation provider, customer-facing contract, field scope, credentials, quotas or runtime adapter are approved.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: cloudflare-doh

--- a/tests/unit/source_activation/test_priority_b_completion.py
+++ b/tests/unit/source_activation/test_priority_b_completion.py
@@ -161,15 +161,25 @@ def test_b4_exact_providers_are_terminal_owned_fail_closed_records() -> None:
         assert record.stages.isdisjoint(forbidden)
 
 
-def test_future_licensed_passive_families_are_owned_not_unknown_plans() -> None:
+def test_future_licensed_passive_families_are_terminal_sa07_dependencies() -> None:
     records = _records()
+    forbidden = {
+        ActivationStage.ADAPTER_PRESENT,
+        ActivationStage.AUTHORIZED,
+        ActivationStage.EXECUTABLE,
+        ActivationStage.SCHEDULED,
+        ActivationStage.LIVE_TESTED,
+    }
 
     for source_id in FUTURE_LICENSED_PASSIVE:
         record = records[source_id]
-        assert record.disposition is ActivationDisposition.PLANNED
+        assert record.disposition is ActivationDisposition.BLOCKED
         assert record.activation_wave == "SA-07"
         assert ActivationStage.MAPPED in record.stages
-        assert ActivationStage.EXECUTABLE not in record.stages
+        assert record.reason is not None
+        assert record.reason.strip()
+        assert record.is_resolved is True
+        assert record.stages.isdisjoint(forbidden)
 
 
 def test_activation_truth_and_matrix_agree_for_priority_b_scope() -> None:

--- a/tests/unit/source_activation/test_sa07_licensed_provider_activation.py
+++ b/tests/unit/source_activation/test_sa07_licensed_provider_activation.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationRecord,
+    ActivationStage,
+)
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+DECISIONS_PATH = Path("docs/source_activation/SA_07_LICENSED_PREMIUM_PROVIDER_DECISIONS.md")
+MATRIX_PATH = Path("docs/source_activation/SOURCE_COVERAGE_MATRIX.md")
+
+FORBIDDEN_BLOCKED_STAGES = {
+    ActivationStage.ADAPTER_PRESENT,
+    ActivationStage.AUTHORIZED,
+    ActivationStage.EXECUTABLE,
+    ActivationStage.SCHEDULED,
+    ActivationStage.LIVE_TESTED,
+}
+
+
+def test_every_sa07_record_is_terminal_blocked_with_reason() -> None:
+    records = _sa07_records()
+    assert records
+    assert len(records) == 21
+    for record in records:
+        assert record.disposition is ActivationDisposition.BLOCKED
+        assert record.reason
+        assert record.is_resolved
+        assert record.stages.isdisjoint(FORBIDDEN_BLOCKED_STAGES)
+
+
+def test_sa07_has_no_planned_records() -> None:
+    assert all(
+        record.disposition is not ActivationDisposition.PLANNED
+        for record in _sa07_records()
+    )
+
+
+def test_sa07_decision_record_and_matrix_cover_every_source_id() -> None:
+    decisions = DECISIONS_PATH.read_text(encoding="utf-8")
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+    for record in _sa07_records():
+        assert f"`{record.source_id}`" in decisions
+        assert f"`{record.source_id}`" in matrix
+
+
+def _sa07_records() -> list[ActivationRecord]:
+    return [
+        record
+        for record in load_activation_inventory(ACTIVATION_PATH)
+        if record.activation_wave == "SA-07"
+    ]


### PR DESCRIPTION
Closes #91

Starts from exact SA-06 squash `0ff43ae98d0780157a0b174a03c682064af133a1`.

SA-07 resolves all 21 sources owned by the wave to explicit terminal `blocked` states. It reuses the existing Lot 22 conditional-provider control plane and deliberately adds no real provider adapter, authorization, credential, schedule, scan/submission path, browser workaround or live-test claim.

The activation truth, provider decision record and Source Coverage Matrix now explicitly enumerate the licensed incident/ransomware/STIX/phishing/passive-DNS/certificate/malware/passive-exposure/technographic/cloud-asset/corporate-news families; the six Priority B-4 providers; LinkedIn; Discord; premium CTI; and commercial datasets.

Every blocked record must have a reason and no `adapter_present`, `authorized`, `executable`, `scheduled` or `live_tested` stages. Full exact-head backend + frontend CI is required before merge.