### PR TITLE
SA-13: activate extended public ATS providers

### DIFF
--- a/.github/workflows/sa13-live-validation.yml
+++ b/.github/workflows/sa13-live-validation.yml
@@ -1,0 +1,39 @@
+name: SA-13 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/cip/adapters/sources/ashby/**"
+      - "src/cip/adapters/sources/recruitee/**"
+      - "src/cip/modules/collection_orchestration/application/ashby_adapter.py"
+      - "src/cip/modules/collection_orchestration/application/recruitee_adapter.py"
+      - "policies/ashby_boards.yml"
+      - "policies/recruitee_sites.yml"
+      - "policies/sources.ats_expansion.yml"
+      - "scripts/live_validate_sa13.py"
+      - ".github/workflows/sa13-live-validation.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  live-public-ats:
+    if: github.event.pull_request.head.ref == 'agent/sa13-ats-expansion'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install --upgrade pip && pip install .
+
+      - name: Controlled Ashby and Recruitee live validation
+        run: python scripts/live_validate_sa13.py

--- a/.github/workflows/sa13-live-validation.yml
+++ b/.github/workflows/sa13-live-validation.yml
@@ -3,16 +3,6 @@ name: SA-13 Live Validation
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "src/cip/adapters/sources/ashby/**"
-      - "src/cip/adapters/sources/recruitee/**"
-      - "src/cip/modules/collection_orchestration/application/ashby_adapter.py"
-      - "src/cip/modules/collection_orchestration/application/recruitee_adapter.py"
-      - "policies/ashby_boards.yml"
-      - "policies/recruitee_sites.yml"
-      - "policies/sources.ats_expansion.yml"
-      - "scripts/live_validate_sa13.py"
-      - ".github/workflows/sa13-live-validation.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/sa13-live-validation.yml
+++ b/.github/workflows/sa13-live-validation.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: sa13-live-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   live-public-ats:
     if: github.event.pull_request.head.ref == 'agent/sa13-ats-expansion'
@@ -24,16 +28,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: "3.12"
           cache: pip
 
       - name: Install project
-        run: python -m pip install --upgrade pip && pip install .
+        run: python -m pip install .
 
       - name: Controlled Ashby and Recruitee live validation
         run: python scripts/live_validate_sa13.py

--- a/docs/source_activation/SA_13_ATS_EXPANSION.md
+++ b/docs/source_activation/SA_13_ATS_EXPANSION.md
@@ -1,0 +1,66 @@
+# SA-13 — Extended ATS acquisition and controlled live validation
+
+## Result
+
+SA-13 adds provider-specific public hiring adapters for Ashby, Recruitee and Teamtailor while reusing the existing collection scheduler/worker, immutable raw-observation path and canonical public-job mapping.
+
+The implementation does not treat documentation or adapter presence as proof of live integration.
+
+## Ashby
+
+Source id: `ashby-job-board`.
+
+Acquisition uses Ashby's documented public Job Postings API under `https://api.ashbyhq.com/posting-api/job-board/{board}` with no authentication. Collection is GET-only and target-bound. The adapter requests no compensation data, ignores unlisted jobs, validates the provider schema, enforces response and job-count bounds, fingerprints jobs for checkpoint/idempotence and maps only public posting metadata through `CanonicalPublicJob`.
+
+Controlled live validation uses the provider's public `Ashby` board. The first successful provider proof retrieved 59 public jobs through the real `AshbyAdapter`. The real result contained no cyber-relevant posting under the current canonical classifier, so zero commercial projections were created; absence of a cyber match is preserved rather than converted into a synthetic signal.
+
+## Recruitee
+
+Source id: `recruitee-careers-site`.
+
+Acquisition uses the unauthenticated Careers Site API `https://{company}.recruitee.com/api/offers/`. Candidate creation, applicant data and the authenticated ATS API are outside this adapter. The provider's structured department/location fields are normalized into the existing canonical job model.
+
+The first live attempt correctly failed closed on a provider timestamp variant (`YYYY-MM-DD HH:MM:SS UTC`). The adapter was then changed to normalize only that UTC provider form plus the already accepted timezone-aware representation, and a deterministic regression test locks the observed format.
+
+The subsequent controlled live proof used the configured public `peopleforpeople.recruitee.com` careers site and retrieved one public job through the real `RecruiteeAdapter`. The posting was not cyber-relevant, so no commercial signal was invented.
+
+## Teamtailor
+
+Source id: `teamtailor-public-jobs`.
+
+The adapter implements Teamtailor's JSON:API public-jobs path, required `X-Api-Version`, bounded pagination, regional API hosts and an account-specific `Public + Read` token supplied only through the existing Provider Onboarding secret-reference path.
+
+The checked-in Teamtailor account registry remains empty and its schedule disabled. Therefore the activation record is truthful: `catalogued`, `reviewed`, `mapped`, `adapter_present`, `authorized`, but not `executable`, `scheduled` or `live_tested`. A deployment must supply one reviewed account and its Public Read token before those stages can be promoted.
+
+## Runtime and evidence boundaries
+
+All three adapters reuse the existing collection runtime. SA-13 introduces no second scheduler, worker, source health subsystem or hiring persistence silo.
+
+Provider payloads remain inside provider adapters. Surviving public postings are normalized through the existing canonical hiring path before any commercial projection. A job posting can support a capability/program signal only when the canonical classifier actually matches its content; provider presence alone never creates a need, score, opportunity, contact target or outreach action.
+
+No application forms, resumes, screening data, candidate records, write endpoints, private data, browser automation, CAPTCHA/MFA handling or authentication bypass are part of SA-13.
+
+## Controlled live validation
+
+The dedicated workflow `.github/workflows/sa13-live-validation.yml` executes `scripts/live_validate_sa13.py` against the real approved public Ashby and Recruitee endpoints. It instantiates the production adapters, not provider-specific test clients, and requires non-empty provider checkpoints while printing only aggregate counts.
+
+Successful proof observed before final reconciliation:
+
+- workflow run `31439468235`;
+- Ashby public jobs retrieved: `59`;
+- Recruitee public jobs retrieved: `1`;
+- cyber-relevant projections: `0` for both sources, truthfully preserved.
+
+Because every code or documentation commit invalidates exact-head proof, the workflow is configured to rerun on every change to this PR. The final merge gate requires both the normal repository CI and the live workflow to pass on the final PR head.
+
+## Completion gate
+
+SA-13 may be squash-merged only when:
+
+1. Ashby and Recruitee have provider-specific real adapters, runtime registration, source governance, portfolio entries, enabled schedules and controlled live proof;
+2. Teamtailor has a real secret-aware adapter path but remains non-live until a deployment Public Read account/token exists;
+3. Source Activation truth exposes Ashby/Recruitee as fully integrated and Teamtailor as an active unresolved integration rather than manufacturing green stages;
+4. deterministic adapter, governance, checkpoint, schema, runtime and activation tests pass;
+5. Ruff, strict Mypy, architecture/release tests, reversible migrations, the complete branch-aware coverage suite and frontend checks pass;
+6. the dedicated live provider workflow passes on the exact final PR head;
+7. reviews and review threads are clear before squash merge.

--- a/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
+++ b/docs/source_activation/SOURCE_COVERAGE_MATRIX.md
@@ -2,7 +2,7 @@
 
 ## Reading this matrix
 
-This document is a human-readable projection of `policies/source_activation.yml`. The policy file and executable invariants are authoritative when prose and state disagree.
+This document is a human-readable projection of the Source Activation bundle rooted at `policies/source_activation.yml` plus additive `policies/source_activation.*.yml` files. The machine-readable activation bundle and executable invariants are authoritative when prose and state disagree.
 
 Symbols:
 
@@ -24,6 +24,9 @@ Symbols:
 | Greenhouse | legacy validation | Y | Y | Y | Y | Y | - | executable, controlled live proof outstanding |
 | Lever | legacy validation | Y | Y | Y | Y | Y | - | executable, controlled live proof outstanding |
 | SmartRecruiters | legacy validation | Y | Y | Y | Y | Y | - | executable, controlled live proof outstanding |
+| Ashby Public Job Postings API `ashby-job-board` | SA-13 | Y | Y | Y | Y | Y | Y | fully integrated; controlled live adapter proof retrieved 59 public jobs |
+| Recruitee Careers Site API `recruitee-careers-site` | SA-13 | Y | Y | Y | Y | Y | Y | fully integrated; controlled live adapter proof retrieved 1 public job |
+| Teamtailor Public Read Jobs API `teamtailor-public-jobs` | SA-13 | Y | Y | Y | - | - | - | real adapter present; account-specific Public Read token/account required before executable, scheduled and live-tested stages |
 | Recherche d'entreprises `recherche-entreprises` | target activation | Y | Y | - | - | N/A | - | MANUAL until an explicit canonical organization target and deployment authorization exist |
 | GLEIF `gleif` | target activation | Y | Y | - | - | N/A | - | MANUAL until an analyst/deployment-selected LEI target exists |
 | BODACC identity `bodacc-identity` | target activation | Y | Y | - | - | N/A | - | MANUAL until an explicit organization/SIREN target and reviewed deployment authorization exist |
@@ -92,7 +95,7 @@ Symbols:
 
 The repository already models candidate families delivered in Lots 13–22: incident reporting, ransomware metadata, threat telemetry, passive exposure, advisory providers, corporate-change intelligence, relationship intelligence, professional context and conditional premium integrations. SA-10 resolves family placeholders as non-executable terminal records; a future useful source must be introduced provider-specifically rather than reopening a generic family as an adapter.
 
-SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Priority B and SA-05 through SA-09 preserve the same provider-level discipline.
+SA-00 established the lifecycle and truth model. SA-01 through SA-04 promote only provider-specific paths whose implementation, authorization and runtime boundaries are explicit. Priority B and SA-05 through SA-09 preserve the same provider-level discipline. SA-13 extends that same provider-specific model with separately evidenced live ATS integrations.
 
 ## Reconciliation invariant
 
@@ -110,12 +113,26 @@ SA-10 separates classification completeness from controlled live validation:
 - `public-web-example-fr-organization` is terminal `not_relevant` as a production source while the checked-in sample remains disabled and unauthorized;
 - `official-company-incident-disclosures`, `regulator-cert-incident-notices`, `official-vendor-psirt`, `official-linux-security-advisories` and `official-package-security-advisories` are terminal `not_relevant` as generic executable sources; any useful future provider must receive a concrete source record;
 - terminal non-executable records require reasons and never gain authorization/execution/live stages for completeness metrics;
-- active real sources without `live_tested` remain unresolved by `audit_inventory` even when unit/integration CI is green;
-- `reference-synthetic` remains the only fully integrated checked-in source until separately authorized controlled provider live evidence is recorded;
+- active real sources missing any mandatory integration stage remain unresolved by `audit_inventory` even when unit/integration CI is green;
+- `reference-synthetic`, `ashby-job-board` and `recruitee-careers-site` are currently fully integrated checked-in records; future provider-specific controlled live evidence may extend this set;
 - CI must not be reinterpreted as provider live validation;
 - activation truth, this matrix and `SA_10_FINAL_SOURCE_COMPLETENESS_AUDIT.md` must agree on the classification-complete but live-validation-open state;
-- one exact final SHA must pass the complete backend and frontend CI before the SA-10 repository classification increment is merged;
+- one exact final SHA must pass the complete backend and frontend CI before an SA increment is merged;
 - issue SA-10 remains open until the outstanding active-source controlled live-validation set is empty.
+
+## SA-13 extended ATS activation boundary
+
+SA-13 is complete only when:
+
+- `ashby-job-board` and `recruitee-careers-site` have provider-specific Source Governance, target registries, real adapters, canonical job mapping, executable portfolio entries, enabled schedules and controlled live provider proof;
+- the dedicated live workflow executes the production `AshbyAdapter` and `RecruiteeAdapter`, not synthetic provider clients, and requires non-empty provider checkpoints;
+- successful controlled provider proof has demonstrated actual public acquisition (59 Ashby jobs and 1 Recruitee job in the recorded proof) while preserving zero commercial projections when those real jobs contain no canonical cyber match;
+- Recruitee's observed `YYYY-MM-DD HH:MM:SS UTC` timestamp form is normalized explicitly and locked by a deterministic regression test rather than weakening timezone requirements;
+- `teamtailor-public-jobs` has a real JSON:API Public Read adapter with regional host, API-version and bounded pagination controls, but remains non-executable/non-scheduled/non-live until one approved account and Public Read token exist through Provider Onboarding;
+- no ATS path accesses applications, resumes, screening data, candidate records or write endpoints;
+- all three adapters reuse the existing collection scheduler/worker and `CanonicalPublicJob` path; no ATS-specific scheduler, health subsystem or persistence silo is introduced;
+- Source Activation bundle truth, this matrix, `SA_13_ATS_EXPANSION.md`, deterministic tests and the live workflow agree on the exact stages;
+- the normal repository CI and the dedicated live workflow both pass on the exact final PR head before squash merge.
 
 ## SA-05 governed local OSINT completion boundary
 

--- a/policies/ashby_boards.yml
+++ b/policies/ashby_boards.yml
@@ -1,0 +1,9 @@
+version: 1
+reviewed_at: 2026-08-11
+
+boards:
+  - id: ashby
+    board_name: Ashby
+    canonical_name: Ashby
+    country_code: US
+    enabled: true

--- a/policies/collection_schedules.ats_expansion.yml
+++ b/policies/collection_schedules.ats_expansion.yml
@@ -1,0 +1,38 @@
+version: 1
+
+schedules:
+  - source_id: ashby-job-board
+    adapter_id: ashby-public-job-postings-api
+    enabled: true
+    interval_seconds: 3600
+    lease_seconds: 180
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 60
+      max_delay_seconds: 1800
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 1800
+
+  - source_id: recruitee-careers-site
+    adapter_id: recruitee-careers-site-api
+    enabled: true
+    interval_seconds: 3600
+    lease_seconds: 180
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 60
+      max_delay_seconds: 1800
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 1800
+
+  - source_id: teamtailor-public-jobs
+    adapter_id: teamtailor-public-read-jobs-api
+    enabled: false
+    interval_seconds: 3600
+    lease_seconds: 180
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 60
+      max_delay_seconds: 1800
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 1800

--- a/policies/provider_onboarding.yml
+++ b/policies/provider_onboarding.yml
@@ -1,5 +1,5 @@
 version: 1
-reviewed_at: 2026-08-09
+reviewed_at: 2026-08-11
 
 providers:
   - source_id: cisa-kev
@@ -66,6 +66,45 @@ providers:
     required_secret_names: []
     human_actions: []
     automatic_onboarding: true
+    blocked_reason: null
+
+  - source_id: ashby-job-board
+    display_name: Ashby Public Job Postings API
+    auth_mode: none
+    documentation_url: https://developers.ashbyhq.com/docs/public-job-posting-api
+    signup_url: null
+    console_url: null
+    required_secret_names: []
+    human_actions: []
+    automatic_onboarding: true
+    blocked_reason: null
+
+  - source_id: recruitee-careers-site
+    display_name: Recruitee Careers Site API
+    auth_mode: none
+    documentation_url: https://docs.recruitee.com/reference/intro-to-careers-site-api
+    signup_url: null
+    console_url: null
+    required_secret_names: []
+    human_actions: []
+    automatic_onboarding: true
+    blocked_reason: null
+
+  - source_id: teamtailor-public-jobs
+    display_name: Teamtailor Public Read Jobs API
+    auth_mode: api_key
+    documentation_url: https://docs.teamtailor.com/
+    signup_url: null
+    console_url: null
+    required_secret_names:
+      - api_token
+    human_actions:
+      - sign_in
+      - accept_provider_terms
+      - retrieve_technical_credentials
+      - register_secret_reference
+      - enable_source_policy
+    automatic_onboarding: false
     blocked_reason: null
 
   - source_id: recherche-entreprises

--- a/policies/recruitee_sites.yml
+++ b/policies/recruitee_sites.yml
@@ -1,0 +1,9 @@
+version: 1
+reviewed_at: 2026-08-11
+
+sites:
+  - id: people-for-people
+    subdomain: peopleforpeople
+    canonical_name: People for People
+    country_code: NL
+    enabled: true

--- a/policies/source_activation.ats_expansion.yml
+++ b/policies/source_activation.ats_expansion.yml
@@ -1,0 +1,44 @@
+version: 1
+
+sources:
+  - source_id: ashby-job-board
+    display_name: Ashby Public Job Postings API
+    category: public_hiring
+    disposition: active
+    activation_wave: SA-13
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable
+      - scheduled
+      - live_tested
+
+  - source_id: recruitee-careers-site
+    display_name: Recruitee Careers Site API
+    category: public_hiring
+    disposition: active
+    activation_wave: SA-13
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable
+      - scheduled
+      - live_tested
+
+  - source_id: teamtailor-public-jobs
+    display_name: Teamtailor Public Read Jobs API
+    category: public_hiring
+    disposition: active
+    activation_wave: SA-13
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized

--- a/policies/source_portfolio.ats_expansion.yml
+++ b/policies/source_portfolio.ats_expansion.yml
@@ -1,0 +1,77 @@
+version: 1
+
+sources:
+  - source_id: ashby-job-board
+    display_name: Ashby Public Job Postings API
+    canonical_url: https://api.ashbyhq.com/posting-api/job-board
+    category: public_hiring
+    status: executable
+    freshness_max_age_seconds: 7200
+    commercial_use_cases: [program_transformation, capability_gap]
+    candidate_origin: SA-13
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      raw_response_storage: false
+      candidate_data: forbidden
+    adapter:
+      adapter_id: ashby-public-job-postings-api
+      adapter_version: "1"
+      provider_schema_version: ashby-public-job-posting-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types: [raw_observation, commercial_signal]
+      supports_corrections: true
+      supports_tombstones: true
+      max_page_size: 5000
+      cost_per_request: 0
+
+  - source_id: recruitee-careers-site
+    display_name: Recruitee Careers Site API
+    canonical_url: https://peopleforpeople.recruitee.com/api/offers/
+    category: public_hiring
+    status: executable
+    freshness_max_age_seconds: 7200
+    commercial_use_cases: [program_transformation, capability_gap]
+    candidate_origin: SA-13
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      raw_response_storage: false
+      candidate_data: forbidden
+    adapter:
+      adapter_id: recruitee-careers-site-api
+      adapter_version: "1"
+      provider_schema_version: recruitee-careers-site-offers-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types: [raw_observation, commercial_signal]
+      supports_corrections: true
+      supports_tombstones: true
+      max_page_size: 5000
+      cost_per_request: 0
+
+  - source_id: teamtailor-public-jobs
+    display_name: Teamtailor Public Read Jobs API
+    canonical_url: https://api.teamtailor.com/v1/jobs
+    category: public_hiring
+    status: paused
+    freshness_max_age_seconds: 7200
+    commercial_use_cases: [program_transformation, capability_gap]
+    candidate_origin: SA-13
+    monthly_cost_limit: 0
+    metadata:
+      activation_requires: connected_public_read_token_and_account
+      authorization_status: approved
+      raw_response_storage: false
+      candidate_data: forbidden
+    adapter:
+      adapter_id: teamtailor-public-read-jobs-api
+      adapter_version: "1"
+      provider_schema_version: teamtailor-jsonapi-public-jobs-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types: [raw_observation, commercial_signal]
+      supports_corrections: true
+      supports_tombstones: true
+      max_page_size: 30
+      cost_per_request: 0

--- a/policies/sources.ats_expansion.yml
+++ b/policies/sources.ats_expansion.yml
@@ -1,0 +1,115 @@
+version: 1
+reviewed_at: 2026-08-11
+
+sources:
+  - id: ashby-job-board
+    name: Ashby Public Job Postings API
+    base_url: https://api.ashbyhq.com/posting-api/job-board
+    status: enabled
+    source_type: api
+    owner: Ashby, Inc.
+    terms_url: https://developers.ashbyhq.com/docs/public-job-posting-api
+    licence: Public Job Postings API documentation
+    allowed_data_categories: [public_job_posting, organization_metadata]
+    prohibited_data_categories: &ats_prohibited
+      - professional_contact
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 4
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_13_ATS_EXPANSION.md#ashby
+      reviewed_at: "2026-08-11T00:15:00+02:00"
+      expires_at: null
+      approved_hosts: [api.ashbyhq.com]
+      approved_path_prefixes: [/posting-api/job-board/]
+      approved_purposes: [commercial-hiring-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: high
+    notes: >-
+      GET-only public job-board data. Compensation is not requested. Unlisted jobs,
+      application forms, candidate data and write APIs are excluded.
+
+  - id: recruitee-careers-site
+    name: Recruitee Careers Site API
+    base_url: https://peopleforpeople.recruitee.com/api/offers/
+    status: enabled
+    source_type: api
+    owner: Tellent / Recruitee
+    terms_url: https://docs.recruitee.com/reference/intro-to-careers-site-api
+    licence: Public Careers Site API documentation
+    allowed_data_categories: [public_job_posting, organization_metadata]
+    prohibited_data_categories: *ats_prohibited
+    rate_limit_per_minute: 4
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_13_ATS_EXPANSION.md#recruitee
+      reviewed_at: "2026-08-11T00:15:00+02:00"
+      expires_at: null
+      approved_hosts: [peopleforpeople.recruitee.com]
+      approved_path_prefixes: [/api/offers/]
+      approved_purposes: [commercial-hiring-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: medium
+    notes: >-
+      GET-only published offers from a configured public Careers Site. Candidate
+      creation/application endpoints and the authenticated ATS API are excluded.
+
+  - id: teamtailor-public-jobs
+    name: Teamtailor Public Read Jobs API
+    base_url: https://api.teamtailor.com/v1/jobs
+    status: enabled
+    source_type: api
+    owner: Teamtailor AB
+    terms_url: https://docs.teamtailor.com/
+    licence: Teamtailor account API terms and Public Read scope
+    allowed_data_categories: [public_job_posting, organization_metadata]
+    prohibited_data_categories: *ats_prohibited
+    rate_limit_per_minute: 30
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_13_ATS_EXPANSION.md#teamtailor
+      reviewed_at: "2026-08-11T00:15:00+02:00"
+      expires_at: null
+      approved_hosts: [api.teamtailor.com, api.na.teamtailor.com, api.au.teamtailor.com]
+      approved_path_prefixes: [/v1/jobs]
+      approved_purposes: [commercial-hiring-intelligence]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: unknown
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: high
+    notes: >-
+      Runtime execution requires a deployment-connected Public Read API key tied
+      to one approved Teamtailor account. Internal/Admin scopes and candidate data
+      are outside this adapter.

--- a/policies/teamtailor_accounts.yml
+++ b/policies/teamtailor_accounts.yml
@@ -1,0 +1,7 @@
+version: 1
+reviewed_at: 2026-08-11
+
+# A Teamtailor Public Read token belongs to a specific customer account. The
+# checked-in registry stays empty until deployment onboarding supplies that
+# account identity and the corresponding secret reference.
+accounts: []

--- a/scripts/live_validate_sa13.py
+++ b/scripts/live_validate_sa13.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+from cip.adapters.sources.ashby.registry import load_ashby_boards
+from cip.adapters.sources.recruitee.registry import load_recruitee_sites
+from cip.modules.collection_orchestration.application.ashby_adapter import AshbyAdapter
+from cip.modules.collection_orchestration.application.recruitee_adapter import RecruiteeAdapter
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+POLICY_PATH = Path("policies/sources.ats_expansion.yml")
+
+
+def main() -> None:
+    entries = {entry.policy.id: entry for entry in load_source_registry(POLICY_PATH)}
+    now = datetime.now(UTC)
+    retention_until = now + timedelta(days=365)
+    ashby = AshbyAdapter(
+        _entry(entries, "ashby-job-board"),
+        load_ashby_boards(Path("policies/ashby_boards.yml")),
+        timeout_seconds=30,
+    )
+    recruitee = RecruiteeAdapter(
+        _entry(entries, "recruitee-careers-site"),
+        load_recruitee_sites(Path("policies/recruitee_sites.yml")),
+        timeout_seconds=30,
+    )
+    ashby_batch = ashby.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=retention_until,
+    )
+    recruitee_batch = recruitee.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=retention_until,
+    )
+    ashby_count = _checkpoint_item_count(ashby_batch.checkpoint_payload)
+    recruitee_count = _checkpoint_item_count(recruitee_batch.checkpoint_payload)
+    if ashby_count < 1:
+        raise RuntimeError("Ashby live validation returned no public jobs")
+    if recruitee_count < 1:
+        raise RuntimeError("Recruitee live validation returned no public jobs")
+    print(
+        "SA-13 live validation passed: "
+        f"ashby_jobs={ashby_count} recruitee_jobs={recruitee_count} "
+        f"ashby_relevant={len(ashby_batch.commercial_projections)} "
+        f"recruitee_relevant={len(recruitee_batch.commercial_projections)}"
+    )
+
+
+def _entry(
+    entries: dict[str, SourceRegistryEntry],
+    source_id: str,
+) -> SourceRegistryEntry:
+    try:
+        return entries[source_id]
+    except KeyError as exc:
+        raise RuntimeError(f"missing live validation source policy: {source_id}") from exc
+
+
+def _checkpoint_item_count(payload: dict[str, object] | None) -> int:
+    if payload is None:
+        return 0
+    raw = payload.get("fingerprints")
+    if not isinstance(raw, dict):
+        return 0
+    total = 0
+    for values in raw.values():
+        if isinstance(values, dict):
+            total += len(values)
+    return total
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/ashby/__init__.py
+++ b/src/cip/adapters/sources/ashby/__init__.py
@@ -1,0 +1,1 @@
+"""Ashby public Job Postings API adapter."""

--- a/src/cip/adapters/sources/ashby/client.py
+++ b/src/cip/adapters/sources/ashby/client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote
+
+import httpx
+
+
+class AshbySourceResponseError(RuntimeError):
+    """Ashby returned an unsafe or unusable public job-board response."""
+
+
+@dataclass(frozen=True, slots=True)
+class AshbyFetchResult:
+    body: bytes
+    request_url: str
+
+
+class AshbyClient:
+    MAX_RESPONSE_BYTES = 8_000_000
+
+    def __init__(self, client: httpx.Client, *, postings_base_url: str) -> None:
+        self._client = client
+        self._postings_base_url = postings_base_url.rstrip("/")
+
+    def board_url(self, board_name: str) -> str:
+        normalized = board_name.strip()
+        if not normalized:
+            raise ValueError("board_name is required")
+        return f"{self._postings_base_url}/{quote(normalized, safe='')}"
+
+    def fetch_jobs(self, board_name: str) -> AshbyFetchResult:
+        url = self.board_url(board_name)
+        response = self._client.get(
+            url,
+            headers={"Accept": "application/json"},
+            params={"includeCompensation": "false"},
+        )
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return AshbyFetchResult(body=response.content, request_url=str(response.request.url))
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    if content_type != "application/json":
+        raise AshbySourceResponseError(
+            f"unexpected content type: {content_type or 'missing'}"
+        )
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise AshbySourceResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise AshbySourceResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise AshbySourceResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/ashby/collector.py
+++ b/src/cip/adapters/sources/ashby/collector.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.ashby.client import AshbyClient
+from cip.adapters.sources.ashby.mapper import ashby_job_to_canonical, map_ashby_job
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.ashby.schemas import AshbyJobBoardResponse, AshbyJobPosting
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class AshbyCollectionDeniedError(RuntimeError):
+    """Source governance denied Ashby collection."""
+
+
+class AshbySourceSchemaError(RuntimeError):
+    """Ashby payload no longer matches the approved public schema."""
+
+
+class AshbySourceWindowError(RuntimeError):
+    """An Ashby board exceeds the configured safe job count."""
+
+
+@dataclass(frozen=True, slots=True)
+class AshbyCheckpoint:
+    fingerprints: Mapping[str, Mapping[str, str]]
+
+    def __post_init__(self) -> None:
+        copied = {
+            board_id: MappingProxyType(dict(values))
+            for board_id, values in self.fingerprints.items()
+        }
+        object.__setattr__(self, "fingerprints", MappingProxyType(copied))
+
+
+@dataclass(frozen=True, slots=True)
+class AshbyCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    projections: tuple[CommercialProjection, ...]
+    checkpoint: AshbyCheckpoint
+    not_modified: bool
+
+
+def collect_ashby_jobs(
+    client: AshbyClient,
+    entry: SourceRegistryEntry,
+    boards: tuple[AshbyBoard, ...],
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: AshbyCheckpoint | None = None,
+    max_jobs_per_board: int = 5_000,
+) -> AshbyCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    enabled_boards = tuple(board for board in boards if board.enabled)
+    if not enabled_boards:
+        raise ValueError("at least one Ashby board must be enabled")
+    if max_jobs_per_board < 1:
+        raise ValueError("max_jobs_per_board must be positive")
+    previous = checkpoint.fingerprints if checkpoint else {}
+    current: dict[str, dict[str, str]] = {}
+    observations: list[RawObservation] = []
+    projections: list[CommercialProjection] = []
+    for board in enabled_boards:
+        _authorize(entry, client.board_url(board.board_name), collected_at=collected)
+        jobs = _parse_response(client.fetch_jobs(board.board_name).body).jobs
+        if len(jobs) > max_jobs_per_board:
+            raise AshbySourceWindowError("Ashby board exceeds configured job limit")
+        current[board.id] = _collect_board(
+            board,
+            tuple(job for job in jobs if job.is_listed),
+            previous=previous.get(board.id, {}),
+            collection_job_id=collection_job_id,
+            collected_at=collected,
+            retention_until=retention_until,
+            observations=observations,
+            projections=projections,
+        )
+    current_checkpoint = AshbyCheckpoint(current)
+    return AshbyCollectionBatch(
+        observations=tuple(observations),
+        projections=tuple(projections),
+        checkpoint=current_checkpoint,
+        not_modified=_checkpoint_equal(previous, current_checkpoint.fingerprints),
+    )
+
+
+def _collect_board(
+    board: AshbyBoard,
+    jobs: tuple[AshbyJobPosting, ...],
+    *,
+    previous: Mapping[str, str],
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    observations: list[RawObservation],
+    projections: list[CommercialProjection],
+) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for job in jobs:
+        key = job.source_job_id
+        if key in fingerprints:
+            raise AshbySourceSchemaError(f"duplicate job id on board {board.id}: {key}")
+        canonical = ashby_job_to_canonical(board, job)
+        fingerprint = canonical.fingerprint()
+        fingerprints[key] = fingerprint
+        mapped = map_ashby_job(
+            board,
+            job,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        if mapped is None:
+            continue
+        observation, projection = mapped
+        projections.append(projection)
+        if previous.get(key) != fingerprint:
+            observations.append(observation)
+    return fingerprints
+
+
+def _authorize(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    *,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_JOB_POSTING,
+            target_url=target_url,
+            purpose="commercial-hiring-intelligence",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise AshbyCollectionDeniedError(decision.reason.value)
+
+
+def _parse_response(body: bytes) -> AshbyJobBoardResponse:
+    try:
+        return AshbyJobBoardResponse.model_validate_json(body)
+    except ValidationError as exc:
+        raise AshbySourceSchemaError("Ashby response schema validation failed") from exc
+
+
+def _checkpoint_equal(
+    previous: Mapping[str, Mapping[str, str]],
+    current: Mapping[str, Mapping[str, str]],
+) -> bool:
+    return {board_id: dict(values) for board_id, values in previous.items()} == {
+        board_id: dict(values) for board_id, values in current.items()
+    }

--- a/src/cip/adapters/sources/ashby/collector.py
+++ b/src/cip/adapters/sources/ashby/collector.py
@@ -12,6 +12,7 @@ from cip.adapters.sources.ashby.client import AshbyClient
 from cip.adapters.sources.ashby.mapper import ashby_job_to_canonical, map_ashby_job
 from cip.adapters.sources.ashby.registry import AshbyBoard
 from cip.adapters.sources.ashby.schemas import AshbyJobBoardResponse, AshbyJobPosting
+from cip.adapters.sources.canonical_jobs import canonical_public_job_observation
 from cip.modules.collection_orchestration.application.ports import CommercialProjection
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import (
@@ -126,10 +127,16 @@ def _collect_board(
             collected_at=collected_at,
             retention_until=retention_until,
         )
-        if mapped is None:
-            continue
-        observation, projection = mapped
-        projections.append(projection)
+        if mapped is not None:
+            observation, projection = mapped
+            projections.append(projection)
+        else:
+            observation = canonical_public_job_observation(
+                canonical,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+            )
         if previous.get(key) != fingerprint:
             observations.append(observation)
     return fingerprints

--- a/src/cip/adapters/sources/ashby/mapper.py
+++ b/src/cip/adapters/sources/ashby/mapper.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.ashby.schemas import AshbyJobPosting
+from cip.adapters.sources.canonical_jobs import CanonicalPublicJob, map_canonical_public_job
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+
+SOURCE_ID = "ashby-job-board"
+ADAPTER_ID = "ashby-public-job-postings-api"
+ADAPTER_VERSION = "1.0.0"
+
+
+def ashby_job_to_canonical(
+    board: AshbyBoard,
+    job: AshbyJobPosting,
+) -> CanonicalPublicJob:
+    department = job.department or job.team
+    seniority = job.team if job.department and job.team else None
+    return CanonicalPublicJob(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        provider_label="Ashby",
+        schema_fingerprint="ashby-public-job-posting-v1",
+        site_id=board.board_name,
+        organization_key=board.id,
+        organization_name=board.canonical_name,
+        country_code=board.country_code,
+        source_job_id=job.source_job_id,
+        title=job.title,
+        source_url=str(job.job_url),
+        published_at=job.published_at,
+        description_text=job.description_plain,
+        location=job.display_location(),
+        department=department,
+        employment_type=job.employment_type,
+        seniority=seniority,
+        language=None,
+    )
+
+
+def map_ashby_job(
+    board: AshbyBoard,
+    job: AshbyJobPosting,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> tuple[RawObservation, CommercialProjection] | None:
+    return map_canonical_public_job(
+        ashby_job_to_canonical(board, job),
+        collection_job_id=collection_job_id,
+        collected_at=collected_at,
+        retention_until=retention_until,
+    )

--- a/src/cip/adapters/sources/ashby/registry.py
+++ b/src/cip/adapters/sources/ashby/registry.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_BOARD_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class AshbyBoard:
+    id: str
+    board_name: str
+    canonical_name: str
+    country_code: str | None = None
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        for field_name in ("id", "board_name", "canonical_name"):
+            value = getattr(self, field_name).strip()
+            if not value:
+                raise ValueError(f"{field_name} is required")
+            object.__setattr__(self, field_name, value)
+        if not _BOARD_NAME_PATTERN.fullmatch(self.board_name):
+            raise ValueError("board_name contains unsupported characters")
+        if self.country_code is not None:
+            country = self.country_code.strip().upper()
+            if len(country) != 2 or not country.isalpha():
+                raise ValueError("country_code must be an ISO alpha-2 code")
+            object.__setattr__(self, "country_code", country)
+
+
+def load_ashby_boards(path: Path) -> tuple[AshbyBoard, ...]:
+    payload = _load_yaml_mapping(path)
+    if _positive_int(payload, "version") != 1:
+        raise ValueError("unsupported Ashby board registry version")
+    raw_boards = payload.get("boards")
+    if not isinstance(raw_boards, list):
+        raise ValueError("boards must be a list")
+    boards: list[AshbyBoard] = []
+    ids: set[str] = set()
+    names: set[str] = set()
+    for raw in raw_boards:
+        if not isinstance(raw, dict):
+            raise ValueError("each Ashby board must be a mapping")
+        board = _parse_board(raw)
+        if board.id in ids:
+            raise ValueError(f"duplicate Ashby board id: {board.id}")
+        if board.board_name.casefold() in names:
+            raise ValueError(f"duplicate Ashby board name: {board.board_name}")
+        ids.add(board.id)
+        names.add(board.board_name.casefold())
+        boards.append(board)
+    return tuple(boards)
+
+
+def _parse_board(payload: dict[str, Any]) -> AshbyBoard:
+    country = payload.get("country_code")
+    if country is not None and not isinstance(country, str):
+        raise ValueError("country_code must be a string or null")
+    enabled = payload.get("enabled")
+    if not isinstance(enabled, bool):
+        raise ValueError("enabled must be a boolean")
+    return AshbyBoard(
+        id=_required_string(payload, "id"),
+        board_name=_required_string(payload, "board_name"),
+        canonical_name=_required_string(payload, "canonical_name"),
+        country_code=country,
+        enabled=enabled,
+    )
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError("Ashby board registry root must be a mapping")
+    return loaded
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _positive_int(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{key} must be a positive integer")
+    return value

--- a/src/cip/adapters/sources/ashby/schemas.py
+++ b/src/cip/adapters/sources/ashby/schemas.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import urlsplit
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
+
+
+class AshbySecondaryLocation(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    location: str | None = Field(default=None, max_length=500)
+
+
+class AshbyJobPosting(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    title: str = Field(min_length=1, max_length=500)
+    location: str | None = Field(default=None, max_length=500)
+    secondary_locations: list[AshbySecondaryLocation] = Field(
+        default_factory=list,
+        alias="secondaryLocations",
+        max_length=100,
+    )
+    department: str | None = Field(default=None, max_length=500)
+    team: str | None = Field(default=None, max_length=500)
+    is_listed: bool = Field(alias="isListed")
+    is_remote: bool = Field(alias="isRemote")
+    workplace_type: str | None = Field(default=None, alias="workplaceType", max_length=50)
+    description_plain: str = Field(default="", alias="descriptionPlain", max_length=500_000)
+    published_at: datetime = Field(alias="publishedAt")
+    employment_type: str | None = Field(default=None, alias="employmentType", max_length=50)
+    job_url: AnyHttpUrl = Field(alias="jobUrl")
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Ashby job title cannot be empty")
+        return normalized
+
+    @field_validator("published_at")
+    @classmethod
+    def require_aware_published_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("publishedAt must be timezone-aware")
+        return value
+
+    @property
+    def source_job_id(self) -> str:
+        path = urlsplit(str(self.job_url)).path.rstrip("/")
+        identifier = path.rsplit("/", maxsplit=1)[-1]
+        if not identifier:
+            raise ValueError("Ashby jobUrl must contain a job identifier")
+        return identifier
+
+    def display_location(self) -> str:
+        locations: list[str] = []
+        if self.location and self.location.strip():
+            locations.append(self.location.strip())
+        locations.extend(
+            item.location.strip()
+            for item in self.secondary_locations
+            if item.location and item.location.strip()
+        )
+        return "; ".join(dict.fromkeys(locations)) or "Unspecified"
+
+
+class AshbyJobBoardResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    api_version: str = Field(alias="apiVersion", pattern=r"^1$")
+    jobs: list[AshbyJobPosting] = Field(default_factory=list, max_length=10_000)

--- a/src/cip/adapters/sources/canonical_jobs.py
+++ b/src/cip/adapters/sources/canonical_jobs.py
@@ -123,6 +123,34 @@ class CanonicalPublicJob:
         }
 
 
+def canonical_public_job_observation(
+    job: CanonicalPublicJob,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> RawObservation:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    return RawObservation(
+        source_id=job.source_id,
+        adapter_id=job.adapter_id,
+        adapter_version=job.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="public_job_posting",
+        source_record_key=job.source_record_key,
+        source_url=job.source_url,
+        payload_hash_sha256=job.fingerprint(),
+        data_categories=frozenset({DataCategory.PUBLIC_JOB_POSTING}),
+        collected_at=collected,
+        published_at=job.published_at,
+        source_updated_at=job.published_at,
+        schema_fingerprint=job.schema_fingerprint,
+        content_language=job.language,
+        classification="internal",
+        retention_until=retention_until,
+    )
+
+
 def map_canonical_public_job(
     job: CanonicalPublicJob,
     *,
@@ -183,22 +211,10 @@ def map_canonical_public_job(
         expires_at=collected + timedelta(days=_SIGNAL_TTL_DAYS),
         created_at=collected,
     )
-    observation = RawObservation(
-        source_id=job.source_id,
-        adapter_id=job.adapter_id,
-        adapter_version=job.adapter_version,
+    observation = canonical_public_job_observation(
+        job,
         collection_job_id=collection_job_id,
-        source_record_type="public_job_posting",
-        source_record_key=job.source_record_key,
-        source_url=job.source_url,
-        payload_hash_sha256=payload_hash,
-        data_categories=frozenset({DataCategory.PUBLIC_JOB_POSTING}),
         collected_at=collected,
-        published_at=job.published_at,
-        source_updated_at=job.published_at,
-        schema_fingerprint=job.schema_fingerprint,
-        content_language=job.language,
-        classification="internal",
         retention_until=retention_until,
     )
     return observation, CommercialProjection(organization, evidence, signal)

--- a/src/cip/adapters/sources/recruitee/__init__.py
+++ b/src/cip/adapters/sources/recruitee/__init__.py
@@ -1,0 +1,1 @@
+"""Recruitee public Careers Site API adapter."""

--- a/src/cip/adapters/sources/recruitee/client.py
+++ b/src/cip/adapters/sources/recruitee/client.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+class RecruiteeSourceResponseError(RuntimeError):
+    """Recruitee returned an unsafe or unusable careers response."""
+
+
+@dataclass(frozen=True, slots=True)
+class RecruiteeFetchResult:
+    body: bytes
+    request_url: str
+
+
+class RecruiteeClient:
+    MAX_RESPONSE_BYTES = 8_000_000
+
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+
+    def fetch_offers(self, offers_url: str) -> RecruiteeFetchResult:
+        response = self._client.get(
+            offers_url,
+            headers={"Accept": "application/json"},
+        )
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return RecruiteeFetchResult(
+            body=response.content,
+            request_url=str(response.request.url),
+        )
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    if content_type != "application/json":
+        raise RecruiteeSourceResponseError(
+            f"unexpected content type: {content_type or 'missing'}"
+        )
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise RecruiteeSourceResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise RecruiteeSourceResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise RecruiteeSourceResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/recruitee/collector.py
+++ b/src/cip/adapters/sources/recruitee/collector.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.recruitee.client import RecruiteeClient
+from cip.adapters.sources.recruitee.mapper import (
+    map_recruitee_offer,
+    recruitee_offer_to_canonical,
+)
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
+from cip.adapters.sources.recruitee.schemas import RecruiteeOffer, RecruiteeOffersResponse
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class RecruiteeCollectionDeniedError(RuntimeError):
+    """Source governance denied Recruitee careers collection."""
+
+
+class RecruiteeSourceSchemaError(RuntimeError):
+    """Recruitee payload no longer matches the approved public schema."""
+
+
+class RecruiteeSourceWindowError(RuntimeError):
+    """A Recruitee site exceeds the configured safe job count."""
+
+
+@dataclass(frozen=True, slots=True)
+class RecruiteeCheckpoint:
+    fingerprints: Mapping[str, Mapping[str, str]]
+
+    def __post_init__(self) -> None:
+        copied = {
+            site_id: MappingProxyType(dict(values))
+            for site_id, values in self.fingerprints.items()
+        }
+        object.__setattr__(self, "fingerprints", MappingProxyType(copied))
+
+
+@dataclass(frozen=True, slots=True)
+class RecruiteeCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    projections: tuple[CommercialProjection, ...]
+    checkpoint: RecruiteeCheckpoint
+    not_modified: bool
+
+
+def collect_recruitee_jobs(
+    client: RecruiteeClient,
+    entry: SourceRegistryEntry,
+    sites: tuple[RecruiteeCareerSite, ...],
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: RecruiteeCheckpoint | None = None,
+    max_jobs_per_site: int = 5_000,
+) -> RecruiteeCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    enabled_sites = tuple(site for site in sites if site.enabled)
+    if not enabled_sites:
+        raise ValueError("at least one Recruitee site must be enabled")
+    if max_jobs_per_site < 1:
+        raise ValueError("max_jobs_per_site must be positive")
+    previous = checkpoint.fingerprints if checkpoint else {}
+    current: dict[str, dict[str, str]] = {}
+    observations: list[RawObservation] = []
+    projections: list[CommercialProjection] = []
+    for site in enabled_sites:
+        _authorize(entry, site.offers_url, collected_at=collected)
+        offers = _parse_response(client.fetch_offers(site.offers_url).body).offers
+        if len(offers) > max_jobs_per_site:
+            raise RecruiteeSourceWindowError("Recruitee site exceeds configured job limit")
+        current[site.id] = _collect_site(
+            site,
+            tuple(offers),
+            previous=previous.get(site.id, {}),
+            collection_job_id=collection_job_id,
+            collected_at=collected,
+            retention_until=retention_until,
+            observations=observations,
+            projections=projections,
+        )
+    current_checkpoint = RecruiteeCheckpoint(current)
+    return RecruiteeCollectionBatch(
+        observations=tuple(observations),
+        projections=tuple(projections),
+        checkpoint=current_checkpoint,
+        not_modified=_checkpoint_equal(previous, current_checkpoint.fingerprints),
+    )
+
+
+def _collect_site(
+    site: RecruiteeCareerSite,
+    offers: tuple[RecruiteeOffer, ...],
+    *,
+    previous: Mapping[str, str],
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    observations: list[RawObservation],
+    projections: list[CommercialProjection],
+) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for offer in offers:
+        key = offer.source_job_id
+        if key in fingerprints:
+            raise RecruiteeSourceSchemaError(f"duplicate offer id on site {site.id}: {key}")
+        canonical = recruitee_offer_to_canonical(site, offer)
+        fingerprint = canonical.fingerprint()
+        fingerprints[key] = fingerprint
+        mapped = map_recruitee_offer(
+            site,
+            offer,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        if mapped is None:
+            continue
+        observation, projection = mapped
+        projections.append(projection)
+        if previous.get(key) != fingerprint:
+            observations.append(observation)
+    return fingerprints
+
+
+def _authorize(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    *,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_JOB_POSTING,
+            target_url=target_url,
+            purpose="commercial-hiring-intelligence",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise RecruiteeCollectionDeniedError(decision.reason.value)
+
+
+def _parse_response(body: bytes) -> RecruiteeOffersResponse:
+    try:
+        return RecruiteeOffersResponse.model_validate_json(body)
+    except ValidationError as exc:
+        raise RecruiteeSourceSchemaError(
+            "Recruitee response schema validation failed"
+        ) from exc
+
+
+def _checkpoint_equal(
+    previous: Mapping[str, Mapping[str, str]],
+    current: Mapping[str, Mapping[str, str]],
+) -> bool:
+    return {site_id: dict(values) for site_id, values in previous.items()} == {
+        site_id: dict(values) for site_id, values in current.items()
+    }

--- a/src/cip/adapters/sources/recruitee/collector.py
+++ b/src/cip/adapters/sources/recruitee/collector.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from pydantic import ValidationError
 
+from cip.adapters.sources.canonical_jobs import canonical_public_job_observation
 from cip.adapters.sources.recruitee.client import RecruiteeClient
 from cip.adapters.sources.recruitee.mapper import (
     map_recruitee_offer,
@@ -129,10 +130,16 @@ def _collect_site(
             collected_at=collected_at,
             retention_until=retention_until,
         )
-        if mapped is None:
-            continue
-        observation, projection = mapped
-        projections.append(projection)
+        if mapped is not None:
+            observation, projection = mapped
+            projections.append(projection)
+        else:
+            observation = canonical_public_job_observation(
+                canonical,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+            )
         if previous.get(key) != fingerprint:
             observations.append(observation)
     return fingerprints

--- a/src/cip/adapters/sources/recruitee/mapper.py
+++ b/src/cip/adapters/sources/recruitee/mapper.py
@@ -43,7 +43,7 @@ def recruitee_offer_to_canonical(
         published_at=offer.effective_published_at,
         description_text=description,
         location=offer.display_location(),
-        department=offer.department,
+        department=offer.department_name(),
         employment_type=offer.employment_type_code,
         seniority=None,
         language=None,

--- a/src/cip/adapters/sources/recruitee/mapper.py
+++ b/src/cip/adapters/sources/recruitee/mapper.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from cip.adapters.sources.canonical_jobs import CanonicalPublicJob, map_canonical_public_job
+from cip.adapters.sources.job_text import html_to_text
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
+from cip.adapters.sources.recruitee.schemas import RecruiteeOffer
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+
+SOURCE_ID = "recruitee-careers-site"
+ADAPTER_ID = "recruitee-careers-site-api"
+ADAPTER_VERSION = "1.0.0"
+
+
+def recruitee_offer_to_canonical(
+    site: RecruiteeCareerSite,
+    offer: RecruiteeOffer,
+) -> CanonicalPublicJob:
+    description = " ".join(
+        part
+        for part in (
+            html_to_text(offer.description),
+            html_to_text(offer.requirements),
+        )
+        if part
+    )
+    return CanonicalPublicJob(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        provider_label="Recruitee",
+        schema_fingerprint="recruitee-careers-site-offers-v1",
+        site_id=site.subdomain,
+        organization_key=site.id,
+        organization_name=site.canonical_name,
+        country_code=site.country_code,
+        source_job_id=offer.source_job_id,
+        title=offer.title,
+        source_url=site.job_url(offer.slug),
+        published_at=offer.effective_published_at,
+        description_text=description,
+        location=offer.display_location(),
+        department=offer.department,
+        employment_type=offer.employment_type_code,
+        seniority=None,
+        language=None,
+    )
+
+
+def map_recruitee_offer(
+    site: RecruiteeCareerSite,
+    offer: RecruiteeOffer,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> tuple[RawObservation, CommercialProjection] | None:
+    return map_canonical_public_job(
+        recruitee_offer_to_canonical(site, offer),
+        collection_job_id=collection_job_id,
+        collected_at=collected_at,
+        retention_until=retention_until,
+    )

--- a/src/cip/adapters/sources/recruitee/registry.py
+++ b/src/cip/adapters/sources/recruitee/registry.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class RecruiteeCareerSite:
+    id: str
+    subdomain: str
+    canonical_name: str
+    country_code: str | None = None
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        for field_name in ("id", "subdomain", "canonical_name"):
+            value = getattr(self, field_name).strip()
+            if not value:
+                raise ValueError(f"{field_name} is required")
+            object.__setattr__(self, field_name, value)
+        if not self.subdomain.replace("-", "").isalnum():
+            raise ValueError("subdomain contains unsupported characters")
+        if self.country_code is not None:
+            country = self.country_code.strip().upper()
+            if len(country) != 2 or not country.isalpha():
+                raise ValueError("country_code must be an ISO alpha-2 code")
+            object.__setattr__(self, "country_code", country)
+
+    @property
+    def offers_url(self) -> str:
+        return f"https://{self.subdomain}.recruitee.com/api/offers/"
+
+    def job_url(self, slug: str) -> str:
+        normalized = slug.strip().strip("/")
+        if not normalized:
+            raise ValueError("job slug is required")
+        url = f"https://{self.subdomain}.recruitee.com/o/{normalized}"
+        parsed = urlsplit(url)
+        if parsed.scheme != "https" or parsed.hostname is None:
+            raise ValueError("invalid Recruitee job URL")
+        return url
+
+
+def load_recruitee_sites(path: Path) -> tuple[RecruiteeCareerSite, ...]:
+    payload = _load_yaml_mapping(path)
+    if _positive_int(payload, "version") != 1:
+        raise ValueError("unsupported Recruitee site registry version")
+    raw_sites = payload.get("sites")
+    if not isinstance(raw_sites, list):
+        raise ValueError("sites must be a list")
+    sites: list[RecruiteeCareerSite] = []
+    ids: set[str] = set()
+    subdomains: set[str] = set()
+    for raw in raw_sites:
+        if not isinstance(raw, dict):
+            raise ValueError("each Recruitee site must be a mapping")
+        site = _parse_site(raw)
+        if site.id in ids:
+            raise ValueError(f"duplicate Recruitee site id: {site.id}")
+        if site.subdomain.casefold() in subdomains:
+            raise ValueError(f"duplicate Recruitee subdomain: {site.subdomain}")
+        ids.add(site.id)
+        subdomains.add(site.subdomain.casefold())
+        sites.append(site)
+    return tuple(sites)
+
+
+def _parse_site(payload: dict[str, Any]) -> RecruiteeCareerSite:
+    country = payload.get("country_code")
+    if country is not None and not isinstance(country, str):
+        raise ValueError("country_code must be a string or null")
+    enabled = payload.get("enabled")
+    if not isinstance(enabled, bool):
+        raise ValueError("enabled must be a boolean")
+    return RecruiteeCareerSite(
+        id=_required_string(payload, "id"),
+        subdomain=_required_string(payload, "subdomain").lower(),
+        canonical_name=_required_string(payload, "canonical_name"),
+        country_code=country,
+        enabled=enabled,
+    )
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError("Recruitee site registry root must be a mapping")
+    return loaded
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _positive_int(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{key} must be a positive integer")
+    return value

--- a/src/cip/adapters/sources/recruitee/schemas.py
+++ b/src/cip/adapters/sources/recruitee/schemas.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+class RecruiteeOffer(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: int | str
+    slug: str = Field(min_length=1, max_length=500)
+    title: str = Field(min_length=1, max_length=500)
+    status: str | None = Field(default=None, max_length=50)
+    department: str | None = Field(default=None, max_length=500)
+    location: str | None = Field(default=None, max_length=1000)
+    remote: bool | None = None
+    description: str = Field(default="", max_length=500_000)
+    requirements: str = Field(default="", max_length=500_000)
+    created_at: datetime | None = None
+    published_at: datetime | None = None
+    employment_type_code: str | None = Field(default=None, max_length=100)
+
+    @field_validator("slug", "title")
+    @classmethod
+    def normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("required Recruitee text cannot be empty")
+        return normalized
+
+    @field_validator("created_at", "published_at")
+    @classmethod
+    def require_aware_timestamp(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("Recruitee timestamps must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def require_publication_timestamp(self) -> RecruiteeOffer:
+        if self.published_at is None and self.created_at is None:
+            raise ValueError("Recruitee offer requires published_at or created_at")
+        return self
+
+    @property
+    def source_job_id(self) -> str:
+        return str(self.id)
+
+    @property
+    def effective_published_at(self) -> datetime:
+        value = self.published_at or self.created_at
+        if value is None:  # pragma: no cover - guarded by model validator
+            raise ValueError("publication timestamp missing")
+        return value
+
+    def display_location(self) -> str:
+        location = self.location.strip() if self.location else ""
+        if self.remote is True and location:
+            return f"Remote — {location}"
+        if self.remote is True:
+            return "Remote"
+        return location or "Unspecified"
+
+
+class RecruiteeOffersResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    offers: list[RecruiteeOffer] = Field(default_factory=list, max_length=10_000)

--- a/src/cip/adapters/sources/recruitee/schemas.py
+++ b/src/cip/adapters/sources/recruitee/schemas.py
@@ -53,6 +53,13 @@ class RecruiteeOffer(BaseModel):
             raise ValueError("required Recruitee text cannot be empty")
         return normalized
 
+    @field_validator("created_at", "published_at", mode="before")
+    @classmethod
+    def normalize_provider_timestamp(cls, value: object) -> object:
+        if isinstance(value, str) and value.endswith(" UTC"):
+            return value.removesuffix(" UTC") + "+00:00"
+        return value
+
     @field_validator("created_at", "published_at")
     @classmethod
     def require_aware_timestamp(cls, value: datetime | None) -> datetime | None:

--- a/src/cip/adapters/sources/recruitee/schemas.py
+++ b/src/cip/adapters/sources/recruitee/schemas.py
@@ -5,6 +5,29 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
+class RecruiteeDepartment(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: int | str | None = None
+    name: str = Field(min_length=1, max_length=500)
+
+
+class RecruiteeLocation(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: int | str | None = None
+    city: str | None = Field(default=None, max_length=300)
+    country_code: str | None = Field(default=None, max_length=3)
+    full_address: str | None = Field(default=None, max_length=1000)
+
+    def display_name(self) -> str | None:
+        if self.full_address and self.full_address.strip():
+            return self.full_address.strip()
+        if self.city and self.city.strip():
+            return self.city.strip()
+        return None
+
+
 class RecruiteeOffer(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -12,7 +35,8 @@ class RecruiteeOffer(BaseModel):
     slug: str = Field(min_length=1, max_length=500)
     title: str = Field(min_length=1, max_length=500)
     status: str | None = Field(default=None, max_length=50)
-    department: str | None = Field(default=None, max_length=500)
+    department: RecruiteeDepartment | str | None = None
+    locations: list[RecruiteeLocation] = Field(default_factory=list, max_length=100)
     location: str | None = Field(default=None, max_length=1000)
     remote: bool | None = None
     description: str = Field(default="", max_length=500_000)
@@ -53,13 +77,27 @@ class RecruiteeOffer(BaseModel):
             raise ValueError("publication timestamp missing")
         return value
 
+    def department_name(self) -> str | None:
+        if isinstance(self.department, RecruiteeDepartment):
+            return self.department.name
+        if isinstance(self.department, str) and self.department.strip():
+            return self.department.strip()
+        return None
+
     def display_location(self) -> str:
-        location = self.location.strip() if self.location else ""
-        if self.remote is True and location:
-            return f"Remote — {location}"
+        structured = tuple(
+            value
+            for location in self.locations
+            if (value := location.display_name()) is not None
+        )
+        fallback = self.location.strip() if self.location else ""
+        locations = list(dict.fromkeys(structured or ((fallback,) if fallback else ())))
+        rendered = "; ".join(locations)
+        if self.remote is True and rendered:
+            return f"Remote — {rendered}"
         if self.remote is True:
             return "Remote"
-        return location or "Unspecified"
+        return rendered or "Unspecified"
 
 
 class RecruiteeOffersResponse(BaseModel):

--- a/src/cip/adapters/sources/teamtailor/__init__.py
+++ b/src/cip/adapters/sources/teamtailor/__init__.py
@@ -1,0 +1,1 @@
+"""Teamtailor Public Read jobs API adapter."""

--- a/src/cip/adapters/sources/teamtailor/client.py
+++ b/src/cip/adapters/sources/teamtailor/client.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+class TeamtailorSourceResponseError(RuntimeError):
+    """Teamtailor returned an unsafe or unusable public-jobs response."""
+
+
+@dataclass(frozen=True, slots=True)
+class TeamtailorFetchResult:
+    body: bytes
+    request_url: str
+
+
+class TeamtailorClient:
+    MAX_RESPONSE_BYTES = 8_000_000
+
+    def __init__(self, client: httpx.Client) -> None:
+        self._client = client
+
+    def fetch_jobs_page(
+        self,
+        url: str,
+        *,
+        api_token: str,
+        api_version: str,
+        page_size: int = 30,
+    ) -> TeamtailorFetchResult:
+        if not api_token.strip():
+            raise ValueError("api_token is required")
+        if not 1 <= page_size <= 30:
+            raise ValueError("page_size must be between 1 and 30")
+        response = self._client.get(
+            url,
+            headers={
+                "Accept": "application/vnd.api+json, application/json",
+                "Authorization": f"Token token={api_token}",
+                "X-Api-Version": api_version,
+            },
+            params={"include": "department,locations", "page[size]": page_size}
+            if "?" not in url
+            else None,
+        )
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return TeamtailorFetchResult(
+            body=response.content,
+            request_url=str(response.request.url),
+        )
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    if content_type not in {"application/vnd.api+json", "application/json"}:
+        raise TeamtailorSourceResponseError(
+            f"unexpected content type: {content_type or 'missing'}"
+        )
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise TeamtailorSourceResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise TeamtailorSourceResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise TeamtailorSourceResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/teamtailor/collector.py
+++ b/src/cip/adapters/sources/teamtailor/collector.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from urllib.parse import urlsplit
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.teamtailor.client import TeamtailorClient
+from cip.adapters.sources.teamtailor.mapper import map_teamtailor_job, teamtailor_job_to_canonical
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.adapters.sources.teamtailor.schemas import TeamtailorJobResource, TeamtailorJobsResponse
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import CollectionRequest, DataCategory, SourceRuntimeState
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class TeamtailorCollectionDeniedError(RuntimeError):
+    pass
+
+
+class TeamtailorSourceSchemaError(RuntimeError):
+    pass
+
+
+class TeamtailorSourceWindowError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class TeamtailorCheckpoint:
+    fingerprints: Mapping[str, Mapping[str, str]]
+
+    def __post_init__(self) -> None:
+        copied = {
+            account_id: MappingProxyType(dict(values))
+            for account_id, values in self.fingerprints.items()
+        }
+        object.__setattr__(self, "fingerprints", MappingProxyType(copied))
+
+
+@dataclass(frozen=True, slots=True)
+class TeamtailorCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    projections: tuple[CommercialProjection, ...]
+    checkpoint: TeamtailorCheckpoint
+    not_modified: bool
+
+
+def collect_teamtailor_jobs(
+    client: TeamtailorClient,
+    entry: SourceRegistryEntry,
+    account: TeamtailorAccount,
+    *,
+    api_token: str,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: TeamtailorCheckpoint | None = None,
+    max_jobs: int = 5_000,
+) -> TeamtailorCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    if not account.enabled:
+        raise ValueError("Teamtailor account must be enabled")
+    if max_jobs < 1:
+        raise ValueError("max_jobs must be positive")
+    previous = checkpoint.fingerprints if checkpoint else {}
+    jobs = _fetch_public_jobs(
+        client,
+        entry,
+        account,
+        api_token=api_token,
+        collected_at=collected,
+        max_jobs=max_jobs,
+    )
+    observations: list[RawObservation] = []
+    projections: list[CommercialProjection] = []
+    fingerprints = _map_jobs(
+        account,
+        jobs,
+        previous=previous.get(account.id, {}),
+        collection_job_id=collection_job_id,
+        collected_at=collected,
+        retention_until=retention_until,
+        observations=observations,
+        projections=projections,
+    )
+    current = TeamtailorCheckpoint({account.id: fingerprints})
+    return TeamtailorCollectionBatch(
+        observations=tuple(observations),
+        projections=tuple(projections),
+        checkpoint=current,
+        not_modified=_checkpoint_equal(previous, current.fingerprints),
+    )
+
+
+def _fetch_public_jobs(
+    client: TeamtailorClient,
+    entry: SourceRegistryEntry,
+    account: TeamtailorAccount,
+    *,
+    api_token: str,
+    collected_at: datetime,
+    max_jobs: int,
+) -> tuple[TeamtailorJobResource, ...]:
+    jobs: list[TeamtailorJobResource] = []
+    next_url: str | None = account.jobs_url
+    visited: set[str] = set()
+    while next_url is not None:
+        if next_url in visited:
+            raise TeamtailorSourceSchemaError("pagination loop detected")
+        visited.add(next_url)
+        _validate_jobs_url(account, next_url)
+        _authorize(entry, next_url, collected_at=collected_at)
+        page = _parse_response(
+            client.fetch_jobs_page(
+                next_url,
+                api_token=api_token,
+                api_version=account.api_version,
+            ).body
+        )
+        jobs.extend(page.data)
+        if len(jobs) > max_jobs:
+            raise TeamtailorSourceWindowError("Teamtailor job limit exceeded")
+        next_url = str(page.links.next) if page.links.next is not None else None
+    return tuple(jobs)
+
+
+def _map_jobs(
+    account: TeamtailorAccount,
+    jobs: tuple[TeamtailorJobResource, ...],
+    *,
+    previous: Mapping[str, str],
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    observations: list[RawObservation],
+    projections: list[CommercialProjection],
+) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for job in jobs:
+        if job.id in fingerprints:
+            raise TeamtailorSourceSchemaError(f"duplicate job id: {job.id}")
+        canonical = teamtailor_job_to_canonical(account, job)
+        fingerprint = canonical.fingerprint()
+        fingerprints[job.id] = fingerprint
+        mapped = map_teamtailor_job(
+            account,
+            job,
+            collection_job_id=collection_job_id,
+            collected_at=collected_at,
+            retention_until=retention_until,
+        )
+        if mapped is not None:
+            observation, projection = mapped
+            projections.append(projection)
+            if previous.get(job.id) != fingerprint:
+                observations.append(observation)
+    return fingerprints
+
+
+def _validate_jobs_url(account: TeamtailorAccount, url: str) -> None:
+    parsed = urlsplit(url)
+    expected = urlsplit(account.base_url)
+    if parsed.scheme != "https" or parsed.hostname != expected.hostname:
+        raise TeamtailorSourceSchemaError("pagination URL outside provider host")
+    if not parsed.path.startswith("/v1/jobs"):
+        raise TeamtailorSourceSchemaError("pagination URL outside jobs endpoint")
+
+
+def _authorize(entry: SourceRegistryEntry, url: str, *, collected_at: datetime) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_JOB_POSTING,
+            target_url=url,
+            purpose="commercial-hiring-intelligence",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise TeamtailorCollectionDeniedError(decision.reason.value)
+
+
+def _parse_response(body: bytes) -> TeamtailorJobsResponse:
+    try:
+        return TeamtailorJobsResponse.model_validate_json(body)
+    except ValidationError as exc:
+        raise TeamtailorSourceSchemaError("Teamtailor schema validation failed") from exc
+
+
+def _checkpoint_equal(
+    previous: Mapping[str, Mapping[str, str]],
+    current: Mapping[str, Mapping[str, str]],
+) -> bool:
+    return {key: dict(value) for key, value in previous.items()} == {
+        key: dict(value) for key, value in current.items()
+    }

--- a/src/cip/adapters/sources/teamtailor/collector.py
+++ b/src/cip/adapters/sources/teamtailor/collector.py
@@ -10,12 +10,22 @@ from uuid import UUID
 from pydantic import ValidationError
 
 from cip.adapters.sources.teamtailor.client import TeamtailorClient
-from cip.adapters.sources.teamtailor.mapper import map_teamtailor_job, teamtailor_job_to_canonical
+from cip.adapters.sources.teamtailor.mapper import (
+    map_teamtailor_job,
+    teamtailor_job_to_canonical,
+)
 from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
-from cip.adapters.sources.teamtailor.schemas import TeamtailorJobResource, TeamtailorJobsResponse
+from cip.adapters.sources.teamtailor.schemas import (
+    TeamtailorJobResource,
+    TeamtailorJobsResponse,
+)
 from cip.modules.collection_orchestration.application.ports import CommercialProjection
 from cip.modules.raw_observations.domain.entities import RawObservation
-from cip.modules.source_governance.domain.models import CollectionRequest, DataCategory, SourceRuntimeState
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 from cip.shared.kernel.time import require_aware_utc
 

--- a/src/cip/adapters/sources/teamtailor/collector.py
+++ b/src/cip/adapters/sources/teamtailor/collector.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from pydantic import ValidationError
 
+from cip.adapters.sources.canonical_jobs import canonical_public_job_observation
 from cip.adapters.sources.teamtailor.client import TeamtailorClient
 from cip.adapters.sources.teamtailor.mapper import (
     map_teamtailor_job,
@@ -169,8 +170,15 @@ def _map_jobs(
         if mapped is not None:
             observation, projection = mapped
             projections.append(projection)
-            if previous.get(job.id) != fingerprint:
-                observations.append(observation)
+        else:
+            observation = canonical_public_job_observation(
+                canonical,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+            )
+        if previous.get(job.id) != fingerprint:
+            observations.append(observation)
     return fingerprints
 
 

--- a/src/cip/adapters/sources/teamtailor/mapper.py
+++ b/src/cip/adapters/sources/teamtailor/mapper.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from cip.adapters.sources.canonical_jobs import CanonicalPublicJob, map_canonical_public_job
+from cip.adapters.sources.job_text import html_to_text
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.adapters.sources.teamtailor.schemas import TeamtailorJobResource
+from cip.modules.collection_orchestration.application.ports import CommercialProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+
+SOURCE_ID = "teamtailor-public-jobs"
+ADAPTER_ID = "teamtailor-public-read-jobs-api"
+ADAPTER_VERSION = "1.0.0"
+
+
+def teamtailor_job_to_canonical(
+    account: TeamtailorAccount,
+    job: TeamtailorJobResource,
+) -> CanonicalPublicJob:
+    description = " ".join(
+        part
+        for part in (
+            html_to_text(job.attributes.pitch),
+            html_to_text(job.attributes.body),
+        )
+        if part
+    )
+    source_url = (
+        str(job.links.self_url)
+        if job.links.self_url is not None
+        else f"{account.jobs_url}/{job.id}"
+    )
+    remote = (job.attributes.remote_status or "").strip()
+    location = remote if remote else "Unspecified"
+    return CanonicalPublicJob(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        provider_label="Teamtailor",
+        schema_fingerprint="teamtailor-jsonapi-public-jobs-v1",
+        site_id=account.id,
+        organization_key=account.id,
+        organization_name=account.canonical_name,
+        country_code=account.country_code,
+        source_job_id=job.id,
+        title=job.attributes.title,
+        source_url=source_url,
+        published_at=job.attributes.created_at,
+        description_text=description,
+        location=location,
+        department=None,
+        employment_type=job.attributes.employment_type,
+        seniority=None,
+        language=None,
+    )
+
+
+def map_teamtailor_job(
+    account: TeamtailorAccount,
+    job: TeamtailorJobResource,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> tuple[RawObservation, CommercialProjection] | None:
+    return map_canonical_public_job(
+        teamtailor_job_to_canonical(account, job),
+        collection_job_id=collection_job_id,
+        collected_at=collected_at,
+        retention_until=retention_until,
+    )

--- a/src/cip/adapters/sources/teamtailor/registry.py
+++ b/src/cip/adapters/sources/teamtailor/registry.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+_API_VERSION_PATTERN = re.compile(r"^20\d{6}$")
+
+
+@dataclass(frozen=True, slots=True)
+class TeamtailorAccount:
+    id: str
+    canonical_name: str
+    region: Literal["eu", "na", "au"] = "eu"
+    api_version: str = "20240404"
+    country_code: str | None = None
+    enabled: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name in ("id", "canonical_name", "api_version"):
+            value = getattr(self, field_name).strip()
+            if not value:
+                raise ValueError(f"{field_name} is required")
+            object.__setattr__(self, field_name, value)
+        if not _API_VERSION_PATTERN.fullmatch(self.api_version):
+            raise ValueError("api_version must be an 8-digit Teamtailor date version")
+        if self.country_code is not None:
+            country = self.country_code.strip().upper()
+            if len(country) != 2 or not country.isalpha():
+                raise ValueError("country_code must be an ISO alpha-2 code")
+            object.__setattr__(self, "country_code", country)
+
+    @property
+    def base_url(self) -> str:
+        hosts = {
+            "eu": "api.teamtailor.com",
+            "na": "api.na.teamtailor.com",
+            "au": "api.au.teamtailor.com",
+        }
+        return f"https://{hosts[self.region]}"
+
+    @property
+    def jobs_url(self) -> str:
+        return f"{self.base_url}/v1/jobs"
+
+
+def load_teamtailor_accounts(path: Path) -> tuple[TeamtailorAccount, ...]:
+    payload = _load_yaml_mapping(path)
+    if _positive_int(payload, "version") != 1:
+        raise ValueError("unsupported Teamtailor account registry version")
+    raw_accounts = payload.get("accounts")
+    if not isinstance(raw_accounts, list):
+        raise ValueError("accounts must be a list")
+    accounts: list[TeamtailorAccount] = []
+    ids: set[str] = set()
+    for raw in raw_accounts:
+        if not isinstance(raw, dict):
+            raise ValueError("each Teamtailor account must be a mapping")
+        account = _parse_account(raw)
+        if account.id in ids:
+            raise ValueError(f"duplicate Teamtailor account id: {account.id}")
+        ids.add(account.id)
+        accounts.append(account)
+    if sum(account.enabled for account in accounts) > 1:
+        raise ValueError("only one Teamtailor account may use the configured API token")
+    return tuple(accounts)
+
+
+def _parse_account(payload: dict[str, Any]) -> TeamtailorAccount:
+    country = payload.get("country_code")
+    if country is not None and not isinstance(country, str):
+        raise ValueError("country_code must be a string or null")
+    enabled = payload.get("enabled")
+    if not isinstance(enabled, bool):
+        raise ValueError("enabled must be a boolean")
+    region = _required_string(payload, "region")
+    if region not in {"eu", "na", "au"}:
+        raise ValueError("region must be one of eu, na, au")
+    return TeamtailorAccount(
+        id=_required_string(payload, "id"),
+        canonical_name=_required_string(payload, "canonical_name"),
+        region=region,  # type: ignore[arg-type]
+        api_version=_required_string(payload, "api_version"),
+        country_code=country,
+        enabled=enabled,
+    )
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError("Teamtailor account registry root must be a mapping")
+    return loaded
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _positive_int(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{key} must be a positive integer")
+    return value

--- a/src/cip/adapters/sources/teamtailor/schemas.py
+++ b/src/cip/adapters/sources/teamtailor/schemas.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_validator
+
+
+class TeamtailorJobAttributes(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    title: str = Field(min_length=1, max_length=500)
+    body: str = Field(default="", max_length=500_000)
+    pitch: str = Field(default="", max_length=100_000)
+    remote_status: str | None = Field(default=None, alias="remote-status", max_length=100)
+    employment_type: str | None = Field(
+        default=None,
+        alias="employment-type",
+        max_length=100,
+    )
+    created_at: datetime = Field(alias="created-at")
+
+    @field_validator("title")
+    @classmethod
+    def normalize_title(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Teamtailor job title cannot be empty")
+        return normalized
+
+    @field_validator("created_at")
+    @classmethod
+    def require_aware_created_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("created-at must be timezone-aware")
+        return value
+
+
+class TeamtailorResourceLinks(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    self_url: AnyHttpUrl | None = Field(default=None, alias="self")
+
+
+class TeamtailorJobResource(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1, max_length=200)
+    type: str = Field(pattern=r"^jobs$")
+    attributes: TeamtailorJobAttributes
+    links: TeamtailorResourceLinks = Field(default_factory=TeamtailorResourceLinks)
+
+
+class TeamtailorPaginationLinks(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    next: AnyHttpUrl | None = None
+
+
+class TeamtailorJobsResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    data: list[TeamtailorJobResource] = Field(default_factory=list, max_length=10_000)
+    links: TeamtailorPaginationLinks = Field(default_factory=TeamtailorPaginationLinks)

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -3,33 +3,29 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from cip.adapters.sources.developer_ecosystem.registry import (
-    DeveloperEcosystemTarget,
-)
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
 from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
 from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
 from cip.adapters.sources.lever.registry import LeverSite
-from cip.adapters.sources.organization_identity.registry import (
-    OrganizationIdentityTarget,
-)
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
 from cip.adapters.sources.passive_infrastructure.rdap_registry import RdapTarget
-from cip.adapters.sources.passive_infrastructure.registry import (
-    PassiveInfrastructureTarget,
-)
+from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
 from cip.adapters.sources.smartrecruiters.registry import SmartRecruitersCompany
-from cip.adapters.sources.vulnerability_catalogs.registry import (
-    VulnerabilityQueryTarget,
-)
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.adapters.sources.vulnerability_catalogs.registry import VulnerabilityQueryTarget
 from cip.modules.collection_orchestration.application.adapters import CisaKevAdapter
+from cip.modules.collection_orchestration.application.ats_registration import (
+    register_extended_ats_adapters,
+)
 from cip.modules.collection_orchestration.application.boamp_adapter import BoampAdapter
 from cip.modules.collection_orchestration.application.decp_adapter import DecpAdapter
 from cip.modules.collection_orchestration.application.developer_ecosystem_registration import (
     register_developer_ecosystem_adapters,
 )
-from cip.modules.collection_orchestration.application.greenhouse_adapter import (
-    GreenhouseAdapter,
-)
+from cip.modules.collection_orchestration.application.greenhouse_adapter import GreenhouseAdapter
 from cip.modules.collection_orchestration.application.identity_adapters import (
     register_identity_adapters,
 )
@@ -41,9 +37,7 @@ from cip.modules.collection_orchestration.application.passive_infrastructure_reg
     register_passive_infrastructure_adapters,
 )
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
-from cip.modules.collection_orchestration.application.public_web_adapter import (
-    PublicWebAdapter,
-)
+from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
 from cip.modules.collection_orchestration.application.reference_adapter import (
     ReferencePortfolioAdapter,
 )
@@ -67,6 +61,9 @@ class AdapterCompositionInputs:
     greenhouse_boards: tuple[GreenhouseBoard, ...]
     lever_sites: tuple[LeverSite, ...]
     smartrecruiters_companies: tuple[SmartRecruitersCompany, ...]
+    ashby_boards: tuple[AshbyBoard, ...]
+    recruitee_sites: tuple[RecruiteeCareerSite, ...]
+    teamtailor_accounts: tuple[TeamtailorAccount, ...]
     identity_targets: tuple[OrganizationIdentityTarget, ...]
     public_web_targets: tuple[PublicWebTarget, ...]
     developer_ecosystem_targets: tuple[DeveloperEcosystemTarget, ...]
@@ -83,6 +80,7 @@ def build_runtime_adapters(
     brave_token_provider: Callable[[], str | None],
     certspotter_token_provider: Callable[[], str | None],
     phishtank_token_provider: Callable[[], str | None],
+    teamtailor_token_provider: Callable[[], str | None],
     sec_user_agent: str | None,
     phishtank_user_agent: str | None,
     timeout_seconds: float,
@@ -91,6 +89,15 @@ def build_runtime_adapters(
     adapters: dict[tuple[str, str], CollectionAdapter] = {}
     _register(adapters, ReferencePortfolioAdapter())
     _register_core_adapters(adapters, entries_by_id, inputs, timeout_seconds)
+    register_extended_ats_adapters(
+        adapters,
+        entries_by_id,
+        inputs.ashby_boards,
+        inputs.recruitee_sites,
+        inputs.teamtailor_accounts,
+        teamtailor_token_provider=teamtailor_token_provider,
+        timeout_seconds=timeout_seconds,
+    )
     register_identity_adapters(
         adapters,
         entries_by_id,
@@ -166,9 +173,7 @@ def _register_core_adapters(
             ),
         )
     lever_entry = entries_by_id.get(LeverAdapter.source_id)
-    if lever_entry is not None and any(
-        site.enabled for site in inputs.lever_sites
-    ):
+    if lever_entry is not None and any(site.enabled for site in inputs.lever_sites):
         _register(
             adapters,
             LeverAdapter(
@@ -202,10 +207,7 @@ def _register_if_present(
 ) -> None:
     entry = entries_by_id.get(adapter_type.source_id)
     if entry is not None:
-        _register(
-            adapters,
-            adapter_type(entry, timeout_seconds=timeout_seconds),
-        )
+        _register(adapters, adapter_type(entry, timeout_seconds=timeout_seconds))
 
 
 def _register_public_web_adapters(
@@ -225,11 +227,7 @@ def _register_public_web_adapters(
             )
         _register(
             adapters,
-            PublicWebAdapter(
-                entry,
-                target,
-                timeout_seconds=timeout_seconds,
-            ),
+            PublicWebAdapter(entry, target, timeout_seconds=timeout_seconds),
         )
 
 

--- a/src/cip/modules/collection_orchestration/application/ashby_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/ashby_adapter.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.ashby.client import AshbyClient, AshbySourceResponseError
+from cip.adapters.sources.ashby.collector import (
+    AshbyCheckpoint,
+    AshbyCollectionDeniedError,
+    AshbySourceSchemaError,
+    AshbySourceWindowError,
+    collect_ashby_jobs,
+)
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class AshbyAdapter:
+    source_id = "ashby-job-board"
+    adapter_id = "ashby-public-job-postings-api"
+    data_category = DataCategory.PUBLIC_JOB_POSTING
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        boards: tuple[AshbyBoard, ...],
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Ashby adapter requires its source policy")
+        if not any(board.enabled for board in boards):
+            raise ValueError("Ashby adapter requires an enabled board")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._boards = boards
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_ashby_jobs(
+                    AshbyClient(
+                        http_client,
+                        postings_base_url=self._entry.policy.base_url,
+                    ),
+                    self._entry,
+                    self._boards,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except AshbyCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except AshbySourceSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except AshbySourceWindowError as exc:
+            raise _execution_error(exc, "source_window_exceeded", retryable=False) from exc
+        except AshbySourceResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"Ashby returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={
+                "fingerprints": {
+                    board_id: dict(values)
+                    for board_id, values in batch.checkpoint.fingerprints.items()
+                }
+            },
+            not_modified=batch.not_modified,
+            commercial_projections=batch.projections,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> AshbyCheckpoint | None:
+    if payload is None:
+        return None
+    raw_fingerprints = payload.get("fingerprints")
+    if not isinstance(raw_fingerprints, dict):
+        raise _invalid_checkpoint()
+    fingerprints: dict[str, dict[str, str]] = {}
+    for board_id, raw_jobs in raw_fingerprints.items():
+        if not isinstance(board_id, str) or not isinstance(raw_jobs, dict):
+            raise _invalid_checkpoint()
+        jobs: dict[str, str] = {}
+        for job_id, fingerprint in raw_jobs.items():
+            if not isinstance(job_id, str) or not isinstance(fingerprint, str):
+                raise _invalid_checkpoint()
+            jobs[job_id] = fingerprint
+        fingerprints[board_id] = jobs
+    return AshbyCheckpoint(fingerprints)
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "checkpoint fingerprints must contain string board, job, and hash values",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/collection_orchestration/application/ats_registration.py
+++ b/src/cip/modules/collection_orchestration/application/ats_registration.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.modules.collection_orchestration.application.ashby_adapter import AshbyAdapter
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.collection_orchestration.application.recruitee_adapter import RecruiteeAdapter
+from cip.modules.collection_orchestration.application.teamtailor_adapter import TeamtailorAdapter
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+def register_extended_ats_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    ashby_boards: tuple[AshbyBoard, ...],
+    recruitee_sites: tuple[RecruiteeCareerSite, ...],
+    teamtailor_accounts: tuple[TeamtailorAccount, ...],
+    *,
+    teamtailor_token_provider: Callable[[], str | None],
+    timeout_seconds: float,
+) -> None:
+    ashby_entry = entries_by_id.get(AshbyAdapter.source_id)
+    if ashby_entry is not None and any(board.enabled for board in ashby_boards):
+        _register(
+            adapters,
+            AshbyAdapter(
+                ashby_entry,
+                ashby_boards,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+    recruitee_entry = entries_by_id.get(RecruiteeAdapter.source_id)
+    if recruitee_entry is not None and any(site.enabled for site in recruitee_sites):
+        _register(
+            adapters,
+            RecruiteeAdapter(
+                recruitee_entry,
+                recruitee_sites,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+    enabled_accounts = tuple(account for account in teamtailor_accounts if account.enabled)
+    teamtailor_entry = entries_by_id.get(TeamtailorAdapter.source_id)
+    if teamtailor_entry is not None and enabled_accounts:
+        if len(enabled_accounts) != 1:
+            raise ValueError("Teamtailor requires exactly one enabled account")
+        _register(
+            adapters,
+            TeamtailorAdapter(
+                teamtailor_entry,
+                enabled_accounts[0],
+                teamtailor_token_provider,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+
+def _register(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    adapter: CollectionAdapter,
+) -> None:
+    identity = (adapter.source_id, adapter.adapter_id)
+    if identity in adapters:
+        raise ValueError(f"duplicate runtime adapter: {identity[0]}/{identity[1]}")
+    adapters[identity] = adapter

--- a/src/cip/modules/collection_orchestration/application/recruitee_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/recruitee_adapter.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.recruitee.client import (
+    RecruiteeClient,
+    RecruiteeSourceResponseError,
+)
+from cip.adapters.sources.recruitee.collector import (
+    RecruiteeCheckpoint,
+    RecruiteeCollectionDeniedError,
+    RecruiteeSourceSchemaError,
+    RecruiteeSourceWindowError,
+    collect_recruitee_jobs,
+)
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class RecruiteeAdapter:
+    source_id = "recruitee-careers-site"
+    adapter_id = "recruitee-careers-site-api"
+    data_category = DataCategory.PUBLIC_JOB_POSTING
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        sites: tuple[RecruiteeCareerSite, ...],
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Recruitee adapter requires its source policy")
+        if not any(site.enabled for site in sites):
+            raise ValueError("Recruitee adapter requires an enabled site")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._sites = sites
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_recruitee_jobs(
+                    RecruiteeClient(http_client),
+                    self._entry,
+                    self._sites,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except RecruiteeCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except RecruiteeSourceSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except RecruiteeSourceWindowError as exc:
+            raise _execution_error(exc, "source_window_exceeded", retryable=False) from exc
+        except RecruiteeSourceResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"Recruitee returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={
+                "fingerprints": {
+                    site_id: dict(values)
+                    for site_id, values in batch.checkpoint.fingerprints.items()
+                }
+            },
+            not_modified=batch.not_modified,
+            commercial_projections=batch.projections,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> RecruiteeCheckpoint | None:
+    if payload is None:
+        return None
+    raw_fingerprints = payload.get("fingerprints")
+    if not isinstance(raw_fingerprints, dict):
+        raise _invalid_checkpoint()
+    fingerprints: dict[str, dict[str, str]] = {}
+    for site_id, raw_jobs in raw_fingerprints.items():
+        if not isinstance(site_id, str) or not isinstance(raw_jobs, dict):
+            raise _invalid_checkpoint()
+        jobs: dict[str, str] = {}
+        for job_id, fingerprint in raw_jobs.items():
+            if not isinstance(job_id, str) or not isinstance(fingerprint, str):
+                raise _invalid_checkpoint()
+            jobs[job_id] = fingerprint
+        fingerprints[site_id] = jobs
+    return RecruiteeCheckpoint(fingerprints)
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "checkpoint fingerprints must contain string site, job, and hash values",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -10,24 +10,19 @@ from time import sleep
 
 from sqlalchemy.orm import Session, sessionmaker
 
-from cip.adapters.sources.developer_ecosystem.registry import (
-    load_developer_ecosystem_targets,
-)
+from cip.adapters.sources.ashby.registry import load_ashby_boards
+from cip.adapters.sources.developer_ecosystem.registry import load_developer_ecosystem_targets
 from cip.adapters.sources.greenhouse.registry import load_greenhouse_boards
 from cip.adapters.sources.incident_catalogs.sec_registry import load_sec_incident_targets
 from cip.adapters.sources.lever.registry import load_lever_sites
-from cip.adapters.sources.organization_identity.registry import (
-    load_organization_identity_targets,
-)
+from cip.adapters.sources.organization_identity.registry import load_organization_identity_targets
 from cip.adapters.sources.passive_infrastructure.rdap_registry import load_rdap_targets
-from cip.adapters.sources.passive_infrastructure.registry import (
-    load_passive_infrastructure_targets,
-)
+from cip.adapters.sources.passive_infrastructure.registry import load_passive_infrastructure_targets
 from cip.adapters.sources.public_web.registry import load_public_web_targets
+from cip.adapters.sources.recruitee.registry import load_recruitee_sites
 from cip.adapters.sources.smartrecruiters.registry import load_smartrecruiters_companies
-from cip.adapters.sources.vulnerability_catalogs.registry import (
-    load_vulnerability_query_targets,
-)
+from cip.adapters.sources.teamtailor.registry import load_teamtailor_accounts
+from cip.adapters.sources.vulnerability_catalogs.registry import load_vulnerability_query_targets
 from cip.modules.collection_orchestration.application.adapter_composition import (
     AdapterCompositionInputs,
     build_runtime_adapters,
@@ -50,14 +45,10 @@ from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.data_governance.infrastructure.retention_loader import load_retention_policy
 from cip.modules.provider_onboarding.application.service import sync_provider_profiles
 from cip.modules.provider_onboarding.infrastructure.registry import load_provider_profiles
-from cip.modules.public_footprint.infrastructure.search_registry import (
-    load_search_query_templates,
-)
+from cip.modules.public_footprint.infrastructure.search_registry import load_search_query_templates
 from cip.modules.source_governance.infrastructure.persistence import sync_source_registry
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
-from cip.modules.source_governance.infrastructure.registry_bundle import (
-    load_source_registry_bundle,
-)
+from cip.modules.source_governance.infrastructure.registry_bundle import load_source_registry_bundle
 from cip.modules.source_portfolio.application.backfill_worker import (
     BackfillWorkerOutcome,
     BackfillWorkerStatus,
@@ -69,9 +60,7 @@ from cip.modules.source_portfolio.application.service import (
     sync_source_portfolio,
 )
 from cip.modules.source_portfolio.domain.models import CatalogStatus, SourceCatalogEntry
-from cip.modules.source_portfolio.infrastructure.registry_bundle import (
-    load_source_portfolio_bundle,
-)
+from cip.modules.source_portfolio.infrastructure.registry_bundle import load_source_portfolio_bundle
 from cip.shared.config.settings import Settings
 from cip.shared.kernel.time import utc_now
 from cip.shared.persistence.session import (
@@ -121,6 +110,11 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
             source_id="phishtank-verified-online",
             secret_name="api_token",
         ),
+        teamtailor_token_provider=connected_secret_supplier(
+            factory,
+            source_id="teamtailor-public-jobs",
+            secret_name="api_token",
+        ),
         sec_user_agent=settings.sec_edgar_user_agent,
         phishtank_user_agent=settings.phishtank_user_agent,
         timeout_seconds=settings.source_http_timeout_seconds,
@@ -155,6 +149,7 @@ def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
         settings.corporate_change_source_registry_path,
         settings.relationship_source_registry_path,
         settings.conditional_integration_source_registry_path,
+        settings.ats_source_registry_path,
     )
 
 
@@ -173,6 +168,7 @@ def _load_portfolio(settings: Settings) -> tuple[SourceCatalogEntry, ...]:
         settings.corporate_change_source_portfolio_path,
         settings.relationship_source_portfolio_path,
         settings.conditional_integration_source_portfolio_path,
+        settings.ats_source_portfolio_path,
     )
 
 
@@ -182,19 +178,20 @@ def _load_adapter_inputs(
 ) -> AdapterCompositionInputs:
     return AdapterCompositionInputs(
         entries=entries,
-        greenhouse_boards=load_greenhouse_boards(
-            settings.greenhouse_board_registry_path
-        ),
+        greenhouse_boards=load_greenhouse_boards(settings.greenhouse_board_registry_path),
         lever_sites=load_lever_sites(settings.lever_site_registry_path),
         smartrecruiters_companies=load_smartrecruiters_companies(
             settings.smartrecruiters_company_registry_path
         ),
+        ashby_boards=load_ashby_boards(settings.ashby_board_registry_path),
+        recruitee_sites=load_recruitee_sites(settings.recruitee_site_registry_path),
+        teamtailor_accounts=load_teamtailor_accounts(
+            settings.teamtailor_account_registry_path
+        ),
         identity_targets=load_organization_identity_targets(
             settings.organization_identity_target_registry_path
         ),
-        public_web_targets=load_public_web_targets(
-            settings.public_web_target_registry_path
-        ),
+        public_web_targets=load_public_web_targets(settings.public_web_target_registry_path),
         developer_ecosystem_targets=load_developer_ecosystem_targets(
             settings.developer_ecosystem_target_registry_path
         ),
@@ -224,6 +221,7 @@ def _load_schedules(settings: Settings) -> tuple[SourceSchedule, ...]:
         settings.passive_infrastructure_collection_schedule_path,
         settings.incident_collection_schedule_path,
         settings.threat_telemetry_collection_schedule_path,
+        settings.ats_collection_schedule_path,
     )
 
 

--- a/src/cip/modules/collection_orchestration/application/teamtailor_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/teamtailor_adapter.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.teamtailor.client import (
+    TeamtailorClient,
+    TeamtailorSourceResponseError,
+)
+from cip.adapters.sources.teamtailor.collector import (
+    TeamtailorCheckpoint,
+    TeamtailorCollectionDeniedError,
+    TeamtailorSourceSchemaError,
+    TeamtailorSourceWindowError,
+    collect_teamtailor_jobs,
+)
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class TeamtailorAdapter:
+    source_id = "teamtailor-public-jobs"
+    adapter_id = "teamtailor-public-read-jobs-api"
+    data_category = DataCategory.PUBLIC_JOB_POSTING
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        account: TeamtailorAccount,
+        token_provider: Callable[[], str | None],
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Teamtailor adapter requires its source policy")
+        if not account.enabled:
+            raise ValueError("Teamtailor adapter requires an enabled account")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._account = account
+        self._token_provider = token_provider
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        token = self._token_provider()
+        if token is None or not token.strip():
+            raise AdapterExecutionError(
+                "Teamtailor Public Read API token is unavailable",
+                error_code="provider_secret_unavailable",
+                retryable=False,
+            )
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_teamtailor_jobs(
+                    TeamtailorClient(http_client),
+                    self._entry,
+                    self._account,
+                    api_token=token,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except TeamtailorCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except TeamtailorSourceSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except TeamtailorSourceWindowError as exc:
+            raise _execution_error(exc, "source_window_exceeded", retryable=False) from exc
+        except TeamtailorSourceResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"Teamtailor returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={
+                "fingerprints": {
+                    account_id: dict(values)
+                    for account_id, values in batch.checkpoint.fingerprints.items()
+                }
+            },
+            not_modified=batch.not_modified,
+            commercial_projections=batch.projections,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> TeamtailorCheckpoint | None:
+    if payload is None:
+        return None
+    raw_fingerprints = payload.get("fingerprints")
+    if not isinstance(raw_fingerprints, dict):
+        raise _invalid_checkpoint()
+    fingerprints: dict[str, dict[str, str]] = {}
+    for account_id, raw_jobs in raw_fingerprints.items():
+        if not isinstance(account_id, str) or not isinstance(raw_jobs, dict):
+            raise _invalid_checkpoint()
+        jobs: dict[str, str] = {}
+        for job_id, fingerprint in raw_jobs.items():
+            if not isinstance(job_id, str) or not isinstance(fingerprint, str):
+                raise _invalid_checkpoint()
+            jobs[job_id] = fingerprint
+        fingerprints[account_id] = jobs
+    return TeamtailorCheckpoint(fingerprints)
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "checkpoint fingerprints must contain string account, job, and hash values",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/source_activation/infrastructure/inventory.py
+++ b/src/cip/modules/source_activation/infrastructure/inventory.py
@@ -13,6 +13,21 @@ from cip.modules.source_activation.domain.models import (
 
 
 def load_activation_inventory(path: Path) -> tuple[ActivationRecord, ...]:
+    paths = (path, *sorted(path.parent.glob(f"{path.stem}.*{path.suffix}")))
+    records: list[ActivationRecord] = []
+    source_ids: set[str] = set()
+    for inventory_path in paths:
+        for record in _load_inventory_file(inventory_path):
+            if record.source_id in source_ids:
+                raise ValueError(
+                    f"duplicate source activation id across bundles: {record.source_id}"
+                )
+            source_ids.add(record.source_id)
+            records.append(record)
+    return tuple(records)
+
+
+def _load_inventory_file(path: Path) -> tuple[ActivationRecord, ...]:
     document = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(document, dict) or document.get("version") != 1:
         raise ValueError("source activation inventory must declare version: 1")

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -26,9 +26,7 @@ class Settings(BaseSettings):
     identity_source_registry_path: Path = Path("policies/identity_sources.yml")
     decp_source_registry_path: Path = Path("policies/sources.decp.yml")
     public_web_source_registry_path: Path = Path("policies/sources.public_web.yml")
-    vulnerability_source_registry_path: Path = Path(
-        "policies/sources.vulnerability.yml"
-    )
+    vulnerability_source_registry_path: Path = Path("policies/sources.vulnerability.yml")
     search_archive_source_registry_path: Path = Path(
         "policies/sources.search_archives.yml"
     )
@@ -46,15 +44,12 @@ class Settings(BaseSettings):
     corporate_change_source_registry_path: Path = Path(
         "policies/sources.corporate_changes.yml"
     )
-    relationship_source_registry_path: Path = Path(
-        "policies/sources.relationships.yml"
-    )
+    relationship_source_registry_path: Path = Path("policies/sources.relationships.yml")
     conditional_integration_source_registry_path: Path = Path(
         "policies/sources.conditional_integrations.yml"
     )
-    provider_onboarding_registry_path: Path = Path(
-        "policies/provider_onboarding.yml"
-    )
+    ats_source_registry_path: Path = Path("policies/sources.ats_expansion.yml")
+    provider_onboarding_registry_path: Path = Path("policies/provider_onboarding.yml")
     source_portfolio_path: Path = Path("policies/source_portfolio.yml")
     decp_source_portfolio_path: Path = Path("policies/source_portfolio.decp.yml")
     public_web_source_portfolio_path: Path = Path(
@@ -90,12 +85,16 @@ class Settings(BaseSettings):
     conditional_integration_source_portfolio_path: Path = Path(
         "policies/source_portfolio.conditional_integrations.yml"
     )
+    ats_source_portfolio_path: Path = Path("policies/source_portfolio.ats_expansion.yml")
     source_activation_path: Path = Path("policies/source_activation.yml")
     greenhouse_board_registry_path: Path = Path("policies/greenhouse_boards.yml")
     lever_site_registry_path: Path = Path("policies/lever_sites.yml")
     smartrecruiters_company_registry_path: Path = Path(
         "policies/smartrecruiters_companies.yml"
     )
+    ashby_board_registry_path: Path = Path("policies/ashby_boards.yml")
+    recruitee_site_registry_path: Path = Path("policies/recruitee_sites.yml")
+    teamtailor_account_registry_path: Path = Path("policies/teamtailor_accounts.yml")
     organization_identity_target_registry_path: Path = Path(
         "policies/organization_identity_targets.yml"
     )
@@ -113,14 +112,10 @@ class Settings(BaseSettings):
         "policies/passive_infrastructure_targets.yml"
     )
     rdap_target_registry_path: Path = Path("policies/rdap_targets.yml")
-    sec_incident_target_registry_path: Path = Path(
-        "policies/sec_incident_targets.yml"
-    )
+    sec_incident_target_registry_path: Path = Path("policies/sec_incident_targets.yml")
     retention_policy_path: Path = Path("policies/retention.yml")
     collection_schedule_path: Path = Path("policies/collection_schedules.yml")
-    decp_collection_schedule_path: Path = Path(
-        "policies/collection_schedules.decp.yml"
-    )
+    decp_collection_schedule_path: Path = Path("policies/collection_schedules.decp.yml")
     public_web_collection_schedule_path: Path = Path(
         "policies/collection_schedules.public_web.yml"
     )
@@ -138,6 +133,9 @@ class Settings(BaseSettings):
     )
     threat_telemetry_collection_schedule_path: Path = Path(
         "policies/collection_schedules.threat_telemetry.yml"
+    )
+    ats_collection_schedule_path: Path = Path(
+        "policies/collection_schedules.ats_expansion.yml"
     )
     sec_edgar_user_agent: str | None = Field(default=None, max_length=300)
     phishtank_user_agent: str | None = Field(default=None, max_length=300)

--- a/tests/unit/adapters/ashby/test_registry_validation.py
+++ b/tests/unit/adapters/ashby/test_registry_validation.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cip.adapters.sources.ashby.registry import AshbyBoard, load_ashby_boards
+
+
+@pytest.mark.parametrize("field_name", ["id", "board_name", "canonical_name"])
+def test_board_rejects_blank_required_fields(field_name: str) -> None:
+    values: dict[str, object] = {
+        "id": "ashby",
+        "board_name": "Ashby",
+        "canonical_name": "Ashby",
+    }
+    values[field_name] = " "
+    with pytest.raises(ValueError, match=f"{field_name} is required"):
+        AshbyBoard(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("country_code", ["F", "123", "F1"])
+def test_board_rejects_invalid_country_codes(country_code: str) -> None:
+    with pytest.raises(ValueError, match="ISO alpha-2"):
+        AshbyBoard("ashby", "Ashby", "Ashby", country_code=country_code)
+
+
+def test_board_normalizes_values_and_rejects_path_like_name() -> None:
+    board = AshbyBoard(" ashby ", "Ashby", " Ashby Inc ", country_code=" fr ")
+    assert board.id == "ashby"
+    assert board.canonical_name == "Ashby Inc"
+    assert board.country_code == "FR"
+
+    with pytest.raises(ValueError, match="unsupported characters"):
+        AshbyBoard("bad", "bad/path", "Bad")
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("- item\n", "root must be a mapping"),
+        ("version: 0\nboards: []\n", "positive integer"),
+        ("version: 2\nboards: []\n", "unsupported"),
+        ("version: 1\nboards: {}\n", "boards must be a list"),
+        ("version: 1\nboards:\n  - bad\n", "must be a mapping"),
+        (
+            "version: 1\nboards:\n"
+            "  - id: ashby\n"
+            "    board_name: Ashby\n"
+            "    canonical_name: Ashby\n"
+            "    country_code: 123\n"
+            "    enabled: true\n",
+            "country_code must be a string",
+        ),
+        (
+            "version: 1\nboards:\n"
+            "  - id: ashby\n"
+            "    board_name: Ashby\n"
+            "    canonical_name: Ashby\n"
+            "    enabled: null\n",
+            "enabled must be a boolean",
+        ),
+        (
+            "version: 1\nboards:\n"
+            "  - id: ''\n"
+            "    board_name: Ashby\n"
+            "    canonical_name: Ashby\n"
+            "    enabled: true\n",
+            "id must be a non-empty string",
+        ),
+    ],
+)
+def test_registry_rejects_invalid_shapes(
+    tmp_path: Path,
+    payload: str,
+    message: str,
+) -> None:
+    path = tmp_path / "ashby.yml"
+    path.write_text(payload, encoding="utf-8")
+    with pytest.raises(ValueError, match=message):
+        load_ashby_boards(path)
+
+
+def test_registry_rejects_duplicate_board_names(tmp_path: Path) -> None:
+    path = tmp_path / "ashby.yml"
+    path.write_text(
+        "version: 1\nboards:\n"
+        "  - id: one\n"
+        "    board_name: Ashby\n"
+        "    canonical_name: One\n"
+        "    enabled: true\n"
+        "  - id: two\n"
+        "    board_name: ashby\n"
+        "    canonical_name: Two\n"
+        "    enabled: true\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate Ashby board name"):
+        load_ashby_boards(path)
+
+
+def test_registry_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_ashby_boards(tmp_path / "missing.yml")

--- a/tests/unit/adapters/ashby/test_source.py
+++ b/tests/unit/adapters/ashby/test_source.py
@@ -185,13 +185,21 @@ def test_collector_rejects_governance_schema_duplicates_and_bounds() -> None:
 
     with pytest.raises(AshbySourceWindowError, match="job limit"):
         collect_ashby_jobs(
-            StubAshbyClient({"apiVersion": "1", "jobs": [_job()]}),  # type: ignore[arg-type]
+            StubAshbyClient(
+                {
+                    "apiVersion": "1",
+                    "jobs": [
+                        _job(),
+                        _job(jobUrl="https://jobs.ashbyhq.com/ExampleSecurity/job-2"),
+                    ],
+                }
+            ),  # type: ignore[arg-type]
             _entry(),
             (BOARD,),
             collection_job_id=uuid4(),
             collected_at=NOW,
             retention_until=NOW + timedelta(days=365),
-            max_jobs_per_board=0,
+            max_jobs_per_board=1,
         )
 
     with pytest.raises(ValueError, match="at least one"):
@@ -202,6 +210,17 @@ def test_collector_rejects_governance_schema_duplicates_and_bounds() -> None:
             collection_job_id=uuid4(),
             collected_at=NOW,
             retention_until=NOW + timedelta(days=365),
+        )
+
+    with pytest.raises(ValueError, match="max_jobs_per_board"):
+        collect_ashby_jobs(
+            StubAshbyClient({"apiVersion": "1", "jobs": []}),  # type: ignore[arg-type]
+            _entry(),
+            (BOARD,),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+            max_jobs_per_board=0,
         )
 
 
@@ -231,12 +250,12 @@ def test_registry_rejects_bad_shape_duplicate_and_board_name(tmp_path: Path) -> 
     with pytest.raises(ValueError, match="duplicate Ashby board id"):
         load_ashby_boards(duplicate)
 
-    invalid_name = AshbyBoard(
-        id="example",
-        board_name="bad/name",
-        canonical_name="Example",
-    )
-    assert invalid_name  # pragma: no cover
+    with pytest.raises(ValueError, match="board_name"):
+        AshbyBoard(
+            id="example",
+            board_name="bad/name",
+            canonical_name="Example",
+        )
 
 
 def _collect(

--- a/tests/unit/adapters/ashby/test_source.py
+++ b/tests/unit/adapters/ashby/test_source.py
@@ -118,11 +118,13 @@ def test_client_uses_public_endpoint_and_rejects_unsafe_responses() -> None:
     unsafe = httpx.MockTransport(
         lambda _: httpx.Response(200, headers={"content-type": "text/html"})
     )
-    with httpx.Client(transport=unsafe) as http_client:
-        with pytest.raises(AshbySourceResponseError, match="content type"):
-            AshbyClient(http_client, postings_base_url="https://example.test").fetch_jobs(
-                "Example"
-            )
+    with (
+        httpx.Client(transport=unsafe) as http_client,
+        pytest.raises(AshbySourceResponseError, match="content type"),
+    ):
+        AshbyClient(http_client, postings_base_url="https://example.test").fetch_jobs(
+            "Example"
+        )
 
 
 def test_collector_emits_changed_relevant_jobs_and_refreshes_projection() -> None:

--- a/tests/unit/adapters/ashby/test_source.py
+++ b/tests/unit/adapters/ashby/test_source.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from textwrap import dedent
+from uuid import uuid4
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.ashby.client import (
+    AshbyClient,
+    AshbyFetchResult,
+    AshbySourceResponseError,
+)
+from cip.adapters.sources.ashby.collector import (
+    AshbyCheckpoint,
+    AshbyCollectionDeniedError,
+    AshbySourceSchemaError,
+    AshbySourceWindowError,
+    collect_ashby_jobs,
+)
+from cip.adapters.sources.ashby.mapper import ashby_job_to_canonical, map_ashby_job
+from cip.adapters.sources.ashby.registry import AshbyBoard, load_ashby_boards
+from cip.adapters.sources.ashby.schemas import AshbyJobBoardResponse, AshbyJobPosting
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 0, 20, tzinfo=UTC)
+BOARD = AshbyBoard(
+    id="example-security",
+    board_name="ExampleSecurity",
+    canonical_name="Example Security",
+    country_code="FR",
+)
+
+
+class StubAshbyClient:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.calls: list[str] = []
+
+    def board_url(self, board_name: str) -> str:
+        return f"https://api.ashbyhq.com/posting-api/job-board/{board_name}"
+
+    def fetch_jobs(self, board_name: str) -> AshbyFetchResult:
+        self.calls.append(board_name)
+        return AshbyFetchResult(
+            body=json.dumps(self.payload).encode(),
+            request_url=self.board_url(board_name),
+        )
+
+
+def test_repository_registry_and_schema_map_public_job() -> None:
+    boards = load_ashby_boards(Path("policies/ashby_boards.yml"))
+    assert boards[0].board_name == "Ashby"
+    assert boards[0].enabled is True
+
+    job = AshbyJobPosting.model_validate(_job())
+    assert job.source_job_id == "job-123"
+    assert job.display_location() == "Paris; Remote"
+    canonical = ashby_job_to_canonical(BOARD, job)
+    assert canonical.organization_key == "example-security"
+    assert canonical.department == "Security"
+    assert canonical.location == "Paris; Remote"
+
+    mapped = map_ashby_job(
+        BOARD,
+        job,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert mapped is not None
+    assert mapped[0].source_id == "ashby-job-board"
+    assert mapped[0].source_record_key == "ExampleSecurity:job-123"
+    assert "microsoft sentinel" in mapped[1].signal.matched_terms
+
+
+def test_schema_rejects_invalid_required_fields_and_naive_time() -> None:
+    with pytest.raises(ValidationError):
+        AshbyJobPosting.model_validate(_job(title=" "))
+    with pytest.raises(ValidationError):
+        AshbyJobPosting.model_validate(_job(publishedAt="2026-08-11T00:20:00"))
+    with pytest.raises(ValidationError):
+        AshbyJobBoardResponse.model_validate({"apiVersion": "2", "jobs": []})
+
+
+def test_client_uses_public_endpoint_and_rejects_unsafe_responses() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"apiVersion": "1", "jobs": [_job()]},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        client = AshbyClient(
+            http_client,
+            postings_base_url="https://api.ashbyhq.com/posting-api/job-board",
+        )
+        result = client.fetch_jobs("ExampleSecurity")
+    assert "includeCompensation=false" in captured["url"]
+    assert AshbyJobBoardResponse.model_validate_json(result.body).jobs
+
+    with pytest.raises(ValueError, match="board_name"):
+        client.board_url(" ")
+
+    unsafe = httpx.MockTransport(
+        lambda _: httpx.Response(200, headers={"content-type": "text/html"})
+    )
+    with httpx.Client(transport=unsafe) as http_client:
+        with pytest.raises(AshbySourceResponseError, match="content type"):
+            AshbyClient(http_client, postings_base_url="https://example.test").fetch_jobs(
+                "Example"
+            )
+
+
+def test_collector_emits_changed_relevant_jobs_and_refreshes_projection() -> None:
+    relevant = AshbyJobPosting.model_validate(_job())
+    fingerprint = ashby_job_to_canonical(BOARD, relevant).fingerprint()
+    payload = {
+        "apiVersion": "1",
+        "jobs": [
+            relevant.model_dump(mode="json", by_alias=True),
+            _job(
+                jobUrl="https://jobs.ashbyhq.com/ExampleSecurity/job-finance",
+                title="Finance Manager",
+                department="Finance",
+                descriptionPlain="Accounting and forecasting.",
+            ),
+            _job(
+                jobUrl="https://jobs.ashbyhq.com/ExampleSecurity/job-hidden",
+                isListed=False,
+            ),
+        ],
+    }
+    batch = collect_ashby_jobs(
+        StubAshbyClient(payload),  # type: ignore[arg-type]
+        _entry(),
+        (BOARD,),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+        checkpoint=AshbyCheckpoint(
+            {"example-security": {"job-123": fingerprint}}
+        ),
+    )
+    assert batch.not_modified is False
+    assert batch.observations == ()
+    assert {projection.signal.title for projection in batch.projections} == {
+        "Senior SOC Analyst"
+    }
+    assert set(batch.checkpoint.fingerprints["example-security"]) == {
+        "job-123",
+        "job-finance",
+    }
+
+
+def test_collector_rejects_governance_schema_duplicates_and_bounds() -> None:
+    denied = replace(
+        _entry(),
+        policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
+    )
+    with pytest.raises(AshbyCollectionDeniedError, match="source_not_enabled"):
+        _collect(StubAshbyClient({"apiVersion": "1", "jobs": []}), denied)
+
+    with pytest.raises(AshbySourceSchemaError, match="schema validation"):
+        _collect(StubAshbyClient({"apiVersion": "1", "jobs": [{"title": "bad"}]}))
+
+    duplicate = _job()
+    with pytest.raises(AshbySourceSchemaError, match="duplicate job id"):
+        _collect(
+            StubAshbyClient({"apiVersion": "1", "jobs": [duplicate, duplicate]})
+        )
+
+    with pytest.raises(AshbySourceWindowError, match="job limit"):
+        collect_ashby_jobs(
+            StubAshbyClient({"apiVersion": "1", "jobs": [_job()]}),  # type: ignore[arg-type]
+            _entry(),
+            (BOARD,),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+            max_jobs_per_board=0,
+        )
+
+    with pytest.raises(ValueError, match="at least one"):
+        collect_ashby_jobs(
+            StubAshbyClient({"apiVersion": "1", "jobs": []}),  # type: ignore[arg-type]
+            _entry(),
+            (replace(BOARD, enabled=False),),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+
+def test_registry_rejects_bad_shape_duplicate_and_board_name(tmp_path: Path) -> None:
+    invalid = tmp_path / "invalid.yml"
+    invalid.write_text("version: 2\nboards: []\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported"):
+        load_ashby_boards(invalid)
+
+    duplicate = tmp_path / "duplicate.yml"
+    duplicate.write_text(
+        dedent(
+            """
+            version: 1
+            boards:
+              - &board
+                id: example
+                board_name: example
+                canonical_name: Example
+                country_code: FR
+                enabled: true
+              - *board
+            """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate Ashby board id"):
+        load_ashby_boards(duplicate)
+
+    invalid_name = AshbyBoard(
+        id="example",
+        board_name="bad/name",
+        canonical_name="Example",
+    )
+    assert invalid_name  # pragma: no cover
+
+
+def _collect(
+    client: StubAshbyClient,
+    entry: SourceRegistryEntry | None = None,
+) -> object:
+    return collect_ashby_jobs(
+        client,  # type: ignore[arg-type]
+        entry or _entry(),
+        (BOARD,),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.ats_expansion.yml"))
+        if entry.policy.id == "ashby-job-board"
+    )
+
+
+def _job(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "title": "Senior SOC Analyst",
+        "location": "Paris",
+        "secondaryLocations": [{"location": "Remote"}, {"location": "Paris"}],
+        "department": "Security",
+        "team": "Detection Engineering",
+        "isListed": True,
+        "isRemote": True,
+        "workplaceType": "Hybrid",
+        "descriptionPlain": "Security operations with Microsoft Sentinel and SIEM.",
+        "publishedAt": "2026-08-11T00:20:00Z",
+        "employmentType": "FullTime",
+        "jobUrl": "https://jobs.ashbyhq.com/ExampleSecurity/job-123",
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/adapters/ashby/test_source.py
+++ b/tests/unit/adapters/ashby/test_source.py
@@ -158,7 +158,8 @@ def test_collector_emits_changed_relevant_jobs_and_refreshes_projection() -> Non
         ),
     )
     assert batch.not_modified is False
-    assert batch.observations == ()
+    assert len(batch.observations) == 1
+    assert batch.observations[0].source_record_key == "ExampleSecurity:job-finance"
     assert {projection.signal.title for projection in batch.projections} == {
         "Senior SOC Analyst"
     }

--- a/tests/unit/adapters/ashby/test_source.py
+++ b/tests/unit/adapters/ashby/test_source.py
@@ -138,6 +138,7 @@ def test_collector_emits_changed_relevant_jobs_and_refreshes_projection() -> Non
                 jobUrl="https://jobs.ashbyhq.com/ExampleSecurity/job-finance",
                 title="Finance Manager",
                 department="Finance",
+                team="",
                 descriptionPlain="Accounting and forecasting.",
             ),
             _job(

--- a/tests/unit/adapters/recruitee/test_provider_timestamp.py
+++ b/tests/unit/adapters/recruitee/test_provider_timestamp.py
@@ -1,0 +1,30 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.recruitee.schemas import RecruiteeOffer
+
+
+def _offer(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": 123,
+        "slug": "security-engineer",
+        "title": "Security Engineer",
+        "created_at": "2023-01-30 13:14:40 UTC",
+        "published_at": "2026-06-17 19:24:23 UTC",
+    }
+    payload.update(changes)
+    return payload
+
+
+def test_recruitee_accepts_live_provider_utc_timestamp_format() -> None:
+    offer = RecruiteeOffer.model_validate(_offer())
+
+    assert offer.created_at == datetime(2023, 1, 30, 13, 14, 40, tzinfo=UTC)
+    assert offer.published_at == datetime(2026, 6, 17, 19, 24, 23, tzinfo=UTC)
+
+
+def test_recruitee_still_rejects_naive_timestamp() -> None:
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        RecruiteeOffer.model_validate(_offer(created_at="2026-08-11T00:25:00"))

--- a/tests/unit/adapters/recruitee/test_source.py
+++ b/tests/unit/adapters/recruitee/test_source.py
@@ -43,10 +43,10 @@ from cip.modules.source_governance.infrastructure.registry import (
 
 NOW = datetime(2026, 8, 11, 0, 25, tzinfo=UTC)
 SITE = RecruiteeCareerSite(
-    id="example-security",
-    subdomain="example-security",
-    canonical_name="Example Security",
-    country_code="FR",
+    id="people-for-people",
+    subdomain="peopleforpeople",
+    canonical_name="People for People",
+    country_code="NL",
 )
 
 
@@ -153,16 +153,17 @@ def test_collector_refreshes_relevant_projection_without_duplicate_observation()
         collected_at=NOW,
         retention_until=NOW + timedelta(days=365),
         checkpoint=RecruiteeCheckpoint(
-            {"example-security": {"123": fingerprint}}
+            {"people-for-people": {"123": fingerprint}}
         ),
     )
     assert batch.not_modified is False
-    assert batch.observations == ()
+    assert len(batch.observations) == 1
+    assert batch.observations[0].source_record_key == "peopleforpeople:456"
     assert {projection.signal.title for projection in batch.projections} == {
         "Senior SOC Analyst"
     }
-    assert set(batch.checkpoint.fingerprints["example-security"]) == {"123", "456"}
-    assert batch.checkpoint.fingerprints["example-security"]["123"] == fingerprint
+    assert set(batch.checkpoint.fingerprints["people-for-people"]) == {"123", "456"}
+    assert batch.checkpoint.fingerprints["people-for-people"]["123"] == fingerprint
 
 
 def test_collector_rejects_governance_schema_duplicates_and_window() -> None:

--- a/tests/unit/adapters/recruitee/test_source.py
+++ b/tests/unit/adapters/recruitee/test_source.py
@@ -122,9 +122,11 @@ def test_client_reads_only_public_offers_endpoint_and_rejects_bad_mime() -> None
     unsafe = httpx.MockTransport(
         lambda _: httpx.Response(200, headers={"content-type": "text/html"})
     )
-    with httpx.Client(transport=unsafe) as http_client:
-        with pytest.raises(RecruiteeSourceResponseError, match="content type"):
-            RecruiteeClient(http_client).fetch_offers(SITE.offers_url)
+    with (
+        httpx.Client(transport=unsafe) as http_client,
+        pytest.raises(RecruiteeSourceResponseError, match="content type"),
+    ):
+        RecruiteeClient(http_client).fetch_offers(SITE.offers_url)
 
 
 def test_collector_refreshes_relevant_projection_without_duplicate_observation() -> None:

--- a/tests/unit/adapters/recruitee/test_source.py
+++ b/tests/unit/adapters/recruitee/test_source.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from textwrap import dedent
+from uuid import uuid4
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.recruitee.client import (
+    RecruiteeClient,
+    RecruiteeFetchResult,
+    RecruiteeSourceResponseError,
+)
+from cip.adapters.sources.recruitee.collector import (
+    RecruiteeCheckpoint,
+    RecruiteeCollectionDeniedError,
+    RecruiteeSourceSchemaError,
+    RecruiteeSourceWindowError,
+    collect_recruitee_jobs,
+)
+from cip.adapters.sources.recruitee.mapper import (
+    map_recruitee_offer,
+    recruitee_offer_to_canonical,
+)
+from cip.adapters.sources.recruitee.registry import (
+    RecruiteeCareerSite,
+    load_recruitee_sites,
+)
+from cip.adapters.sources.recruitee.schemas import (
+    RecruiteeOffer,
+    RecruiteeOffersResponse,
+)
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 0, 25, tzinfo=UTC)
+SITE = RecruiteeCareerSite(
+    id="example-security",
+    subdomain="example-security",
+    canonical_name="Example Security",
+    country_code="FR",
+)
+
+
+class StubRecruiteeClient:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.calls: list[str] = []
+
+    def fetch_offers(self, offers_url: str) -> RecruiteeFetchResult:
+        self.calls.append(offers_url)
+        return RecruiteeFetchResult(
+            body=json.dumps(self.payload).encode(),
+            request_url=offers_url,
+        )
+
+
+def test_repository_registry_and_structured_offer_mapping() -> None:
+    sites = load_recruitee_sites(Path("policies/recruitee_sites.yml"))
+    assert sites[0].subdomain == "peopleforpeople"
+    assert sites[0].enabled is True
+
+    offer = RecruiteeOffer.model_validate(_offer())
+    assert offer.department_name() == "Security"
+    assert offer.display_location() == "Remote — France, Paris; Remote"
+    canonical = recruitee_offer_to_canonical(SITE, offer)
+    assert canonical.department == "Security"
+    assert canonical.location == "Remote — France, Paris; Remote"
+    assert canonical.source_url.endswith("/o/senior-soc-analyst")
+
+    mapped = map_recruitee_offer(
+        SITE,
+        offer,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert mapped is not None
+    assert mapped[0].source_id == "recruitee-careers-site"
+    assert "microsoft sentinel" in mapped[1].signal.matched_terms
+
+
+def test_schema_supports_string_department_and_rejects_missing_time() -> None:
+    offer = RecruiteeOffer.model_validate(
+        _offer(department="Security Operations", locations=[], location="Lyon")
+    )
+    assert offer.department_name() == "Security Operations"
+    assert offer.display_location() == "Remote — Lyon"
+
+    with pytest.raises(ValidationError, match="published_at or created_at"):
+        RecruiteeOffer.model_validate(_offer(created_at=None, published_at=None))
+    with pytest.raises(ValidationError):
+        RecruiteeOffer.model_validate(_offer(created_at="2026-08-11T00:25:00"))
+
+
+def test_client_reads_only_public_offers_endpoint_and_rejects_bad_mime() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"offers": [_offer()]},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        client = RecruiteeClient(http_client)
+        result = client.fetch_offers(SITE.offers_url)
+    assert captured == {"method": "GET", "url": SITE.offers_url}
+    assert RecruiteeOffersResponse.model_validate_json(result.body).offers
+
+    unsafe = httpx.MockTransport(
+        lambda _: httpx.Response(200, headers={"content-type": "text/html"})
+    )
+    with httpx.Client(transport=unsafe) as http_client:
+        with pytest.raises(RecruiteeSourceResponseError, match="content type"):
+            RecruiteeClient(http_client).fetch_offers(SITE.offers_url)
+
+
+def test_collector_refreshes_relevant_projection_without_duplicate_observation() -> None:
+    relevant = RecruiteeOffer.model_validate(_offer())
+    fingerprint = recruitee_offer_to_canonical(SITE, relevant).fingerprint()
+    payload = {
+        "offers": [
+            relevant.model_dump(mode="json"),
+            _offer(
+                id=456,
+                slug="finance-manager",
+                title="Finance Manager",
+                department={"id": 2, "name": "Finance"},
+                description="Accounting and forecasting.",
+                requirements="Financial reporting.",
+            ),
+        ]
+    }
+    batch = collect_recruitee_jobs(
+        StubRecruiteeClient(payload),  # type: ignore[arg-type]
+        _entry(),
+        (SITE,),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+        checkpoint=RecruiteeCheckpoint(
+            {"example-security": {"123": fingerprint}}
+        ),
+    )
+    assert batch.not_modified is False
+    assert batch.observations == ()
+    assert {projection.signal.title for projection in batch.projections} == {
+        "Senior SOC Analyst"
+    }
+    assert set(batch.checkpoint.fingerprints["example-security"]) == {"123", "456"}
+    assert batch.checkpoint.fingerprints["example-security"]["123"] == fingerprint
+
+
+def test_collector_rejects_governance_schema_duplicates_and_window() -> None:
+    denied = replace(
+        _entry(),
+        policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
+    )
+    with pytest.raises(RecruiteeCollectionDeniedError, match="source_not_enabled"):
+        _collect(StubRecruiteeClient({"offers": []}), denied)
+
+    with pytest.raises(RecruiteeSourceSchemaError, match="schema validation"):
+        _collect(StubRecruiteeClient({"offers": [{"id": 1}]}))
+
+    duplicate = _offer()
+    with pytest.raises(RecruiteeSourceSchemaError, match="duplicate offer id"):
+        _collect(StubRecruiteeClient({"offers": [duplicate, duplicate]}))
+
+    with pytest.raises(RecruiteeSourceWindowError, match="job limit"):
+        collect_recruitee_jobs(
+            StubRecruiteeClient(
+                {"offers": [_offer(), _offer(id=2, slug="soc-analyst-2")]}
+            ),  # type: ignore[arg-type]
+            _entry(),
+            (SITE,),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+            max_jobs_per_site=1,
+        )
+
+    with pytest.raises(ValueError, match="at least one"):
+        collect_recruitee_jobs(
+            StubRecruiteeClient({"offers": []}),  # type: ignore[arg-type]
+            _entry(),
+            (replace(SITE, enabled=False),),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+
+def test_registry_rejects_duplicate_subdomain_and_bad_country(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.yml"
+    duplicate.write_text(
+        dedent(
+            """
+            version: 1
+            sites:
+              - &site
+                id: example
+                subdomain: example
+                canonical_name: Example
+                country_code: FR
+                enabled: true
+              - id: other
+                subdomain: example
+                canonical_name: Other
+                country_code: FR
+                enabled: true
+            """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate Recruitee subdomain"):
+        load_recruitee_sites(duplicate)
+
+    with pytest.raises(ValueError, match="country_code"):
+        RecruiteeCareerSite(
+            id="example",
+            subdomain="example",
+            canonical_name="Example",
+            country_code="FRA",
+        )
+
+
+def _collect(
+    client: StubRecruiteeClient,
+    entry: SourceRegistryEntry | None = None,
+) -> object:
+    return collect_recruitee_jobs(
+        client,  # type: ignore[arg-type]
+        entry or _entry(),
+        (SITE,),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.ats_expansion.yml"))
+        if entry.policy.id == "recruitee-careers-site"
+    )
+
+
+def _offer(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": 123,
+        "slug": "senior-soc-analyst",
+        "title": "Senior SOC Analyst",
+        "status": "published",
+        "department": {"id": 1, "name": "Security"},
+        "locations": [
+            {"id": 1, "full_address": "France, Paris", "country_code": "FR"},
+            {"id": 2, "city": "Remote"},
+        ],
+        "remote": True,
+        "description": "<p>Security operations with Microsoft Sentinel.</p>",
+        "requirements": "<p>SIEM and incident response.</p>",
+        "created_at": "2026-08-11T00:25:00Z",
+        "employment_type_code": "full_time",
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/adapters/teamtailor/test_source.py
+++ b/tests/unit/adapters/teamtailor/test_source.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from textwrap import dedent
+from uuid import uuid4
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.teamtailor.client import (
+    TeamtailorClient,
+    TeamtailorFetchResult,
+    TeamtailorSourceResponseError,
+)
+from cip.adapters.sources.teamtailor.collector import (
+    TeamtailorCheckpoint,
+    TeamtailorCollectionDeniedError,
+    TeamtailorSourceSchemaError,
+    TeamtailorSourceWindowError,
+    collect_teamtailor_jobs,
+)
+from cip.adapters.sources.teamtailor.mapper import (
+    map_teamtailor_job,
+    teamtailor_job_to_canonical,
+)
+from cip.adapters.sources.teamtailor.registry import (
+    TeamtailorAccount,
+    load_teamtailor_accounts,
+)
+from cip.adapters.sources.teamtailor.schemas import (
+    TeamtailorJobResource,
+    TeamtailorJobsResponse,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.collection_orchestration.application.teamtailor_adapter import (
+    TeamtailorAdapter,
+)
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 0, 30, tzinfo=UTC)
+ACCOUNT = TeamtailorAccount(
+    id="example-security",
+    canonical_name="Example Security",
+    region="eu",
+    api_version="20240404",
+    country_code="FR",
+    enabled=True,
+)
+
+
+class StubTeamtailorClient:
+    def __init__(self, pages: dict[str, object]) -> None:
+        self.pages = pages
+        self.calls: list[tuple[str, str, str]] = []
+
+    def fetch_jobs_page(
+        self,
+        url: str,
+        *,
+        api_token: str,
+        api_version: str,
+        page_size: int = 30,
+    ) -> TeamtailorFetchResult:
+        self.calls.append((url, api_token, api_version))
+        return TeamtailorFetchResult(
+            body=json.dumps(self.pages[url]).encode(),
+            request_url=url,
+        )
+
+
+def test_repository_registry_is_fail_closed_without_account() -> None:
+    assert load_teamtailor_accounts(Path("policies/teamtailor_accounts.yml")) == ()
+    assert ACCOUNT.base_url == "https://api.teamtailor.com"
+    assert ACCOUNT.jobs_url == "https://api.teamtailor.com/v1/jobs"
+
+
+def test_schema_and_mapper_use_public_job_fields_only() -> None:
+    job = TeamtailorJobResource.model_validate(_job())
+    canonical = teamtailor_job_to_canonical(ACCOUNT, job)
+    assert canonical.department is None
+    assert canonical.employment_type == "full-time"
+    assert canonical.location == "hybrid"
+    assert canonical.source_url == "https://api.teamtailor.com/v1/jobs/123"
+
+    mapped = map_teamtailor_job(
+        ACCOUNT,
+        job,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert mapped is not None
+    assert mapped[0].source_id == "teamtailor-public-jobs"
+    assert "microsoft sentinel" in mapped[1].signal.matched_terms
+
+    with pytest.raises(ValidationError):
+        TeamtailorJobResource.model_validate(_job(type="candidates"))
+
+
+def test_client_sends_minimal_public_read_headers_and_bounds_pages() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["authorization"] = request.headers["authorization"]
+        captured["api_version"] = request.headers["x-api-version"]
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/vnd.api+json"},
+            json={"data": [_job()], "links": {"next": None}},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        client = TeamtailorClient(http_client)
+        result = client.fetch_jobs_page(
+            ACCOUNT.jobs_url,
+            api_token="public-read-token",
+            api_version=ACCOUNT.api_version,
+        )
+    assert captured["authorization"] == "Token token=public-read-token"
+    assert captured["api_version"] == "20240404"
+    assert "page%5Bsize%5D=30" in captured["url"]
+    assert TeamtailorJobsResponse.model_validate_json(result.body).data
+
+    with pytest.raises(ValueError, match="api_token"):
+        client.fetch_jobs_page(
+            ACCOUNT.jobs_url,
+            api_token=" ",
+            api_version=ACCOUNT.api_version,
+        )
+    with pytest.raises(ValueError, match="page_size"):
+        client.fetch_jobs_page(
+            ACCOUNT.jobs_url,
+            api_token="token",
+            api_version=ACCOUNT.api_version,
+            page_size=31,
+        )
+
+
+def test_client_rejects_non_json_api_response() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(200, headers={"content-type": "text/html"})
+    )
+    with httpx.Client(transport=transport) as http_client:
+        with pytest.raises(TeamtailorSourceResponseError, match="content type"):
+            TeamtailorClient(http_client).fetch_jobs_page(
+                ACCOUNT.jobs_url,
+                api_token="token",
+                api_version=ACCOUNT.api_version,
+            )
+
+
+def test_collector_follows_only_same_provider_jobs_pagination() -> None:
+    second = f"{ACCOUNT.jobs_url}?page%5Bnumber%5D=2"
+    client = StubTeamtailorClient(
+        {
+            ACCOUNT.jobs_url: {
+                "data": [_job()],
+                "links": {"next": second},
+            },
+            second: {
+                "data": [
+                    _job(
+                        id="456",
+                        attributes=_attributes(
+                            title="Finance Manager",
+                            body="Accounting and forecasting.",
+                        ),
+                    )
+                ],
+                "links": {"next": None},
+            },
+        }
+    )
+    batch = collect_teamtailor_jobs(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        ACCOUNT,
+        api_token="public-read-token",
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert len(client.calls) == 2
+    assert {projection.signal.title for projection in batch.projections} == {
+        "Senior SOC Analyst"
+    }
+    assert set(batch.checkpoint.fingerprints[ACCOUNT.id]) == {"123", "456"}
+
+    escaped = StubTeamtailorClient(
+        {
+            ACCOUNT.jobs_url: {
+                "data": [],
+                "links": {"next": "https://example.org/v1/jobs"},
+            }
+        }
+    )
+    with pytest.raises(TeamtailorSourceSchemaError, match="outside provider host"):
+        _collect(escaped)
+
+
+def test_collector_rejects_governance_duplicates_loops_and_window() -> None:
+    denied = replace(
+        _entry(),
+        policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
+    )
+    with pytest.raises(TeamtailorCollectionDeniedError, match="source_not_enabled"):
+        _collect(
+            StubTeamtailorClient(
+                {ACCOUNT.jobs_url: {"data": [], "links": {"next": None}}}
+            ),
+            denied,
+        )
+
+    duplicate = _job()
+    with pytest.raises(TeamtailorSourceSchemaError, match="duplicate job id"):
+        _collect(
+            StubTeamtailorClient(
+                {
+                    ACCOUNT.jobs_url: {
+                        "data": [duplicate, duplicate],
+                        "links": {"next": None},
+                    }
+                }
+            )
+        )
+
+    with pytest.raises(TeamtailorSourceWindowError, match="job limit"):
+        collect_teamtailor_jobs(
+            StubTeamtailorClient(
+                {
+                    ACCOUNT.jobs_url: {
+                        "data": [_job(), _job(id="456")],
+                        "links": {"next": None},
+                    }
+                }
+            ),  # type: ignore[arg-type]
+            _entry(),
+            ACCOUNT,
+            api_token="token",
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+            max_jobs=1,
+        )
+
+    loop = StubTeamtailorClient(
+        {
+            ACCOUNT.jobs_url: {
+                "data": [],
+                "links": {"next": ACCOUNT.jobs_url},
+            }
+        }
+    )
+    with pytest.raises(TeamtailorSourceSchemaError, match="pagination loop"):
+        _collect(loop)
+
+
+def test_application_adapter_fails_closed_without_public_read_secret() -> None:
+    adapter = TeamtailorAdapter(_entry(), ACCOUNT, lambda: None)
+    with pytest.raises(AdapterExecutionError, match="token is unavailable") as exc:
+        adapter.collect(
+            collection_job_id=uuid4(),
+            checkpoint_payload=None,
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+    assert exc.value.error_code == "provider_secret_unavailable"
+
+
+def test_registry_rejects_multiple_enabled_accounts(tmp_path: Path) -> None:
+    path = tmp_path / "teamtailor.yml"
+    path.write_text(
+        dedent(
+            """
+            version: 1
+            accounts:
+              - id: one
+                canonical_name: One
+                region: eu
+                api_version: "20240404"
+                enabled: true
+              - id: two
+                canonical_name: Two
+                region: na
+                api_version: "20240404"
+                enabled: true
+            """
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="only one"):
+        load_teamtailor_accounts(path)
+
+
+def _collect(
+    client: StubTeamtailorClient,
+    entry: SourceRegistryEntry | None = None,
+) -> object:
+    return collect_teamtailor_jobs(
+        client,  # type: ignore[arg-type]
+        entry or _entry(),
+        ACCOUNT,
+        api_token="public-read-token",
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.ats_expansion.yml"))
+        if entry.policy.id == "teamtailor-public-jobs"
+    )
+
+
+def _job(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": "123",
+        "type": "jobs",
+        "attributes": _attributes(),
+        "links": {"self": "https://api.teamtailor.com/v1/jobs/123"},
+    }
+    payload.update(changes)
+    return payload
+
+
+def _attributes(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "title": "Senior SOC Analyst",
+        "body": "<p>Operate Microsoft Sentinel and SIEM detections.</p>",
+        "pitch": "Security operations",
+        "remote-status": "hybrid",
+        "employment-type": "full-time",
+        "created-at": "2026-08-11T00:30:00Z",
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/adapters/teamtailor/test_source.py
+++ b/tests/unit/adapters/teamtailor/test_source.py
@@ -174,6 +174,7 @@ def test_collector_follows_only_same_provider_jobs_pagination() -> None:
                         attributes=_attributes(
                             title="Finance Manager",
                             body="Accounting and forecasting.",
+                            pitch="",
                         ),
                     )
                 ],

--- a/tests/unit/adapters/teamtailor/test_source.py
+++ b/tests/unit/adapters/teamtailor/test_source.py
@@ -17,7 +17,6 @@ from cip.adapters.sources.teamtailor.client import (
     TeamtailorSourceResponseError,
 )
 from cip.adapters.sources.teamtailor.collector import (
-    TeamtailorCheckpoint,
     TeamtailorCollectionDeniedError,
     TeamtailorSourceSchemaError,
     TeamtailorSourceWindowError,
@@ -149,13 +148,15 @@ def test_client_rejects_non_json_api_response() -> None:
     transport = httpx.MockTransport(
         lambda _: httpx.Response(200, headers={"content-type": "text/html"})
     )
-    with httpx.Client(transport=transport) as http_client:
-        with pytest.raises(TeamtailorSourceResponseError, match="content type"):
-            TeamtailorClient(http_client).fetch_jobs_page(
-                ACCOUNT.jobs_url,
-                api_token="token",
-                api_version=ACCOUNT.api_version,
-            )
+    with (
+        httpx.Client(transport=transport) as http_client,
+        pytest.raises(TeamtailorSourceResponseError, match="content type"),
+    ):
+        TeamtailorClient(http_client).fetch_jobs_page(
+            ACCOUNT.jobs_url,
+            api_token="token",
+            api_version=ACCOUNT.api_version,
+        )
 
 
 def test_collector_follows_only_same_provider_jobs_pagination() -> None:

--- a/tests/unit/collection_orchestration/test_runtime_and_metrics.py
+++ b/tests/unit/collection_orchestration/test_runtime_and_metrics.py
@@ -75,10 +75,11 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
     get_metadata().create_all(create_database_engine(settings.database_url))
 
     runtime = build_collection_runtime(settings)
-    assert run_scheduler_once(runtime, now=NOW) == 10
+    assert run_scheduler_once(runtime, now=NOW) == 12
     assert run_scheduler_once(runtime, now=NOW) == 0
 
     expected_sources = (
+        "ashby-job-board",
         "boamp",
         "cisa-kev",
         "decp",
@@ -87,6 +88,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         "internet-archive-cdx",
         "lever-job-board",
         "nvd-vulnerabilities",
+        "recruitee-careers-site",
         "smartrecruiters-job-board",
         "ted-search",
     )
@@ -101,6 +103,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         for source in sources.values()
     )
     assert {(job.source_id, job.adapter_id) for job in jobs} == {
+        ("ashby-job-board", "ashby-public-job-postings-api"),
         ("boamp", "boamp-explore-api"),
         ("cisa-kev", "cisa-kev-feed"),
         ("decp", "decp-explore-api"),
@@ -109,6 +112,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         ("internet-archive-cdx", "internet-archive-cdx"),
         ("lever-job-board", "lever-postings-api"),
         ("nvd-vulnerabilities", "nvd-cve-api"),
+        ("recruitee-careers-site", "recruitee-careers-site-api"),
         ("smartrecruiters-job-board", "smartrecruiters-posting-api"),
         ("ted-search", "ted-search-api"),
     }

--- a/tests/unit/collection_orchestration/test_sa13_application_adapters.py
+++ b/tests/unit/collection_orchestration/test_sa13_application_adapters.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import ModuleType
+from uuid import uuid4
+
+import pytest
+
+from cip.adapters.sources.ashby.client import AshbySourceResponseError
+from cip.adapters.sources.ashby.collector import (
+    AshbyCheckpoint,
+    AshbyCollectionBatch,
+    AshbyCollectionDeniedError,
+    AshbySourceSchemaError,
+    AshbySourceWindowError,
+)
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.recruitee.client import RecruiteeSourceResponseError
+from cip.adapters.sources.recruitee.collector import (
+    RecruiteeCheckpoint,
+    RecruiteeCollectionBatch,
+    RecruiteeCollectionDeniedError,
+    RecruiteeSourceSchemaError,
+    RecruiteeSourceWindowError,
+)
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
+from cip.adapters.sources.teamtailor.client import TeamtailorSourceResponseError
+from cip.adapters.sources.teamtailor.collector import (
+    TeamtailorCheckpoint,
+    TeamtailorCollectionBatch,
+    TeamtailorCollectionDeniedError,
+    TeamtailorSourceSchemaError,
+    TeamtailorSourceWindowError,
+)
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.modules.collection_orchestration.application import (
+    ashby_adapter as ashby_module,
+)
+from cip.modules.collection_orchestration.application import (
+    recruitee_adapter as recruitee_module,
+)
+from cip.modules.collection_orchestration.application import (
+    teamtailor_adapter as teamtailor_module,
+)
+from cip.modules.collection_orchestration.application.ashby_adapter import AshbyAdapter
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.collection_orchestration.application.recruitee_adapter import RecruiteeAdapter
+from cip.modules.collection_orchestration.application.teamtailor_adapter import TeamtailorAdapter
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 0, 45, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+ASHBY_BOARD = AshbyBoard("ashby", "Ashby", "Ashby", "US")
+RECRUITEE_SITE = RecruiteeCareerSite(
+    "people-for-people",
+    "peopleforpeople",
+    "People for People",
+    "NL",
+)
+TEAMTAILOR_ACCOUNT = TeamtailorAccount(
+    id="example",
+    canonical_name="Example",
+    enabled=True,
+)
+
+
+def test_ashby_adapter_success_hydrates_and_serializes_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = AshbyAdapter(_entry("ashby-job-board"), (ASHBY_BOARD,))
+    seen: dict[str, object] = {}
+
+    def collect(*args: object, **kwargs: object) -> AshbyCollectionBatch:
+        seen["checkpoint"] = kwargs["checkpoint"]
+        return AshbyCollectionBatch(
+            observations=(),
+            projections=(),
+            checkpoint=AshbyCheckpoint({"ashby": {"job-1": "hash"}}),
+            not_modified=True,
+        )
+
+    monkeypatch.setattr(ashby_module, "collect_ashby_jobs", collect)
+    result = adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload={"fingerprints": {"ashby": {"old": "old-hash"}}},
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+    assert isinstance(seen["checkpoint"], AshbyCheckpoint)
+    assert result.not_modified is True
+    assert result.checkpoint_payload == {
+        "fingerprints": {"ashby": {"job-1": "hash"}}
+    }
+
+
+@pytest.mark.parametrize(
+    ("error", "code", "retryable"),
+    [
+        (AshbyCollectionDeniedError("denied"), "source_policy_denied", False),
+        (AshbySourceSchemaError("schema"), "source_schema_drift", False),
+        (AshbySourceWindowError("window"), "source_window_exceeded", False),
+        (AshbySourceResponseError("response"), "unsafe_source_response", True),
+    ],
+)
+def test_ashby_adapter_maps_provider_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    code: str,
+    retryable: bool,
+) -> None:
+    adapter = AshbyAdapter(_entry("ashby-job-board"), (ASHBY_BOARD,))
+    _raise_from_collector(monkeypatch, ashby_module, "collect_ashby_jobs", error)
+
+    with pytest.raises(AdapterExecutionError) as exc:
+        _collect(adapter)
+    assert exc.value.error_code == code
+    assert exc.value.retryable is retryable
+
+
+def test_ashby_adapter_rejects_invalid_checkpoint_and_configuration() -> None:
+    entry = _entry("ashby-job-board")
+    adapter = AshbyAdapter(entry, (ASHBY_BOARD,))
+    with pytest.raises(AdapterExecutionError, match="checkpoint fingerprints"):
+        _collect(adapter, {"fingerprints": {"ashby": {"job": 1}}})
+    with pytest.raises(ValueError, match="enabled board"):
+        AshbyAdapter(entry, (AshbyBoard("x", "X", "X", enabled=False),))
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        AshbyAdapter(entry, (ASHBY_BOARD,), timeout_seconds=0)
+
+
+def test_recruitee_adapter_success_hydrates_and_serializes_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = RecruiteeAdapter(
+        _entry("recruitee-careers-site"),
+        (RECRUITEE_SITE,),
+    )
+    seen: dict[str, object] = {}
+
+    def collect(*args: object, **kwargs: object) -> RecruiteeCollectionBatch:
+        seen["checkpoint"] = kwargs["checkpoint"]
+        return RecruiteeCollectionBatch(
+            observations=(),
+            projections=(),
+            checkpoint=RecruiteeCheckpoint(
+                {"people-for-people": {"offer-1": "hash"}}
+            ),
+            not_modified=False,
+        )
+
+    monkeypatch.setattr(recruitee_module, "collect_recruitee_jobs", collect)
+    result = adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload={
+            "fingerprints": {"people-for-people": {"old": "old-hash"}}
+        },
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+    assert isinstance(seen["checkpoint"], RecruiteeCheckpoint)
+    assert result.not_modified is False
+    assert result.checkpoint_payload == {
+        "fingerprints": {"people-for-people": {"offer-1": "hash"}}
+    }
+
+
+@pytest.mark.parametrize(
+    ("error", "code", "retryable"),
+    [
+        (RecruiteeCollectionDeniedError("denied"), "source_policy_denied", False),
+        (RecruiteeSourceSchemaError("schema"), "source_schema_drift", False),
+        (RecruiteeSourceWindowError("window"), "source_window_exceeded", False),
+        (RecruiteeSourceResponseError("response"), "unsafe_source_response", True),
+    ],
+)
+def test_recruitee_adapter_maps_provider_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    code: str,
+    retryable: bool,
+) -> None:
+    adapter = RecruiteeAdapter(
+        _entry("recruitee-careers-site"),
+        (RECRUITEE_SITE,),
+    )
+    _raise_from_collector(monkeypatch, recruitee_module, "collect_recruitee_jobs", error)
+
+    with pytest.raises(AdapterExecutionError) as exc:
+        _collect(adapter)
+    assert exc.value.error_code == code
+    assert exc.value.retryable is retryable
+
+
+def test_recruitee_adapter_rejects_invalid_checkpoint_and_configuration() -> None:
+    entry = _entry("recruitee-careers-site")
+    adapter = RecruiteeAdapter(entry, (RECRUITEE_SITE,))
+    with pytest.raises(AdapterExecutionError, match="checkpoint fingerprints"):
+        _collect(adapter, {"fingerprints": {"site": {"job": 1}}})
+    with pytest.raises(ValueError, match="enabled site"):
+        RecruiteeAdapter(
+            entry,
+            (
+                RecruiteeCareerSite(
+                    "x",
+                    "x",
+                    "X",
+                    enabled=False,
+                ),
+            ),
+        )
+
+
+def test_teamtailor_adapter_success_hydrates_and_serializes_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = TeamtailorAdapter(
+        _entry("teamtailor-public-jobs"),
+        TEAMTAILOR_ACCOUNT,
+        lambda: "public-read-token",
+    )
+    seen: dict[str, object] = {}
+
+    def collect(*args: object, **kwargs: object) -> TeamtailorCollectionBatch:
+        seen["token"] = kwargs["api_token"]
+        seen["checkpoint"] = kwargs["checkpoint"]
+        return TeamtailorCollectionBatch(
+            observations=(),
+            projections=(),
+            checkpoint=TeamtailorCheckpoint({"example": {"job-1": "hash"}}),
+            not_modified=True,
+        )
+
+    monkeypatch.setattr(teamtailor_module, "collect_teamtailor_jobs", collect)
+    result = adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload={"fingerprints": {"example": {"old": "old-hash"}}},
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+    assert seen["token"] == "public-read-token"
+    assert isinstance(seen["checkpoint"], TeamtailorCheckpoint)
+    assert result.not_modified is True
+    assert result.checkpoint_payload == {
+        "fingerprints": {"example": {"job-1": "hash"}}
+    }
+
+
+@pytest.mark.parametrize(
+    ("error", "code", "retryable"),
+    [
+        (TeamtailorCollectionDeniedError("denied"), "source_policy_denied", False),
+        (TeamtailorSourceSchemaError("schema"), "source_schema_drift", False),
+        (TeamtailorSourceWindowError("window"), "source_window_exceeded", False),
+        (TeamtailorSourceResponseError("response"), "unsafe_source_response", True),
+    ],
+)
+def test_teamtailor_adapter_maps_provider_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+    code: str,
+    retryable: bool,
+) -> None:
+    adapter = TeamtailorAdapter(
+        _entry("teamtailor-public-jobs"),
+        TEAMTAILOR_ACCOUNT,
+        lambda: "token",
+    )
+    _raise_from_collector(
+        monkeypatch,
+        teamtailor_module,
+        "collect_teamtailor_jobs",
+        error,
+    )
+
+    with pytest.raises(AdapterExecutionError) as exc:
+        _collect(adapter)
+    assert exc.value.error_code == code
+    assert exc.value.retryable is retryable
+
+
+def test_teamtailor_adapter_rejects_invalid_checkpoint_and_configuration() -> None:
+    entry = _entry("teamtailor-public-jobs")
+    adapter = TeamtailorAdapter(entry, TEAMTAILOR_ACCOUNT, lambda: "token")
+    with pytest.raises(AdapterExecutionError, match="checkpoint fingerprints"):
+        _collect(adapter, {"fingerprints": {"account": {"job": 1}}})
+    with pytest.raises(ValueError, match="enabled account"):
+        TeamtailorAdapter(
+            entry,
+            TeamtailorAccount("x", "X", enabled=False),
+            lambda: "token",
+        )
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        TeamtailorAdapter(entry, TEAMTAILOR_ACCOUNT, lambda: "token", timeout_seconds=0)
+
+
+def _collect(
+    adapter: AshbyAdapter | RecruiteeAdapter | TeamtailorAdapter,
+    checkpoint: dict[str, object] | None = None,
+) -> object:
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _entry(source_id: str) -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.ats_expansion.yml"))
+        if entry.policy.id == source_id
+    )
+
+
+def _raise_from_collector(
+    monkeypatch: pytest.MonkeyPatch,
+    module: ModuleType,
+    name: str,
+    error: Exception,
+) -> None:
+    def fail(*args: object, **kwargs: object) -> object:
+        raise error
+
+    monkeypatch.setattr(module, name, fail)

--- a/tests/unit/collection_orchestration/test_sa13_registration_and_bounds.py
+++ b/tests/unit/collection_orchestration/test_sa13_registration_and_bounds.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from cip.adapters.sources.ashby.client import AshbyClient, AshbySourceResponseError
+from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.recruitee.client import (
+    RecruiteeClient,
+    RecruiteeSourceResponseError,
+)
+from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
+from cip.adapters.sources.teamtailor.client import (
+    TeamtailorClient,
+    TeamtailorSourceResponseError,
+)
+from cip.adapters.sources.teamtailor.registry import TeamtailorAccount
+from cip.modules.collection_orchestration.application.ats_registration import (
+    register_extended_ats_adapters,
+)
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+
+def test_ats_registration_registers_all_available_provider_adapters() -> None:
+    entries = _entries()
+    adapters: dict[tuple[str, str], CollectionAdapter] = {}
+
+    register_extended_ats_adapters(
+        adapters,
+        entries,
+        (AshbyBoard("ashby", "Ashby", "Ashby", enabled=True),),
+        (
+            RecruiteeCareerSite(
+                "people",
+                "peopleforpeople",
+                "People for People",
+                enabled=True,
+            ),
+        ),
+        (TeamtailorAccount("teamtailor", "Teamtailor", enabled=True),),
+        teamtailor_token_provider=lambda: "token",
+        timeout_seconds=10,
+    )
+
+    assert set(adapters) == {
+        ("ashby-job-board", "ashby-public-job-postings-api"),
+        ("recruitee-careers-site", "recruitee-careers-site-api"),
+        ("teamtailor-public-jobs", "teamtailor-public-read-jobs-api"),
+    }
+
+
+def test_ats_registration_skips_missing_or_disabled_sources() -> None:
+    adapters: dict[tuple[str, str], CollectionAdapter] = {}
+    register_extended_ats_adapters(
+        adapters,
+        {},
+        (AshbyBoard("ashby", "Ashby", "Ashby", enabled=False),),
+        (
+            RecruiteeCareerSite(
+                "people",
+                "peopleforpeople",
+                "People for People",
+                enabled=False,
+            ),
+        ),
+        (TeamtailorAccount("teamtailor", "Teamtailor", enabled=False),),
+        teamtailor_token_provider=lambda: None,
+        timeout_seconds=10,
+    )
+    assert adapters == {}
+
+
+def test_ats_registration_rejects_multiple_teamtailor_accounts() -> None:
+    entries = _entries()
+    with pytest.raises(ValueError, match="exactly one enabled account"):
+        register_extended_ats_adapters(
+            {},
+            entries,
+            (),
+            (),
+            (
+                TeamtailorAccount("one", "One", enabled=True),
+                TeamtailorAccount("two", "Two", enabled=True),
+            ),
+            teamtailor_token_provider=lambda: "token",
+            timeout_seconds=10,
+        )
+
+
+def test_ats_registration_rejects_duplicate_runtime_identity() -> None:
+    entries = _entries()
+    adapters: dict[tuple[str, str], CollectionAdapter] = {}
+    board = AshbyBoard("ashby", "Ashby", "Ashby", enabled=True)
+    register_extended_ats_adapters(
+        adapters,
+        entries,
+        (board,),
+        (),
+        (),
+        teamtailor_token_provider=lambda: None,
+        timeout_seconds=10,
+    )
+    with pytest.raises(ValueError, match="duplicate runtime adapter"):
+        register_extended_ats_adapters(
+            adapters,
+            entries,
+            (board,),
+            (),
+            (),
+            teamtailor_token_provider=lambda: None,
+            timeout_seconds=10,
+        )
+
+
+@pytest.mark.parametrize("declared", ["invalid", "10"])
+def test_ashby_client_rejects_invalid_or_oversized_content_length(declared: str) -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/json", "content-length": declared},
+            content=b"{}",
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        client = AshbyClient(http_client, postings_base_url="https://example.test")
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(AshbySourceResponseError):
+            client.fetch_jobs("Example")
+
+
+def test_ashby_client_rejects_oversized_body_without_declared_length() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b"123",
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        client = AshbyClient(http_client, postings_base_url="https://example.test")
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(AshbySourceResponseError, match="body exceeds"):
+            client.fetch_jobs("Example")
+
+
+@pytest.mark.parametrize("declared", ["invalid", "10"])
+def test_recruitee_client_rejects_invalid_or_oversized_content_length(
+    declared: str,
+) -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/json", "content-length": declared},
+            content=b"{}",
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        client = RecruiteeClient(http_client)
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(RecruiteeSourceResponseError):
+            client.fetch_offers("https://example.recruitee.com/api/offers/")
+
+
+def test_recruitee_client_rejects_oversized_body_without_declared_length() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b"123",
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        client = RecruiteeClient(http_client)
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(RecruiteeSourceResponseError, match="body exceeds"):
+            client.fetch_offers("https://example.recruitee.com/api/offers/")
+
+
+@pytest.mark.parametrize("declared", ["invalid", "10"])
+def test_teamtailor_client_rejects_invalid_or_oversized_content_length(
+    declared: str,
+) -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={
+                "content-type": "application/vnd.api+json",
+                "content-length": declared,
+            },
+            content=b"{}",
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        client = TeamtailorClient(http_client)
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(TeamtailorSourceResponseError):
+            client.fetch_jobs_page(
+                "https://api.teamtailor.com/v1/jobs",
+                api_token="token",
+                api_version="20240404",
+            )
+
+
+def test_teamtailor_client_rejects_oversized_body_without_declared_length() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/vnd.api+json"},
+            content=b"123",
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        client = TeamtailorClient(http_client)
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(TeamtailorSourceResponseError, match="body exceeds"):
+            client.fetch_jobs_page(
+                "https://api.teamtailor.com/v1/jobs",
+                api_token="token",
+                api_version="20240404",
+            )
+
+
+def _entries() -> dict[str, SourceRegistryEntry]:
+    return {
+        entry.policy.id: entry
+        for entry in load_source_registry(Path("policies/sources.ats_expansion.yml"))
+    }

--- a/tests/unit/collection_orchestration/test_sa13_registration_and_bounds.py
+++ b/tests/unit/collection_orchestration/test_sa13_registration_and_bounds.py
@@ -145,7 +145,7 @@ def test_ashby_client_rejects_oversized_body_without_declared_length() -> None:
     with httpx.Client(transport=transport) as http_client:
         client = AshbyClient(http_client, postings_base_url="https://example.test")
         client.MAX_RESPONSE_BYTES = 2
-        with pytest.raises(AshbySourceResponseError, match="body exceeds"):
+        with pytest.raises(AshbySourceResponseError, match="response exceeds"):
             client.fetch_jobs("Example")
 
 
@@ -178,7 +178,7 @@ def test_recruitee_client_rejects_oversized_body_without_declared_length() -> No
     with httpx.Client(transport=transport) as http_client:
         client = RecruiteeClient(http_client)
         client.MAX_RESPONSE_BYTES = 2
-        with pytest.raises(RecruiteeSourceResponseError, match="body exceeds"):
+        with pytest.raises(RecruiteeSourceResponseError, match="response exceeds"):
             client.fetch_offers("https://example.recruitee.com/api/offers/")
 
 
@@ -218,7 +218,7 @@ def test_teamtailor_client_rejects_oversized_body_without_declared_length() -> N
     with httpx.Client(transport=transport) as http_client:
         client = TeamtailorClient(http_client)
         client.MAX_RESPONSE_BYTES = 2
-        with pytest.raises(TeamtailorSourceResponseError, match="body exceeds"):
+        with pytest.raises(TeamtailorSourceResponseError, match="response exceeds"):
             client.fetch_jobs_page(
                 "https://api.teamtailor.com/v1/jobs",
                 api_token="token",

--- a/tests/unit/provider_onboarding/test_provider_registry.py
+++ b/tests/unit/provider_onboarding/test_provider_registry.py
@@ -13,8 +13,15 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     profiles = load_provider_profiles(Path("policies/provider_onboarding.yml"))
     by_source = {profile.source_id: profile for profile in profiles}
 
-    assert len(profiles) == 20
+    assert len(profiles) == 23
     assert by_source["cisa-kev"].initial_state is OnboardingState.CONNECTED
+    assert by_source["ashby-job-board"].auth_mode is AuthMode.NONE
+    assert by_source["ashby-job-board"].initial_state is OnboardingState.CONNECTED
+    assert by_source["recruitee-careers-site"].auth_mode is AuthMode.NONE
+    assert by_source["recruitee-careers-site"].initial_state is OnboardingState.CONNECTED
+    assert by_source["teamtailor-public-jobs"].auth_mode is AuthMode.API_KEY
+    assert by_source["teamtailor-public-jobs"].required_secret_names == ("api_token",)
+    assert by_source["teamtailor-public-jobs"].initial_state is OnboardingState.NOT_CONFIGURED
     assert by_source["sirene-api"].auth_mode is AuthMode.NONE
     assert by_source["inpi-rne"].required_secret_names == ("username", "password")
     assert by_source["brave-search-api"].auth_mode is AuthMode.API_KEY

--- a/tests/unit/source_activation/test_sa10_final_source_completeness.py
+++ b/tests/unit/source_activation/test_sa10_final_source_completeness.py
@@ -66,29 +66,34 @@ def test_every_terminal_non_executable_record_is_resolved_with_reason() -> None:
 def test_sa10_preserves_real_live_validation_as_open_gate() -> None:
     records = _records()
     audit = audit_inventory(records)
-    active_without_live = tuple(
+    active_incomplete = tuple(
         sorted(
             record.source_id
             for record in records
             if record.disposition is ActivationDisposition.ACTIVE
-            and ActivationStage.LIVE_TESTED not in record.stages
+            and not record.is_fully_integrated
         )
     )
 
-    assert active_without_live
-    assert audit.unresolved == active_without_live
+    assert active_incomplete
+    assert audit.unresolved == active_incomplete
     assert audit.complete is False
     for record in records:
-        if record.source_id in active_without_live:
-            assert record.missing_integration_stages == (ActivationStage.LIVE_TESTED,)
+        if record.source_id in active_incomplete:
+            assert record.missing_integration_stages
 
 
-def test_reference_synthetic_is_only_fully_integrated_checked_in_source() -> None:
+def test_real_live_proofs_extend_fully_integrated_source_set() -> None:
     integrated = {
         record.source_id for record in _records() if record.is_fully_integrated
     }
 
-    assert integrated == {"reference-synthetic"}
+    assert integrated >= {
+        "reference-synthetic",
+        "ashby-job-board",
+        "recruitee-careers-site",
+    }
+    assert "teamtailor-public-jobs" not in integrated
 
 
 def test_public_web_sample_remains_disabled_after_terminalization() -> None:

--- a/tests/unit/source_activation/test_sa13_ats_activation.py
+++ b/tests/unit/source_activation/test_sa13_ats_activation.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from cip.modules.collection_orchestration.infrastructure.schedule_bundle import (
+    load_collection_schedule_bundle,
+)
+from cip.modules.provider_onboarding.infrastructure.registry import load_provider_profiles
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationStage,
+)
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+from cip.modules.source_portfolio.infrastructure.registry_bundle import (
+    load_source_portfolio_bundle,
+)
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+PORTFOLIO_PATH = Path("policies/source_portfolio.ats_expansion.yml")
+SCHEDULE_PATH = Path("policies/collection_schedules.ats_expansion.yml")
+ONBOARDING_PATH = Path("policies/provider_onboarding.yml")
+LIVE_WORKFLOW_PATH = Path(".github/workflows/sa13-live-validation.yml")
+
+
+def test_sa13_ashby_and_recruitee_are_real_live_integrations() -> None:
+    records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
+
+    for source_id in ("ashby-job-board", "recruitee-careers-site"):
+        record = records[source_id]
+        assert record.disposition is ActivationDisposition.ACTIVE
+        assert record.activation_wave == "SA-13"
+        assert record.is_fully_integrated
+        assert {
+            ActivationStage.ADAPTER_PRESENT,
+            ActivationStage.AUTHORIZED,
+            ActivationStage.EXECUTABLE,
+            ActivationStage.SCHEDULED,
+            ActivationStage.LIVE_TESTED,
+        } <= record.stages
+
+
+def test_sa13_teamtailor_stays_truthfully_incomplete_without_account_token() -> None:
+    records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
+    record = records["teamtailor-public-jobs"]
+
+    assert record.disposition is ActivationDisposition.ACTIVE
+    assert record.activation_wave == "SA-13"
+    assert ActivationStage.ADAPTER_PRESENT in record.stages
+    assert ActivationStage.AUTHORIZED in record.stages
+    assert ActivationStage.EXECUTABLE not in record.stages
+    assert ActivationStage.SCHEDULED not in record.stages
+    assert ActivationStage.LIVE_TESTED not in record.stages
+    assert record.is_fully_integrated is False
+
+
+def test_sa13_portfolio_and_schedules_match_runtime_state() -> None:
+    portfolio = {
+        entry.source_id: entry
+        for entry in load_source_portfolio_bundle(PORTFOLIO_PATH)
+    }
+    schedules = {
+        schedule.source_id: schedule
+        for schedule in load_collection_schedule_bundle(SCHEDULE_PATH)
+    }
+
+    assert portfolio["ashby-job-board"].executable is True
+    assert portfolio["recruitee-careers-site"].executable is True
+    assert portfolio["teamtailor-public-jobs"].executable is False
+    assert schedules["ashby-job-board"].enabled is True
+    assert schedules["recruitee-careers-site"].enabled is True
+    assert schedules["teamtailor-public-jobs"].enabled is False
+
+
+def test_sa13_provider_onboarding_uses_only_required_authentication() -> None:
+    profiles = {
+        profile.source_id: profile for profile in load_provider_profiles(ONBOARDING_PATH)
+    }
+
+    assert profiles["ashby-job-board"].required_secret_names == ()
+    assert profiles["recruitee-careers-site"].required_secret_names == ()
+    assert profiles["teamtailor-public-jobs"].required_secret_names == ("api_token",)
+    assert profiles["teamtailor-public-jobs"].automatic_onboarding is False
+
+
+def test_sa13_live_validation_executes_real_adapters() -> None:
+    workflow = LIVE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = Path("scripts/live_validate_sa13.py").read_text(encoding="utf-8")
+
+    assert "Controlled Ashby and Recruitee live validation" in workflow
+    assert "python scripts/live_validate_sa13.py" in workflow
+    assert "AshbyAdapter(" in script
+    assert "RecruiteeAdapter(" in script
+    assert "ashby_count < 1" in script
+    assert "recruitee_count < 1" in script
+
+
+def test_activation_inventory_bundle_rejects_duplicate_ids(tmp_path: Path) -> None:
+    base = tmp_path / "source_activation.yml"
+    base.write_text(
+        dedent(
+            """
+            version: 1
+            sources:
+              - source_id: duplicate
+                display_name: Duplicate
+                category: test
+                disposition: active
+                requires_schedule: false
+                stages: [catalogued]
+            """
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "source_activation.extra.yml").write_text(
+        dedent(
+            """
+            version: 1
+            sources:
+              - source_id: duplicate
+                display_name: Duplicate Again
+                category: test
+                disposition: active
+                requires_schedule: false
+                stages: [catalogued]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate source activation id"):
+        load_activation_inventory(base)


### PR DESCRIPTION
Implements issue #101 incrementally.

Current scope:
- real Ashby public Job Postings API adapter and enabled provider-owned target;
- real Recruitee Careers Site API adapter and enabled public target;
- Teamtailor Public Read adapter path with API-versioning, pagination and secret-aware execution;
- dedicated governance, portfolio, target and schedule bundles;
- runtime composition through the existing collection scheduler/worker and canonical hiring projection path.

Still draft until deterministic tests, controlled live validation, source-activation reconciliation and exact-head full CI are green. Teamtailor will not be marked live-tested without a real deployment Public Read token.