### PR TITLE
SA-10: finalize source classification without faking live validation

### DIFF
--- a/docs/source_activation/SA_10_FINAL_SOURCE_COMPLETENESS_AUDIT.md
+++ b/docs/source_activation/SA_10_FINAL_SOURCE_COMPLETENESS_AUDIT.md
@@ -1,0 +1,76 @@
+# SA-10 — Final source completeness classification and controlled live-validation gate
+
+## Result
+
+SA-10 deliberately separates two different notions of completion.
+
+### Classification completeness: complete
+
+Every checked-in Source Activation record now has an explicit non-`planned` disposition. The remaining target-dependent/generic/sample records have been resolved as follows:
+
+- `recherche-entreprises` — `manual`: governed adapter present; a deployment-specific canonical organization target and authorization are still required.
+- `gleif` — `manual`: governed adapter present; an analyst/deployment-selected LEI target is required.
+- `bodacc-identity` — `manual`: governed adapter present; an explicit organization/SIREN target and reviewed deployment authorization are required.
+- `osint-framework-import` — `manual`: analyst catalogue-discovery input only; imported listings never grant execution authority.
+- `public-web-example-fr-organization` — `not_relevant`: checked-in disabled sample/configuration target, not a production source.
+- `official-company-incident-disclosures` — `not_relevant`: generic family placeholder, not an executable provider; concrete sources must be provider-specific.
+- `regulator-cert-incident-notices` — `not_relevant`: generic family placeholder, not an endpoint; concrete regulator/CERT sources require provider-specific records.
+- `official-vendor-psirt` — `not_relevant`: generic family placeholder; concrete vendor feeds/APIs require separate source records.
+- `official-linux-security-advisories` — `not_relevant`: generic family placeholder; distro-specific feeds/APIs require separate source records.
+- `official-package-security-advisories` — `not_relevant`: generic family placeholder; ecosystem-specific feeds/APIs require separate source records.
+
+No `planned` record remains in `policies/source_activation.yml`. Manual/blocked/not-relevant records retain a non-empty reason and never gain execution authority merely to improve a completeness percentage.
+
+### Controlled live validation: still open
+
+Repository CI, deterministic fixtures and no-network adapter tests are **not** controlled provider live validation. SA-10 therefore does not synthesize `live_tested` stages.
+
+The synthetic reference adapter remains the only checked-in `active` record that is currently fully integrated according to the activation model because its required stages include `live_tested`.
+
+Every real active source that lacks `live_tested` remains unresolved by `audit_inventory`, even though its adapter/runtime implementation may be validated by CI. The exact outstanding list is derived in tests from the activation inventory rather than duplicated as a manually maintained source of truth.
+
+A source can receive `live_tested` only through a separately authorized provider-specific controlled validation that records the tested provider/method, deployment authorization, target/scope where applicable, timestamp, result, and any required onboarding/credential state without committing secrets.
+
+## What SA-10 does not do
+
+SA-10 does not:
+
+- call external providers merely to manufacture a green status;
+- enable checked-in target registries;
+- create deployment credentials or secrets;
+- invent provider contracts, licences or commercial rights;
+- change a blocked/manual/not-relevant source into `active`;
+- mark a source `live_tested` from unit/integration tests;
+- weaken `audit_inventory`, coverage, lint, typing, architecture or migration gates;
+- treat a successful HTTP response as proof of legal authorization, evidence quality or commercial usefulness.
+
+## Controlled live-validation evidence requirements
+
+For each active real provider that is still missing `live_tested`, a future validation record must establish at least:
+
+1. the exact source/provider and acquisition method;
+2. current Source Governance authorization for the tested host/path/method;
+3. deployment Provider Onboarding state and secret references where required;
+4. an approved target/scope when the source is target-bound;
+5. bounded quota/cost/time behavior;
+6. safe error, redirect and rate-limit behavior;
+7. canonical mapping/provenance output without secret leakage;
+8. evidence-boundary compliance (no unsupported exposure/compromise/need inference);
+9. validation timestamp and reproducible result metadata;
+10. an explicit review decision before adding `live_tested` to activation truth.
+
+## SA-10 repository gate
+
+The repository-side SA-10 classification increment may be merged only when:
+
+- no activation record has disposition `planned`;
+- every terminal non-executable disposition has a non-empty reason and is resolved by the activation model;
+- the checked-in sample public-web target remains disabled and non-authorized;
+- the Source Coverage Matrix matches all newly terminalized records;
+- `audit_inventory` remains incomplete exactly because real active sources still lack controlled live validation, not because of unknown classifications;
+- the synthetic reference remains the only fully integrated checked-in source unless real controlled live evidence is separately added;
+- deterministic SA-10 reconciliation tests pass;
+- one exact final SHA passes the complete backend and frontend CI;
+- reviews and review threads are clear before squash merge.
+
+After this repository gate is merged, issue SA-10 remains open until provider-specific controlled live validations close the outstanding active-source set. No product lot should claim the entire Source Activation axis is fully live-validated before that evidence exists.

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -24,12 +24,12 @@ Symbols:
 | Greenhouse | legacy validation | Y | Y | Y | Y | Y | - | executable, controlled live proof outstanding |
 | Lever | legacy validation | Y | Y | Y | Y | Y | - | executable, controlled live proof outstanding |
 | SmartRecruiters | legacy validation | Y | Y | Y | Y | Y | - | executable, controlled live proof outstanding |
