### PR TITLE
SA-09: keep isolated browser runtime trigger false

### DIFF
--- a/docs/source_activation/SA_09_BROWSER_RUNTIME_DECISION.md
+++ b/docs/source_activation/SA_09_BROWSER_RUNTIME_DECISION.md
@@ -1,0 +1,72 @@
+# SA-09 — Isolated browser runtime trigger decision
+
+## Decision
+
+The SA-09 browser trigger is **false** for the current source inventory.
+
+The Master Plan permits an isolated browser only for an approved source that cannot be served safely by an official API, feed/bulk export, bounded static HTTP/document path, governed local tool or analyst-assisted/manual workflow. No currently authorized/executable source meets that condition.
+
+Therefore SA-09 deliberately adds **no browser runtime**.
+
+## Current acquisition coverage
+
+Current authorized/executable source paths are already served through bounded mechanisms such as:
+
+- official/public APIs for vulnerability, procurement, hiring, search and passive metadata;
+- bounded feeds, static HTTP, sitemaps, `security.txt` and public documents;
+- passive DNS/CT/RDAP lookups with target and governance controls;
+- bounded developer/package metadata APIs;
+- governed local Sherlock execution only for analyst-approved professional targets;
+- manual analyst review for generic corporate-change/relationship sources;
+- blocked conditional/licensed sources where commercial/access authorization is absent.
+
+A source being blocked by licence, authentication, private access, provenance or authorization requirements is **not** a reason to add a browser. Browser automation cannot be used to work around those gates.
+
+## Runtime intentionally absent
+
+SA-09 does not add:
+
+- Playwright;
+- Chromium/Chrome automation;
+- Selenium;
+- Puppeteer;
+- persistent browser profiles;
+- cookie/session pools;
+- copied authenticated browser sessions;
+- browser credentials;
+- login automation;
+- CAPTCHA or MFA handling/bypass;
+- anti-bot, fingerprint or stealth/evasion logic;
+- proxy/Tor rotation;
+- browser-based paywall or access-control bypass;
+- arbitrary user-supplied URL browsing;
+- crawl-on-page-view behavior.
+
+## Reopening trigger
+
+A future source may reopen SA-09 only through a dedicated reviewed source-activation change that proves all of the following:
+
+1. the source itself is concrete and approved by Source Governance;
+2. legal/commercial authorization exists for the exact automated browser use;
+3. official API, feed/export, static HTTP and analyst/manual routes are genuinely insufficient;
+4. browser execution is the least-complex authorized acquisition mode;
+5. exact hosts, paths, methods, redirects, page/byte/time budgets and retention are approved;
+6. no login, CAPTCHA/MFA, paywall or access-control bypass is required;
+7. credentials/cookies, if legitimately required, are deployment secrets governed by Provider Onboarding and never checked in or exposed to the frontend;
+8. the browser runs in an isolated disposable environment with downloads, local-network access and arbitrary navigation disabled by default;
+9. source-specific canonical mapping/evidence semantics are defined before runtime activation;
+10. deterministic no-network tests and a separately authorized controlled live validation pass.
+
+The browser runtime must remain source-specific infrastructure. It must not become a generic arbitrary browsing service or a shared bypass mechanism.
+
+## Completion gate
+
+SA-09 may close only when:
+
+- the repository contains no browser automation dependency required by the product runtime;
+- no activation record is made executable under `SA-09`;
+- the decision document records the false trigger and strict reopening conditions;
+- deterministic tests verify the Python and web manifests remain free of Playwright/Selenium/Puppeteer browser automation dependencies;
+- no cookie/session/authentication/CAPTCHA/MFA/proxy/Tor workaround is introduced;
+- one exact final SHA passes the complete backend and frontend CI;
+- reviews and review threads are clear before squash merge.

--- a/tests/unit/source_activation/test_sa09_browser_runtime_decision.py
+++ b/tests/unit/source_activation/test_sa09_browser_runtime_decision.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from cip.modules.source_activation.domain.models import ActivationStage
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+PYPROJECT_PATH = Path("pyproject.toml")
+WEB_PACKAGE_PATH = Path("apps/web/package.json")
+DECISION_PATH = Path("docs/source_activation/SA_09_BROWSER_RUNTIME_DECISION.md")
+
+BROWSER_DEPENDENCY_TOKENS = (
+    "playwright",
+    "selenium",
+    "puppeteer",
+)
+
+
+def test_sa09_does_not_add_browser_automation_dependencies() -> None:
+    manifests = (
+        PYPROJECT_PATH.read_text(encoding="utf-8").lower(),
+        WEB_PACKAGE_PATH.read_text(encoding="utf-8").lower(),
+    )
+
+    for manifest in manifests:
+        for token in BROWSER_DEPENDENCY_TOKENS:
+            assert token not in manifest
+
+
+def test_sa09_creates_no_executable_browser_activation() -> None:
+    records = load_activation_inventory(ACTIVATION_PATH)
+    sa09_records = [record for record in records if record.activation_wave == "SA-09"]
+
+    assert all(ActivationStage.EXECUTABLE not in record.stages for record in sa09_records)
+
+
+def test_sa09_decision_records_false_trigger_and_reopening_boundary() -> None:
+    decision = DECISION_PATH.read_text(encoding="utf-8")
+
+    assert "browser trigger is **false**" in decision
+    assert "adds **no browser runtime**" in decision
+    assert "official API, feed/export, static HTTP" in decision
+    assert "CAPTCHA/MFA" in decision
+    assert "proxy/Tor" in decision
+    assert "isolated disposable environment" in decision
+    assert "generic arbitrary browsing service" in decision


### PR DESCRIPTION
Closes #95

Starts from exact SA-08 squash `26e3a5c77ef5a7339438ba91e8dab075328f20fb`.

SA-09 records that the isolated-browser trigger is false for the current inventory. No currently authorized/executable source requires Playwright/Chromium or another automated browser; approved paths are handled by APIs, feeds/static HTTP/documents, passive target-bound lookups, governed local tooling or manual analyst workflows. Blocked licence/auth/provenance sources do not justify browser automation.

This PR adds no browser runtime, adapter, cookie/session pool, login automation, CAPTCHA/MFA handling, stealth/evasion, proxy/Tor support or arbitrary browsing capability. Deterministic tests enforce absence of Playwright/Selenium/Puppeteer dependencies from the Python/web manifests and prevent an executable SA-09 activation.

Full exact-head backend + frontend CI is required before merge.