-| Recherche d'entreprises | target activation | Y | Y | - | - | N/A | - | paused until explicit identity target |
-| GLEIF | target activation | Y | Y | - | - | N/A | - | paused until explicit LEI target |
-| BODACC identity | target activation | Y | Y | - | - | N/A | - | paused until explicit French SIREN target |
+| Recherche d'entreprises `recherche-entreprises` | target activation | Y | Y | - | - | N/A | - | MANUAL until an explicit canonical organization target and deployment authorization exist |
+| GLEIF `gleif` | target activation | Y | Y | - | - | N/A | - | MANUAL until an analyst/deployment-selected LEI target exists |
+| BODACC identity `bodacc-identity` | target activation | Y | Y | - | - | N/A | - | MANUAL until an explicit organization/SIREN target and reviewed deployment authorization exist |
 | Synthetic reference | test reference | Y | Y | Y | Y | N/A | Y | fully integrated test capability |
-| OSINT Framework import | SA-00 | - | - | - | - | N/A | - | catalogue normalization implemented; no execution authority |
-| public-web target path | SA-02 / Priority B-3 | Y | Y | - | - | - | - | bounded sitemap + RSS/Atom + security.txt + public-document capability; checked-in example remains disabled/unauthorized |
+| OSINT Framework import `osint-framework-import` | SA-00 | - | - | - | - | N/A | - | MANUAL analyst catalogue-discovery input only; listings never grant execution authority |
+| public-web sample `public-web-example-fr-organization` | SA-02 / Priority B-3 | Y | Y | - | - | N/A | - | NOT_RELEVANT as a production source; checked-in sample remains disabled/unauthorized |
 | NVD | SA-01 | Y | Y | Y | Y | Y | - | governed paginated adapter; live proof outstanding |
 | FIRST EPSS | SA-01 | Y | Y | Y | Y | N/A | - | bounded explicit-CVE lookup; live proof outstanding |
 | GitHub Global Advisories | SA-01 | Y | Y | Y | Y | Y | - | governed paginated adapter; live proof outstanding |
@@ -64,9 +64,11 @@ Symbols:
 | Licensed passive exposure `licensed-passive-exposure` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending provider-specific customer-facing data rights and onboarding |
 | Licensed technography `licensed-technographic-observations` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending explicit embedding/redistribution rights and onboarding |
 | Licensed cloud-asset observations `licensed-cloud-asset-observations` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete provider, field scope, commercial rights and adapter |
-| Generic company incident source family | SA-10 | Y | - | - | - | - | - | provider-specific decomposition required after SEC path |
-| Generic regulator/CERT incident family | SA-10 | Y | - | - | - | - | - | concrete official endpoints and authorizations required |
-| Generic vendor/Linux/package advisory families | SA-10 | Y | - | - | - | - | - | provider/ecosystem-specific decomposition required |
+| Generic company incident family `official-company-incident-disclosures` | SA-10 | Y | - | - | - | N/A | - | NOT_RELEVANT as an executable source; provider-specific decomposition required beyond SEC |
+| Generic regulator/CERT incident family `regulator-cert-incident-notices` | SA-10 | Y | - | - | - | N/A | - | NOT_RELEVANT as an endpoint; concrete official provider records are required |
+| Generic vendor PSIRT family `official-vendor-psirt` | SA-10 | Y | - | - | - | N/A | - | NOT_RELEVANT as an executable source; concrete vendor feeds/APIs are required |
+| Generic Linux advisory family `official-linux-security-advisories` | SA-10 | Y | - | - | - | N/A | - | NOT_RELEVANT as an executable source; distro-specific provider records are required |
+| Generic package advisory family `official-package-security-advisories` | SA-10 | Y | - | - | - | N/A | - | NOT_RELEVANT as an executable source; ecosystem-specific provider records are required |
 | Official corporate disclosures `official-corporate-disclosures` | SA-06 | Y | - | - | - | N/A | - | MANUAL bounded first-party acquisition + Lot 18 analyst-reviewed mapping |
 | Official regulatory change notices `official-regulatory-change-notices` | SA-06 | Y | - | - | - | N/A | - | MANUAL source-specific regulator review + Lot 18 evidence classification |
 | Licensed corporate news `licensed-corporate-news-metadata` | SA-07 | Y | - | - | - | N/A | - | BLOCKED pending concrete licensed provider, customer-facing rights and runtime onboarding |
@@ -88,15 +90,32 @@ Symbols:
 
 ## Known broader source families
 
-The repository already models additional candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. Candidate families remain non-executable until a concrete provider, method and authorization are selected.
+The repository already models candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. SA-10 resolves family placeholders as non-executable terminal records; a future useful source must be introduced provider-specifically rather than reopening a generic family as an adapter.
 
-SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Priority B completion continues the same provider-level discipline for passive organization and technology evidence. Later waves must continue at provider level rather than hiding candidates behind family-level completion claims.
+SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Priority B and SA-05 through SA-09 preserve the same provider-level discipline.
 
 ## Reconciliation invariant
 
 Every `source_id` contained in every checked-in `source_portfolio*.yml` bundle must have an activation record. Repository tests enforce this invariant across the activation bundles added by each SA/Priority-B increment.
 
-OSINT Framework synchronization remains candidate discovery only. An upstream entry can stay non-executable, but relevant candidates must eventually receive an explicit `active`, `planned`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` disposition before SA-10 closes.
+OSINT Framework synchronization remains candidate discovery only. Its import record is terminal `manual`; every discovered candidate still requires its own provider-specific `active`, `manual`, `blocked`, `replaced`, `duplicate`, or `not_relevant` decision before execution can exist.
+
+## SA-10 final source completeness and live-validation gate
+
+SA-10 separates classification completeness from controlled live validation:
+
+- no activation record may remain `planned`;
+- `recherche-entreprises`, `gleif` and `bodacc-identity` are terminal `manual` because their adapters require deployment-specific organization/identifier targets and authorization;
+- `osint-framework-import` is terminal `manual` as analyst catalogue-discovery input only;
+- `public-web-example-fr-organization` is terminal `not_relevant` as a production source while the checked-in sample remains disabled and unauthorized;
+- `official-company-incident-disclosures`, `regulator-cert-incident-notices`, `official-vendor-psirt`, `official-linux-security-advisories` and `official-package-security-advisories` are terminal `not_relevant` as generic executable sources; any useful future provider must receive a concrete source record;
+- terminal non-executable records require reasons and never gain authorization/execution/live stages for completeness metrics;
+- active real sources without `live_tested` remain unresolved by `audit_inventory` even when unit/integration CI is green;
+- `reference-synthetic` remains the only fully integrated checked-in source until separately authorized controlled provider live evidence is recorded;
+- CI must not be reinterpreted as provider live validation;
+- activation truth, this matrix and `SA_10_FINAL_SOURCE_COMPLETENESS_AUDIT.md` must agree on the classification-complete but live-validation-open state;
+- one exact final SHA must pass the complete backend and frontend CI before the SA-10 repository classification increment is merged;
+- issue SA-10 remains open until the outstanding active-source controlled live-validation set is empty.
 
 ## SA-05 governed local OSINT completion boundary
 
@@ -228,7 +247,7 @@ SA-03 is complete only when:
 - DNS answers remain review-required organization links with shared-infrastructure risk;
 - certificate issuance remains review-required passive context and never proves endpoint deployment or exposure;
 - no adapter assesses vulnerability applicability, verifies exposure, infers compromise, creates a need/opportunity, or performs outreach;
-- the licensed passive providers remain planned for SA-07 instead of being falsely activated under `.example.invalid` placeholders;
+- licensed passive providers are terminalized under SA-07 as blocked dependencies rather than falsely activated under `.example.invalid` placeholders;
 - deterministic adapter/runtime/registry tests and the complete repository CI pass on one exact final SHA;
 - `live_tested` remains false until separately authorized controlled provider validation is evidenced.
 

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -55,25 +55,28 @@ sources:
   - source_id: recherche-entreprises
     display_name: API Recherche d'entreprises
     category: organization_identity
-    disposition: planned
+    disposition: manual
     activation_wave: identity-target-activation
     requires_schedule: false
+    reason: A governed adapter exists, but execution requires a deployment-specific canonical organization target and explicit authorization; checked-in defaults do not contain a production target.
     stages: [catalogued, reviewed, mapped, adapter_present]
 
   - source_id: gleif
     display_name: GLEIF LEI API
     category: organization_identity
-    disposition: planned
+    disposition: manual
     activation_wave: identity-target-activation
     requires_schedule: false
+    reason: A governed adapter exists, but execution requires an analyst/deployment-selected LEI bound to a canonical organization; checked-in defaults do not authorize a production target.
     stages: [catalogued, reviewed, mapped, adapter_present]
 
   - source_id: bodacc-identity
     display_name: BODACC identity claims
     category: organization_identity
-    disposition: planned
+    disposition: manual
     activation_wave: identity-target-activation
     requires_schedule: false
+    reason: A governed adapter exists, but execution requires an explicit French organization/SIREN target and reviewed deployment authorization; checked-in defaults remain fail-closed.
     stages: [catalogued, reviewed, mapped, adapter_present]
 
   - source_id: reference-synthetic
@@ -86,16 +89,19 @@ sources:
   - source_id: osint-framework-import
     display_name: OSINT Framework imported candidates
     category: catalog_candidate
-    disposition: planned
+    disposition: manual
     activation_wave: SA-00
     requires_schedule: false
+    reason: The import is a governed analyst catalogue-discovery input only; an OSINT Framework listing never grants source authorization or runtime execution and candidates require provider-specific review.
     stages: [catalogued, reviewed]
 
   - source_id: public-web-example-fr-organization
     display_name: Example public website candidate
     category: corporate_public_footprint
-    disposition: planned
+    disposition: not_relevant
     activation_wave: SA-02
+    requires_schedule: false
+    reason: This checked-in disabled sample target exists only to exercise bounded public-web configuration and is not a production source; real organization targets are deployment-specific governed records.
     stages: [catalogued, reviewed, mapped, adapter_present]
 
   - source_id: cve-org-services
@@ -163,17 +169,19 @@ sources:
   - source_id: official-company-incident-disclosures
     display_name: Public Company Incident Disclosures
     category: live_incidents
-    disposition: planned
+    disposition: not_relevant
     activation_wave: SA-10
-    reason: Generic source-family placeholder requires provider-specific decomposition after SEC activation.
+    requires_schedule: false
+    reason: This generic family placeholder is not an executable provider; SEC is already modeled provider-specifically and any additional company disclosure source must be added as its own governed concrete source.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: regulator-cert-incident-notices
     display_name: Regulator and CERT Incident Notices
     category: live_incidents
-    disposition: planned
+    disposition: not_relevant
     activation_wave: SA-10
-    reason: Generic regulator/CERT family requires concrete provider endpoints and source-specific authorization.
+    requires_schedule: false
+    reason: This generic regulator/CERT family is not itself a provider endpoint; each useful official source requires a concrete provider record, exact endpoints and source-specific authorization.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: licensed-incident-reporting
@@ -387,25 +395,28 @@ sources:
   - source_id: official-vendor-psirt
     display_name: Official Vendor PSIRT Advisories
     category: vulnerability_advisory
-    disposition: planned
+    disposition: not_relevant
     activation_wave: SA-10
-    reason: Generic family must be decomposed into concrete vendor feeds before adapter authorization.
+    requires_schedule: false
+    reason: The generic vendor-PSIRT family is not an executable source; each useful vendor feed/API must be represented by a concrete provider-specific source with its own governance and mapping.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-linux-security-advisories
     display_name: Official Linux Security Advisories
     category: vulnerability_advisory
-    disposition: planned
+    disposition: not_relevant
     activation_wave: SA-10
-    reason: Generic Linux advisory family requires provider-specific decomposition and value review.
+    requires_schedule: false
+    reason: The generic Linux advisory family is not an executable provider; distro-specific feeds/APIs require separate concrete source records and value/governance review.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-package-security-advisories
     display_name: Official Package Security Advisories
     category: vulnerability_advisory
-    disposition: planned
+    disposition: not_relevant
     activation_wave: SA-10
-    reason: Generic package advisory family requires ecosystem-specific provider selection.
+    requires_schedule: false
+    reason: The generic package-advisory family is not an executable provider; ecosystem-specific feeds/APIs must be introduced as concrete governed source records.
     stages: [catalogued, reviewed, mapped]
 
   - source_id: official-corporate-disclosures

--- a/tests/unit/source_activation/test_priority_b_completion.py
+++ b/tests/unit/source_activation/test_priority_b_completion.py
@@ -95,8 +95,10 @@ def test_sa00_through_sa04_regression_state_is_explicit() -> None:
     records = _records()
     osint_import = records["osint-framework-import"]
 
-    assert osint_import.disposition is ActivationDisposition.PLANNED
+    assert osint_import.disposition is ActivationDisposition.MANUAL
     assert osint_import.activation_wave == "SA-00"
+    assert osint_import.reason
+    assert osint_import.is_resolved
     assert {
         ActivationStage.CATALOGUED,
         ActivationStage.REVIEWED,
@@ -129,8 +131,10 @@ def test_b3_capability_does_not_fake_authorize_example_target() -> None:
     target = _yaml(PUBLIC_WEB_TARGETS_PATH)["targets"][0]
     matrix = MATRIX_PATH.read_text(encoding="utf-8")
 
-    assert record.disposition is ActivationDisposition.PLANNED
+    assert record.disposition is ActivationDisposition.NOT_RELEVANT
     assert record.activation_wave == "SA-02"
+    assert record.reason
+    assert record.is_resolved
     assert ActivationStage.ADAPTER_PRESENT in record.stages
     assert ActivationStage.AUTHORIZED not in record.stages
     assert ActivationStage.EXECUTABLE not in record.stages

--- a/tests/unit/source_activation/test_sa10_final_source_completeness.py
+++ b/tests/unit/source_activation/test_sa10_final_source_completeness.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from cip.modules.source_activation.domain.audit import audit_inventory
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationRecord,
+    ActivationStage,
+)
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+MATRIX_PATH = Path("docs/source_activation/SOURCE_COVERAGE_MATRIX.md")
+AUDIT_PATH = Path("docs/source_activation/SA_10_FINAL_SOURCE_COMPLETENESS_AUDIT.md")
+PUBLIC_WEB_TARGETS_PATH = Path("policies/public_web_targets.yml")
+
+TERMINALIZED = {
+    "recherche-entreprises": ActivationDisposition.MANUAL,
+    "gleif": ActivationDisposition.MANUAL,
+    "bodacc-identity": ActivationDisposition.MANUAL,
+    "osint-framework-import": ActivationDisposition.MANUAL,
+    "public-web-example-fr-organization": ActivationDisposition.NOT_RELEVANT,
+    "official-company-incident-disclosures": ActivationDisposition.NOT_RELEVANT,
+    "regulator-cert-incident-notices": ActivationDisposition.NOT_RELEVANT,
+    "official-vendor-psirt": ActivationDisposition.NOT_RELEVANT,
+    "official-linux-security-advisories": ActivationDisposition.NOT_RELEVANT,
+    "official-package-security-advisories": ActivationDisposition.NOT_RELEVANT,
+}
+TERMINAL_NON_EXECUTABLE = {
+    ActivationDisposition.MANUAL,
+    ActivationDisposition.BLOCKED,
+    ActivationDisposition.REPLACED,
+    ActivationDisposition.DUPLICATE,
+    ActivationDisposition.NOT_RELEVANT,
+}
+
+
+def test_sa10_has_no_planned_activation_records() -> None:
+    records = _records()
+
+    assert all(record.disposition is not ActivationDisposition.PLANNED for record in records)
+
+
+def test_sa10_terminalizes_remaining_records_without_execution_authority() -> None:
+    records = {record.source_id: record for record in _records()}
+
+    for source_id, disposition in TERMINALIZED.items():
+        record = records[source_id]
+        assert record.disposition is disposition
+        assert record.reason
+        assert record.is_resolved
+        assert ActivationStage.AUTHORIZED not in record.stages
+        assert ActivationStage.EXECUTABLE not in record.stages
+        assert ActivationStage.LIVE_TESTED not in record.stages
+
+
+def test_every_terminal_non_executable_record_is_resolved_with_reason() -> None:
+    for record in _records():
+        if record.disposition in TERMINAL_NON_EXECUTABLE:
+            assert record.reason
+            assert record.is_resolved
+
+
+def test_sa10_preserves_real_live_validation_as_open_gate() -> None:
+    records = _records()
+    audit = audit_inventory(records)
+    active_without_live = tuple(
+        sorted(
+            record.source_id
+            for record in records
+            if record.disposition is ActivationDisposition.ACTIVE
+            and ActivationStage.LIVE_TESTED not in record.stages
+        )
+    )
+
+    assert active_without_live
+    assert audit.unresolved == active_without_live
+    assert audit.complete is False
+    for record in records:
+        if record.source_id in active_without_live:
+            assert record.missing_integration_stages == (ActivationStage.LIVE_TESTED,)
+
+
+def test_reference_synthetic_is_only_fully_integrated_checked_in_source() -> None:
+    integrated = {
+        record.source_id for record in _records() if record.is_fully_integrated
+    }
+
+    assert integrated == {"reference-synthetic"}
+
+
+def test_public_web_sample_remains_disabled_after_terminalization() -> None:
+    payload = _yaml(PUBLIC_WEB_TARGETS_PATH)
+    target = payload["targets"][0]
+
+    assert target["id"] == "public-web-example-fr-organization"
+    assert target["enabled"] is False
+    assert target["authorization"]["document_reference"] is None
+    assert target["authorization"]["reviewed_at"] is None
+
+
+def test_sa10_audit_and_matrix_cover_terminalized_sources_and_open_live_gate() -> None:
+    audit_text = AUDIT_PATH.read_text(encoding="utf-8")
+    matrix = MATRIX_PATH.read_text(encoding="utf-8")
+
+    for source_id in TERMINALIZED:
+        assert f"`{source_id}`" in audit_text
+        assert f"`{source_id}`" in matrix
+    assert "Controlled live validation: still open" in audit_text
+    assert "SA-10 final source completeness" in matrix
+
+
+def _records() -> list[ActivationRecord]:
+    return list(load_activation_inventory(ACTIVATION_PATH))
+
+
+def _yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload


### PR DESCRIPTION
Part of #97 — intentionally does NOT close the issue.

Starts from exact SA-09 squash `38bd3d0e0718a6da501679f26d91e7be5e52d131`.

This repository increment completes source **classification**: no activation record remains `planned`. Target-dependent identity capabilities and OSINT Framework import are terminal `manual`; the checked-in public-web sample and generic incident/advisory family placeholders are terminal `not_relevant` as executable sources. All terminal states retain reasons and no synthetic authorization/execution/live stages are added.

It also records the separate controlled-live-validation gate. Real active sources without `live_tested` remain unresolved by `audit_inventory`; repository CI is not treated as provider live evidence. The synthetic reference adapter remains the only fully integrated checked-in source unless a separately authorized provider-specific live proof is added.

Source Activation truth, the Coverage Matrix, SA-10 audit documentation and deterministic tests are synchronized. Full exact-head backend + frontend CI is required before this classification increment can merge. Issue #97 must remain open after merge until the outstanding active-source live-validation set is empty.