### PR TITLE
SA-12: activate PLACE awards and ADEME funding sources

### DIFF
--- a/.github/workflows/sa12-live-validation.yml
+++ b/.github/workflows/sa12-live-validation.yml
@@ -1,0 +1,33 @@
+name: SA-12 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa12-live-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-public-procurement-funding:
+    if: github.event.pull_request.head.ref == 'agent/sa12-procurement-funding-expansion'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled PLACE and ADEME live validation
+        run: python scripts/live_validate_sa12.py

--- a/docs/source_activation/SA_12_PROCUREMENT_FUNDING.md
+++ b/docs/source_activation/SA_12_PROCUREMENT_FUNDING.md
@@ -1,0 +1,100 @@
+# SA-12 — PLACE procurement awards and ADEME public funding
+
+## Result
+
+SA-12 adds two provider-specific, scheduled and controlled-live-tested public data integrations while reusing the existing collection scheduler, worker, source governance, immutable raw-observation path and canonical persistence modules.
+
+`place-awards` and `ademe-financial-aid` are promoted to `live_tested` only after the production adapters completed real provider acquisition. Normal CI is not treated as provider live proof.
+
+## PLACE — marchés publics conclus
+
+Source id: `place-awards`.
+
+Acquisition uses the official PLACE award-history dataset exposed by `data.economie.gouv.fr`. The adapter is GET-only, requests a selected set of procurement fields, uses bounded pages and response sizes, validates JSON strictly, applies Source Governance before network access, and maintains a latest-award checkpoint.
+
+Every collected award is retained as procurement history. Collection is not restricted to cyber-classified titles. The canonical service taxonomy may therefore be empty for an award, while the underlying procurement publication and contract remain evidence.
+
+The mapping emits:
+
+- an immutable `RawObservation` with source record type `procurement_award`;
+- a deterministic buyer organization scoped to the PLACE claim;
+- a `ProcurementPublication` of kind `AWARD` and procedure status `AWARDED`;
+- a `ProcurementContractProjection` with amount, notification date, optional awardee party and optional cyber service-family classification.
+
+A historical award is not a current procurement need, renewal or incumbent relationship by itself. Later fusion/scoring logic must preserve that temporal distinction.
+
+### PLACE live-provider drift handled
+
+Controlled live acquisition exposed provider details that deterministic fixtures had not captured:
+
+1. `annee_de_notification` is delivered as a year such as `"2017"`, not an ISO date;
+2. `geocode_att` is an object with `lon` and `lat`, not an array;
+3. some valid award rows have `nom_attributaire = null`.
+
+The final schema models those forms explicitly. Longitude/latitude remain bounded. A missing awardee never causes the contract to be discarded and never creates a synthetic supplier; the canonical contract is retained with `parties=()`.
+
+## ADEME — aides financières
+
+Source id: `ademe-financial-aid`.
+
+Acquisition uses the official ADEME Data Fair dataset through its public `/lines` API. The adapter is GET-only and selects only the fields required for public funding intelligence. It follows the provider `next` cursor with an exact HTTPS host/path check on every page, loop detection and a bounded page budget. The next cursor is persisted as the collection checkpoint.
+
+The provider keys are normalized inside the adapter only:
+
+- `_id` → canonical record id;
+- `nomBeneficiaire` → beneficiary name;
+- `objet` → funding object;
+- `nature` → aid nature;
+- `dateConvention` → event date;
+- `montant` → amount.
+
+Each row emits an immutable `RawObservation` plus a corporate-change `CONFIRMATION` claim with event type `FUNDING`. Beneficiary names remain unresolved (`organization_id=None`, `UNRESOLVED`) so a name-only match never becomes a canonical organization merge.
+
+Funding older than the configured current-context horizon, or funding whose date cannot be parsed safely, remains historical-only. Funding metadata does not create a current cyber need by itself.
+
+### ADEME live-provider drift handled
+
+Controlled live acquisition exposed several provider details and the adapter was corrected against them rather than weakening validation:
+
+1. the dataset uses `nomBeneficiaire` and `dateConvention`, not generic `nom` / `date` fields;
+2. Data Fair injects `_score: null` into returned rows even when it is not requested, so `_score` is modeled explicitly as optional provider metadata;
+3. cursor pages may omit `total`, so `total` is optional but remains non-negative whenever present.
+
+The schema remains `extra="forbid"`; unrelated new provider fields still fail closed as schema drift.
+
+## End-to-end persistence
+
+SA-12 extends `AdapterCollectionBatch` with `corporate_change_claims` and reuses the existing collection worker to call the existing `persist_change_claims` reconciliation path. No second worker, scheduler, source-health subsystem or funding persistence silo is introduced.
+
+PLACE continues through the existing procurement organization/publication/contract persistence path. ADEME continues through the existing corporate-change claim persistence path.
+
+## Controlled live validation
+
+The dedicated workflow `.github/workflows/sa12-live-validation.yml` executes `scripts/live_validate_sa12.py` against the real public endpoints using `PlaceAwardsAdapter` and `AdemeFundingAdapter` themselves.
+
+The live harness retains no provider payload and prints aggregate counts only. It fails unless both providers return non-empty observations and unless canonical projections/claims are preserved one-for-one.
+
+Successful controlled provider proof:
+
+- workflow run: `31474048440`;
+- source-code head for the proof: `1139c09857049b90cca176995148d4317a249949`;
+- PLACE public award observations: `500`;
+- PLACE procurement projections: `500`;
+- ADEME public aid observations: `500`;
+- ADEME funding claims: `500`.
+
+This proof justified adding `live_tested` to both Source Activation records. Because the documentation and activation commits that follow change the PR head, the workflow must pass again on the exact final merge candidate.
+
+## Completion gate
+
+SA-12 may be squash-merged only when:
+
+1. both provider-specific real adapters, governance policies, executable portfolio entries and enabled schedules are present;
+2. PLACE retains all acquired award history without converting historical awards into current needs;
+3. ADEME retains beneficiary names as unresolved funding claims rather than name-only entity merges;
+4. provider schemas explicitly lock all live drift observed during implementation;
+5. the existing worker persists PLACE procurement and ADEME corporate-change projections without a parallel subsystem;
+6. deterministic provider, checkpoint, governance, runtime, error-contract and activation tests pass;
+7. Ruff, strict Mypy, architecture/release checks, reversible migrations, branch-aware coverage and frontend checks pass;
+8. the dedicated SA-12 live workflow passes on the exact final PR head;
+9. reviews and review threads are clear before squash merge.

--- a/policies/collection_schedules.procurement_funding.yml
+++ b/policies/collection_schedules.procurement_funding.yml
@@ -1,0 +1,26 @@
+version: 1
+
+schedules:
+  - source_id: place-awards
+    adapter_id: place-open-data-awards-api
+    interval_seconds: 86400
+    lease_seconds: 300
+    enabled: true
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 60
+      max_delay_seconds: 3600
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 7200
+
+  - source_id: ademe-financial-aid
+    adapter_id: ademe-data-fair-financial-aid-api
+    interval_seconds: 900
+    lease_seconds: 300
+    enabled: true
+    retry:
+      max_attempts: 4
+      base_delay_seconds: 60
+      max_delay_seconds: 1800
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 3600

--- a/policies/source_activation.procurement_funding.yml
+++ b/policies/source_activation.procurement_funding.yml
@@ -14,6 +14,7 @@ sources:
       - authorized
       - executable
       - scheduled
+      - live_tested
 
   - source_id: ademe-financial-aid
     display_name: ADEME Aides financières API
@@ -28,3 +29,4 @@ sources:
       - authorized
       - executable
       - scheduled
+      - live_tested

--- a/policies/source_activation.procurement_funding.yml
+++ b/policies/source_activation.procurement_funding.yml
@@ -1,0 +1,30 @@
+version: 1
+
+sources:
+  - source_id: place-awards
+    display_name: PLACE Marchés publics conclus API
+    category: procurement
+    disposition: active
+    activation_wave: SA-12
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable
+      - scheduled
+
+  - source_id: ademe-financial-aid
+    display_name: ADEME Aides financières API
+    category: corporate_change
+    disposition: active
+    activation_wave: SA-12
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable
+      - scheduled

--- a/policies/source_portfolio.procurement_funding.yml
+++ b/policies/source_portfolio.procurement_funding.yml
@@ -1,0 +1,58 @@
+version: 1
+
+sources:
+  - source_id: place-awards
+    display_name: PLACE Marchés conclus
+    canonical_url: https://data.economie.gouv.fr/explore/dataset/marches-publics-conclus-recenses-sur-la-plateforme-des-achats-de-letat-/
+    category: procurement
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases:
+      - contract_history
+      - incumbent_discovery
+      - renewal_context
+    monthly_cost_limit: 0
+    adapter:
+      adapter_id: place-open-data-awards-api
+      adapter_version: "1"
+      provider_schema_version: place-awards-selected-fields-v1
+      modes:
+        - historical_backfill
+        - incremental_cursor
+      canonical_output_types:
+        - raw_observation
+        - procurement_publication
+        - procurement_contract
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 100
+      max_window_days: 3650
+      cost_per_request: 0
+
+  - source_id: ademe-financial-aid
+    display_name: ADEME Aides financières
+    canonical_url: https://data.ademe.fr/datasets/les-aides-financieres-de-l%27ademe
+    category: corporate_change
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases:
+      - funding_event_context
+      - transformation_program_context
+    monthly_cost_limit: 0
+    adapter:
+      adapter_id: ademe-data-fair-financial-aid-api
+      adapter_version: "1"
+      provider_schema_version: ademe-financial-aid-selected-fields-v1
+      modes:
+        - historical_backfill
+        - incremental_cursor
+      canonical_output_types:
+        - raw_observation
+        - corporate_change_claim
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 100
+      max_window_days: 3650
+      cost_per_request: 0

--- a/policies/sources.procurement_funding.yml
+++ b/policies/sources.procurement_funding.yml
@@ -1,0 +1,92 @@
+version: 1
+reviewed_at: 2026-08-11
+
+sources:
+  - id: place-awards
+    name: PLACE — marchés publics conclus
+    base_url: https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/marches-publics-conclus-recenses-sur-la-plateforme-des-achats-de-letat-/records
+    status: enabled
+    source_type: api
+    owner: Direction des achats de l'Etat
+    terms_url: https://data.economie.gouv.fr/explore/dataset/marches-publics-conclus-recenses-sur-la-plateforme-des-achats-de-letat-/information/
+    licence: Licence Ouverte 2.0
+    allowed_data_categories:
+      - contract_award
+      - organization_metadata
+    prohibited_data_categories:
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 4
+    retention_days: 3650
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: place-open-data-lo2-2026-08-11
+      reviewed_at: 2026-08-11T07:40:00Z
+      expires_at: null
+      approved_hosts:
+        - data.economie.gouv.fr
+      approved_path_prefixes:
+        - /api/explore/v2.1/catalog/datasets/marches-publics-conclus-recenses-sur-la-plateforme-des-achats-de-letat-/records
+      approved_purposes:
+        - procurement-history-intelligence
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: low
+      expected_stability: high
+    notes: >-
+      Official PLACE award history. An awarded historical contract is retained as
+      procurement evidence and never treated as a current procurement need by itself.
+
+  - id: ademe-financial-aid
+    name: ADEME — aides financières
+    base_url: https://data.ademe.fr/data-fair/api/v1/datasets/les-aides-financieres-de-l'ademe/lines
+    status: enabled
+    source_type: api
+    owner: ADEME
+    terms_url: https://data.ademe.fr/datasets/les-aides-financieres-de-l%27ademe
+    licence: Licence Ouverte 2.0
+    allowed_data_categories:
+      - public_result_metadata
+    prohibited_data_categories:
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 60
+    retention_days: 3650
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: ademe-open-data-lo2-2026-08-11
+      reviewed_at: 2026-08-11T07:40:00Z
+      expires_at: null
+      approved_hosts:
+        - data.ademe.fr
+      approved_path_prefixes:
+        - /data-fair/api/v1/datasets/les-aides-financieres-de-l'ademe/lines
+      approved_purposes:
+        - public-funding-intelligence
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: low
+      expected_stability: high
+    notes: >-
+      Official public funding results. Beneficiary names remain unresolved claims;
+      collection never turns a name-only match into a canonical organization merge.

--- a/scripts/live_validate_sa12.py
+++ b/scripts/live_validate_sa12.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+from cip.modules.collection_orchestration.application.ademe_funding_adapter import (
+    AdemeFundingAdapter,
+)
+from cip.modules.collection_orchestration.application.place_awards_adapter import (
+    PlaceAwardsAdapter,
+)
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+POLICY_PATH = Path("policies/sources.procurement_funding.yml")
+
+
+def main() -> None:
+    entries = {entry.policy.id: entry for entry in load_source_registry(POLICY_PATH)}
+    now = datetime.now(UTC)
+    retention_until = now + timedelta(days=3650)
+    place = PlaceAwardsAdapter(_entry(entries, "place-awards"), timeout_seconds=30)
+    ademe = AdemeFundingAdapter(
+        _entry(entries, "ademe-financial-aid"),
+        timeout_seconds=30,
+    )
+
+    place_batch = place.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=retention_until,
+    )
+    ademe_batch = ademe.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=retention_until,
+    )
+
+    place_count = len(place_batch.observations)
+    ademe_count = len(ademe_batch.observations)
+    if place_count < 1:
+        raise RuntimeError("PLACE live validation returned no public award records")
+    if len(place_batch.procurement_projections) != place_count:
+        raise RuntimeError("PLACE live validation lost procurement projections")
+    if ademe_count < 1:
+        raise RuntimeError("ADEME live validation returned no financial-aid records")
+    if len(ademe_batch.corporate_change_claims) != ademe_count:
+        raise RuntimeError("ADEME live validation lost funding claims")
+
+    print(
+        "SA-12 live validation passed: "
+        f"place_awards={place_count} "
+        f"place_procurement={len(place_batch.procurement_projections)} "
+        f"ademe_aids={ademe_count} "
+        f"ademe_funding_claims={len(ademe_batch.corporate_change_claims)}"
+    )
+
+
+def _entry(
+    entries: dict[str, SourceRegistryEntry],
+    source_id: str,
+) -> SourceRegistryEntry:
+    try:
+        return entries[source_id]
+    except KeyError as exc:
+        raise RuntimeError(f"missing live validation source policy: {source_id}") from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/ademe_funding/__init__.py
+++ b/src/cip/adapters/sources/ademe_funding/__init__.py
@@ -1,0 +1,1 @@
+"""ADEME public financial-aid source adapter."""

--- a/src/cip/adapters/sources/ademe_funding/client.py
+++ b/src/cip/adapters/sources/ademe_funding/client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import httpx
+
+
+class AdemeFundingResponseError(RuntimeError):
+    """ADEME Data Fair returned an unsafe or unusable response."""
+
+
+@dataclass(frozen=True, slots=True)
+class AdemeFundingFetchResult:
+    body: bytes
+    request_url: str
+
+
+class AdemeFundingClient:
+    PAGE_SIZE = 100
+    MAX_RESPONSE_BYTES = 5_000_000
+    SELECT_FIELDS = ("_id", "nom", "objet", "nature", "date", "montant")
+
+    def __init__(self, client: httpx.Client, *, lines_url: str) -> None:
+        self._client = client
+        self._lines_url = lines_url.rstrip("/")
+
+    def first_page_url(self) -> str:
+        query = urlencode(
+            {
+                "select": ",".join(self.SELECT_FIELDS),
+                "size": self.PAGE_SIZE,
+            }
+        )
+        return f"{self._lines_url}?{query}"
+
+    def fetch_url(self, url: str) -> AdemeFundingFetchResult:
+        response = self._client.get(url, headers={"Accept": "application/json"})
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return AdemeFundingFetchResult(body=response.content, request_url=str(response.url))
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    if content_type != "application/json":
+        raise AdemeFundingResponseError(
+            f"unexpected content type: {content_type or 'missing'}"
+        )
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise AdemeFundingResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise AdemeFundingResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise AdemeFundingResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/ademe_funding/client.py
+++ b/src/cip/adapters/sources/ademe_funding/client.py
@@ -19,7 +19,14 @@ class AdemeFundingFetchResult:
 class AdemeFundingClient:
     PAGE_SIZE = 100
     MAX_RESPONSE_BYTES = 5_000_000
-    SELECT_FIELDS = ("_id", "nom", "objet", "nature", "date", "montant")
+    SELECT_FIELDS = (
+        "_id",
+        "nomBeneficiaire",
+        "objet",
+        "nature",
+        "dateConvention",
+        "montant",
+    )
 
     def __init__(self, client: httpx.Client, *, lines_url: str) -> None:
         self._client = client

--- a/src/cip/adapters/sources/ademe_funding/collector.py
+++ b/src/cip/adapters/sources/ademe_funding/collector.py
@@ -59,7 +59,11 @@ def collect_ademe_funding(
     collected = require_aware_utc(collected_at, field_name="collected_at")
     if max_pages < 1:
         raise ValueError("max_pages must be positive")
-    current_url = checkpoint.next_url if checkpoint and checkpoint.next_url else client.first_page_url()
+    current_url = (
+        checkpoint.next_url
+        if checkpoint and checkpoint.next_url
+        else client.first_page_url()
+    )
     observations: list[RawObservation] = []
     claims: list[ChangeClaimSnapshot] = []
     visited: set[str] = set()

--- a/src/cip/adapters/sources/ademe_funding/collector.py
+++ b/src/cip/adapters/sources/ademe_funding/collector.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from urllib.parse import unquote, urljoin, urlsplit
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.ademe_funding.client import AdemeFundingClient
+from cip.adapters.sources.ademe_funding.mapper import map_ademe_funding_line
+from cip.adapters.sources.ademe_funding.schemas import AdemeFundingResponse
+from cip.modules.corporate_changes.domain.models import ChangeClaimSnapshot
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class AdemeFundingCollectionDeniedError(RuntimeError):
+    """Source governance denied ADEME funding collection."""
+
+
+class AdemeFundingSchemaError(RuntimeError):
+    """ADEME funding payload no longer matches the selected-field schema."""
+
+
+class AdemeFundingPaginationError(RuntimeError):
+    """ADEME returned an unsafe pagination cursor."""
+
+
+@dataclass(frozen=True, slots=True)
+class AdemeFundingCheckpoint:
+    next_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AdemeFundingCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    claims: tuple[ChangeClaimSnapshot, ...]
+    checkpoint: AdemeFundingCheckpoint
+    not_modified: bool
+
+
+def collect_ademe_funding(
+    client: AdemeFundingClient,
+    entry: SourceRegistryEntry,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: AdemeFundingCheckpoint | None = None,
+    max_pages: int = 5,
+) -> AdemeFundingCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    if max_pages < 1:
+        raise ValueError("max_pages must be positive")
+    current_url = checkpoint.next_url if checkpoint and checkpoint.next_url else client.first_page_url()
+    observations: list[RawObservation] = []
+    claims: list[ChangeClaimSnapshot] = []
+    visited: set[str] = set()
+    next_url: str | None = current_url
+
+    for _page_index in range(max_pages):
+        if next_url is None:
+            break
+        normalized = _validate_page_url(entry, next_url)
+        if normalized in visited:
+            raise AdemeFundingPaginationError("ADEME pagination loop detected")
+        visited.add(normalized)
+        _authorize(entry, normalized, collected_at=collected)
+        response = _parse_response(client.fetch_url(normalized).body)
+        for line in response.results:
+            observation, claim = map_ademe_funding_line(
+                line,
+                collection_job_id=collection_job_id,
+                collected_at=collected,
+                retention_until=retention_until,
+            )
+            observations.append(observation)
+            claims.append(claim)
+        next_url = _resolve_next(entry.policy.base_url, response.next)
+
+    return AdemeFundingCollectionBatch(
+        observations=tuple(observations),
+        claims=tuple(claims),
+        checkpoint=AdemeFundingCheckpoint(next_url=next_url),
+        not_modified=not observations,
+    )
+
+
+def _validate_page_url(entry: SourceRegistryEntry, url: str) -> str:
+    parsed = urlsplit(url)
+    base = urlsplit(entry.policy.base_url)
+    if parsed.scheme != "https" or parsed.hostname != base.hostname:
+        raise AdemeFundingPaginationError("ADEME pagination URL outside provider host")
+    path = unquote(parsed.path)
+    expected = unquote(base.path).rstrip("/")
+    if path.rstrip("/") != expected:
+        raise AdemeFundingPaginationError("ADEME pagination URL outside lines endpoint")
+    return url
+
+
+def _resolve_next(base_url: str, value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return urljoin(base_url, normalized)
+
+
+def _authorize(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    *,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=target_url,
+            purpose="public-funding-intelligence",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise AdemeFundingCollectionDeniedError(decision.reason.value)
+
+
+def _parse_response(body: bytes) -> AdemeFundingResponse:
+    try:
+        return AdemeFundingResponse.model_validate_json(body)
+    except ValidationError as exc:
+        raise AdemeFundingSchemaError(
+            "ADEME funding response schema validation failed"
+        ) from exc

--- a/src/cip/adapters/sources/ademe_funding/mapper.py
+++ b/src/cip/adapters/sources/ademe_funding/mapper.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from hashlib import sha256
+from uuid import UUID
+
+from cip.adapters.sources.ademe_funding.schemas import AdemeFundingLine
+from cip.modules.corporate_changes.domain.models import (
+    ChangeClaimSnapshot,
+    ChangeClaimType,
+    ChangeEventType,
+    ChangeSourceKind,
+    OrganizationLinkStatus,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.shared.kernel.time import require_aware_utc
+
+SOURCE_ID = "ademe-financial-aid"
+ADAPTER_ID = "ademe-data-fair-financial-aid-api"
+ADAPTER_VERSION = "1.0.0"
+DATASET_URL = "https://data.ademe.fr/datasets/les-aides-financieres-de-l%27ademe"
+
+
+def map_ademe_funding_line(
+    line: AdemeFundingLine,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> tuple[RawObservation, ChangeClaimSnapshot]:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    payload_hash = _payload_hash(line)
+    event_at = _event_timestamp(line.date)
+    observation = RawObservation(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        collection_job_id=collection_job_id,
+        source_record_type="public_funding_award",
+        source_record_key=line.id,
+        source_url=DATASET_URL,
+        payload_hash_sha256=payload_hash,
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        collected_at=collected,
+        published_at=event_at,
+        source_updated_at=event_at,
+        schema_fingerprint="ademe-financial-aid-selected-fields-1",
+        content_language="fr",
+        classification="internal",
+        retention_until=retention_until,
+    )
+    claim = ChangeClaimSnapshot(
+        source_id=SOURCE_ID,
+        source_kind=ChangeSourceKind.REGULATOR,
+        source_record_key=line.id,
+        article_id=line.id,
+        source_url=DATASET_URL,
+        event_key=f"ademe-funding:{line.id}",
+        claim_type=ChangeClaimType.CONFIRMATION,
+        event_type=ChangeEventType.FUNDING,
+        title=f"Aide ADEME — {line.nom}",
+        excerpt=_excerpt(line),
+        claimed_organization_name=line.nom,
+        organization_id=None,
+        organization_link_status=OrganizationLinkStatus.UNRESOLVED,
+        published_at=collected,
+        modified_at=collected,
+        event_at=event_at,
+        independence_key=SOURCE_ID,
+        confidence=0.92,
+        historical_only=(
+            event_at is None or event_at < collected - timedelta(days=180)
+        ),
+        metadata_only=True,
+    )
+    return observation, claim
+
+
+def _excerpt(line: AdemeFundingLine) -> str:
+    text = (
+        f"Bénéficiaire: {line.nom}. Nature: {line.nature}. "
+        f"Montant: {line.montant} EUR. Objet: {line.objet}. Date: {line.date}."
+    )
+    return text[:500]
+
+
+def _event_timestamp(value: str) -> datetime | None:
+    candidate = value.strip()[:10]
+    try:
+        parsed = date.fromisoformat(candidate)
+    except ValueError:
+        return None
+    return datetime.combine(parsed, datetime.min.time(), UTC)
+
+
+def _payload_hash(line: AdemeFundingLine) -> str:
+    encoded = json.dumps(
+        line.model_dump(mode="json", by_alias=True),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return sha256(encoded).hexdigest()

--- a/src/cip/adapters/sources/ademe_funding/schemas.py
+++ b/src/cip/adapters/sources/ademe_funding/schemas.py
@@ -9,10 +9,10 @@ class AdemeFundingLine(BaseModel):
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
     id: str = Field(alias="_id")
-    nom: str
+    nom: str = Field(alias="nomBeneficiaire")
     objet: str
     nature: str
-    date: str
+    date: str = Field(alias="dateConvention")
     montant: Decimal
 
     @field_validator("id", "nom", "objet", "nature", "date")

--- a/src/cip/adapters/sources/ademe_funding/schemas.py
+++ b/src/cip/adapters/sources/ademe_funding/schemas.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class AdemeFundingLine(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    id: str = Field(alias="_id")
+    nom: str
+    objet: str
+    nature: str
+    date: str
+    montant: Decimal
+
+    @field_validator("id", "nom", "objet", "nature", "date")
+    @classmethod
+    def _required_text(cls, value: str) -> str:
+        if not value:
+            raise ValueError("required ADEME funding field cannot be blank")
+        return value
+
+    @field_validator("montant")
+    @classmethod
+    def _non_negative_amount(cls, value: Decimal) -> Decimal:
+        if value < 0:
+            raise ValueError("ADEME funding amount cannot be negative")
+        return value
+
+
+class AdemeFundingResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    total: int
+    results: tuple[AdemeFundingLine, ...]
+    next: str | None = None
+
+    @field_validator("total")
+    @classmethod
+    def _non_negative_total(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("ADEME total cannot be negative")
+        return value

--- a/src/cip/adapters/sources/ademe_funding/schemas.py
+++ b/src/cip/adapters/sources/ademe_funding/schemas.py
@@ -34,13 +34,13 @@ class AdemeFundingLine(BaseModel):
 class AdemeFundingResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    total: int
+    total: int | None = None
     results: tuple[AdemeFundingLine, ...]
     next: str | None = None
 
     @field_validator("total")
     @classmethod
-    def _non_negative_total(cls, value: int) -> int:
-        if value < 0:
+    def _non_negative_total(cls, value: int | None) -> int | None:
+        if value is not None and value < 0:
             raise ValueError("ADEME total cannot be negative")
         return value

--- a/src/cip/adapters/sources/ademe_funding/schemas.py
+++ b/src/cip/adapters/sources/ademe_funding/schemas.py
@@ -14,6 +14,7 @@ class AdemeFundingLine(BaseModel):
     nature: str
     date: str = Field(alias="dateConvention")
     montant: Decimal
+    score: float | None = Field(default=None, alias="_score")
 
     @field_validator("id", "nom", "objet", "nature", "date")
     @classmethod

--- a/src/cip/adapters/sources/place_awards/__init__.py
+++ b/src/cip/adapters/sources/place_awards/__init__.py
@@ -1,0 +1,1 @@
+"""PLACE public procurement award source adapter."""

--- a/src/cip/adapters/sources/place_awards/client.py
+++ b/src/cip/adapters/sources/place_awards/client.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+
+class PlaceSourceResponseError(RuntimeError):
+    """PLACE open-data API returned an unsafe or unusable response."""
+
+
+@dataclass(frozen=True, slots=True)
+class PlaceFetchResult:
+    body: bytes
+
+
+class PlaceAwardsClient:
+    PAGE_SIZE = 100
+    MAX_RESPONSE_BYTES = 5_000_000
+    SELECT_FIELDS = (
+        "annee_de_notification",
+        "entite_publique",
+        "entite_d_achat",
+        "code_postal_entite_d_achat",
+        "nom_attributaire",
+        "siret_attributaire",
+        "date_de_notification",
+        "code_postal_attributaire",
+        "ville",
+        "nature_du_marche",
+        "objet_du_marche",
+        "tranche_budgetaire",
+        "montant",
+        "attributaire_est_une_pme",
+        "geocode_att",
+    )
+
+    def __init__(self, client: httpx.Client, *, records_url: str) -> None:
+        self._client = client
+        self._records_url = records_url
+
+    def fetch_page(self, *, offset: int) -> PlaceFetchResult:
+        if offset < 0 or offset % self.PAGE_SIZE != 0:
+            raise ValueError("PLACE offset must be a non-negative page boundary")
+        response = self._client.get(
+            self._records_url,
+            headers={"Accept": "application/json"},
+            params={
+                "select": ",".join(self.SELECT_FIELDS),
+                "order_by": "date_de_notification DESC,entite_publique ASC",
+                "limit": self.PAGE_SIZE,
+                "offset": offset,
+            },
+        )
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return PlaceFetchResult(body=response.content)
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    if content_type != "application/json":
+        raise PlaceSourceResponseError(
+            f"unexpected content type: {content_type or 'missing'}"
+        )
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise PlaceSourceResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise PlaceSourceResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise PlaceSourceResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/place_awards/collector.py
+++ b/src/cip/adapters/sources/place_awards/collector.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.place_awards.client import PlaceAwardsClient
+from cip.adapters.sources.place_awards.mapper import map_place_award
+from cip.adapters.sources.place_awards.schemas import PlaceAwardsResponse
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.procurement_history.domain.models import ProcurementHistoryProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class PlaceCollectionDeniedError(RuntimeError):
+    """Source governance denied PLACE award collection."""
+
+
+class PlaceSourceSchemaError(RuntimeError):
+    """PLACE payload no longer matches the selected-field schema."""
+
+
+class PlaceSourceWindowError(RuntimeError):
+    """The PLACE checkpoint was not reached inside the bounded page window."""
+
+
+@dataclass(frozen=True, slots=True)
+class PlaceCheckpoint:
+    latest_source_record_key: str | None = None
+    latest_notification_date: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PlaceCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    buyers: tuple[Organization, ...]
+    procurement: tuple[ProcurementHistoryProjection, ...]
+    checkpoint: PlaceCheckpoint
+    not_modified: bool
+
+
+def collect_place_awards(
+    client: PlaceAwardsClient,
+    entry: SourceRegistryEntry,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: PlaceCheckpoint | None = None,
+    max_pages: int = 5,
+) -> PlaceCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    _authorize(entry, collected_at=collected)
+    if max_pages < 1:
+        raise ValueError("max_pages must be positive")
+    previous = checkpoint.latest_source_record_key if checkpoint else None
+    observations: list[RawObservation] = []
+    buyers: dict[UUID, Organization] = {}
+    procurement: list[ProcurementHistoryProjection] = []
+    newest_key: str | None = None
+    newest_date: str | None = None
+    checkpoint_reached = False
+    last_page_size = 0
+    total_count = 0
+
+    for page_index in range(max_pages):
+        response = _parse_response(
+            client.fetch_page(offset=page_index * client.PAGE_SIZE).body
+        )
+        total_count = response.total_count
+        last_page_size = len(response.results)
+        for award in response.results:
+            mapped = map_place_award(
+                award,
+                collection_job_id=collection_job_id,
+                collected_at=collected,
+                retention_until=retention_until,
+            )
+            record_key = mapped.observation.source_record_key
+            if newest_key is None:
+                newest_key = record_key
+                newest_date = award.date_de_notification.isoformat()
+            if previous is not None and record_key == previous:
+                checkpoint_reached = True
+                break
+            observations.append(mapped.observation)
+            buyers[mapped.buyer.id] = mapped.buyer
+            procurement.append(mapped.procurement)
+        if checkpoint_reached or last_page_size < client.PAGE_SIZE:
+            break
+
+    if (
+        previous is not None
+        and not checkpoint_reached
+        and last_page_size == client.PAGE_SIZE
+        and total_count > max_pages * client.PAGE_SIZE
+    ):
+        raise PlaceSourceWindowError(
+            "PLACE checkpoint was not reached within the configured page budget"
+        )
+
+    next_checkpoint = PlaceCheckpoint(
+        latest_source_record_key=newest_key or previous,
+        latest_notification_date=(
+            newest_date or (checkpoint.latest_notification_date if checkpoint else None)
+        ),
+    )
+    return PlaceCollectionBatch(
+        observations=tuple(observations),
+        buyers=tuple(buyers.values()),
+        procurement=tuple(procurement),
+        checkpoint=next_checkpoint,
+        not_modified=bool(previous is not None and newest_key == previous),
+    )
+
+
+def _authorize(entry: SourceRegistryEntry, *, collected_at: datetime) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.CONTRACT_AWARD,
+            target_url=entry.policy.base_url,
+            purpose="procurement-history-intelligence",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise PlaceCollectionDeniedError(decision.reason.value)
+
+
+def _parse_response(body: bytes) -> PlaceAwardsResponse:
+    try:
+        return PlaceAwardsResponse.model_validate_json(body)
+    except ValidationError as exc:
+        raise PlaceSourceSchemaError("PLACE response schema validation failed") from exc

--- a/src/cip/adapters/sources/place_awards/mapper.py
+++ b/src/cip/adapters/sources/place_awards/mapper.py
@@ -53,6 +53,7 @@ def map_place_award(
     payload_hash = _payload_hash(award)
     source_record_key = _source_record_key(award)
     buyer = _buyer(award, collected_at=collected)
+    awardee = _awardee(award)
     published_at = datetime.combine(award.date_de_notification, datetime.min.time(), UTC)
     observation = RawObservation(
         source_id=SOURCE_ID,
@@ -102,7 +103,7 @@ def map_place_award(
         title=award.objet_du_marche,
         status=ContractStatus.AWARDED,
         confidence=0.9,
-        parties=(_awardee(award),),
+        parties=(awardee,) if awardee is not None else (),
         service_families=classify_service_families(award.searchable_text()),
         amount=(
             MoneyAmount(value=award.montant, currency="EUR")
@@ -132,7 +133,9 @@ def _buyer(award: PlaceAward, *, collected_at: datetime) -> Organization:
     )
 
 
-def _awardee(award: PlaceAward) -> ProcurementParty:
+def _awardee(award: PlaceAward) -> ProcurementParty | None:
+    if award.nom_attributaire is None:
+        return None
     siret = _normalized_siret(award.siret_attributaire)
     return ProcurementParty(
         role=ProcurementPartyRole.AWARDEE,

--- a/src/cip/adapters/sources/place_awards/mapper.py
+++ b/src/cip/adapters/sources/place_awards/mapper.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from cip.adapters.sources.place_awards.schemas import PlaceAward
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.procurement_history.domain.models import (
+    ContractStatus,
+    DateBasis,
+    MoneyAmount,
+    PartyResolutionStatus,
+    ProcurementContractProjection,
+    ProcurementHistoryProjection,
+    ProcurementParty,
+    ProcurementPartyRole,
+    ProcurementProcedureStatus,
+    ProcurementPublication,
+    ProcurementPublicationKind,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.service_taxonomy.domain.classifier import classify_service_families
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.shared.kernel.time import require_aware_utc
+
+SOURCE_ID = "place-awards"
+ADAPTER_ID = "place-open-data-awards-api"
+ADAPTER_VERSION = "1.0.0"
+DATASET_URL = (
+    "https://data.economie.gouv.fr/explore/dataset/"
+    "marches-publics-conclus-recenses-sur-la-plateforme-des-achats-de-letat-/"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PlaceAwardMapping:
+    observation: RawObservation
+    buyer: Organization
+    procurement: ProcurementHistoryProjection
+
+
+def map_place_award(
+    award: PlaceAward,
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> PlaceAwardMapping:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    payload_hash = _payload_hash(award)
+    source_record_key = _source_record_key(award)
+    buyer = _buyer(award, collected_at=collected)
+    published_at = datetime.combine(award.date_de_notification, datetime.min.time(), UTC)
+    observation = RawObservation(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        collection_job_id=collection_job_id,
+        source_record_type="procurement_award",
+        source_record_key=source_record_key,
+        source_url=DATASET_URL,
+        payload_hash_sha256=payload_hash,
+        data_categories=frozenset({DataCategory.CONTRACT_AWARD}),
+        collected_at=collected,
+        published_at=published_at,
+        source_updated_at=published_at,
+        schema_fingerprint="place-awards-selected-fields-1",
+        content_language="fr",
+        classification="internal",
+        retention_until=retention_until,
+    )
+    procedure_key = f"place:procedure:{source_record_key}"
+    publication = ProcurementPublication(
+        id=uuid5(NAMESPACE_URL, f"place:publication:{source_record_key}:{payload_hash}"),
+        procedure_key=procedure_key,
+        source_id=SOURCE_ID,
+        source_record_key=source_record_key,
+        source_url=DATASET_URL,
+        kind=ProcurementPublicationKind.AWARD,
+        procedure_status=ProcurementProcedureStatus.AWARDED,
+        buyer_organization_id=buyer.id,
+        title=award.objet_du_marche,
+        content_hash_sha256=payload_hash,
+        collected_at=collected,
+        published_at=published_at,
+        details={
+            "public_entity": award.entite_publique,
+            "purchasing_entity": award.entite_d_achat,
+            "buyer_postal_code": award.code_postal_entite_d_achat,
+            "market_nature": award.nature_du_marche,
+            "budget_band": award.tranche_budgetaire,
+            "awardee_is_sme": award.attributaire_est_une_pme,
+        },
+    )
+    contract = ProcurementContractProjection(
+        contract_key=f"place:contract:{source_record_key}",
+        procedure_key=procedure_key,
+        buyer_organization_id=buyer.id,
+        title=award.objet_du_marche,
+        status=ContractStatus.AWARDED,
+        confidence=0.9,
+        parties=(_awardee(award),),
+        service_families=classify_service_families(award.searchable_text()),
+        amount=(
+            MoneyAmount(value=award.montant, currency="EUR")
+            if award.montant is not None
+            else None
+        ),
+        notification_date=award.date_de_notification,
+        notification_date_basis=DateBasis.PUBLISHED,
+    )
+    return PlaceAwardMapping(
+        observation=observation,
+        buyer=buyer,
+        procurement=ProcurementHistoryProjection(publication=publication, contract=contract),
+    )
+
+
+def _buyer(award: PlaceAward, *, collected_at: datetime) -> Organization:
+    name = award.buyer_name()
+    normalized = " ".join(name.casefold().split())
+    return Organization(
+        id=uuid5(NAMESPACE_URL, f"place:buyer-name:{normalized}"),
+        canonical_name=name,
+        legal_name=name,
+        country_code="FR",
+        created_at=collected_at,
+        updated_at=collected_at,
+    )
+
+
+def _awardee(award: PlaceAward) -> ProcurementParty:
+    siret = _normalized_siret(award.siret_attributaire)
+    return ProcurementParty(
+        role=ProcurementPartyRole.AWARDEE,
+        published_name=award.nom_attributaire,
+        resolution_status=PartyResolutionStatus.UNRESOLVED,
+        confidence=0.84 if siret else 0.7,
+        official_identifier=f"SIRET:{siret}" if siret else None,
+    )
+
+
+def _source_record_key(award: PlaceAward) -> str:
+    identity = {
+        "buyer": award.buyer_name(),
+        "awardee": award.nom_attributaire,
+        "awardee_siret": _normalized_siret(award.siret_attributaire),
+        "date": award.date_de_notification.isoformat(),
+        "object": award.objet_du_marche,
+        "amount": str(award.montant) if award.montant is not None else None,
+        "nature": award.nature_du_marche,
+    }
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    return sha256(encoded).hexdigest()
+
+
+def _payload_hash(award: PlaceAward) -> str:
+    encoded = json.dumps(
+        award.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return sha256(encoded).hexdigest()
+
+
+def _normalized_siret(value: str | None) -> str | None:
+    if value is None:
+        return None
+    digits = "".join(character for character in value if character.isdigit())
+    return digits if len(digits) == 14 else None

--- a/src/cip/adapters/sources/place_awards/schemas.py
+++ b/src/cip/adapters/sources/place_awards/schemas.py
@@ -20,7 +20,7 @@ class PlaceAward(BaseModel):
     entite_publique: str
     entite_d_achat: str | None = None
     code_postal_entite_d_achat: str | None = None
-    nom_attributaire: str
+    nom_attributaire: str | None = None
     siret_attributaire: str | None = None
     date_de_notification: date
     code_postal_attributaire: str | None = None
@@ -32,12 +32,17 @@ class PlaceAward(BaseModel):
     attributaire_est_une_pme: str | None = None
     geocode_att: PlaceGeoPoint | None = None
 
-    @field_validator("entite_publique", "nom_attributaire", "objet_du_marche")
+    @field_validator("entite_publique", "objet_du_marche")
     @classmethod
     def _required_text(cls, value: str) -> str:
         if not value:
             raise ValueError("required PLACE text field cannot be blank")
         return value
+
+    @field_validator("nom_attributaire")
+    @classmethod
+    def _optional_awardee(cls, value: str | None) -> str | None:
+        return value or None
 
     @field_validator("annee_de_notification")
     @classmethod

--- a/src/cip/adapters/sources/place_awards/schemas.py
+++ b/src/cip/adapters/sources/place_awards/schemas.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class PlaceGeoPoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lon: float = Field(ge=-180, le=180)
+    lat: float = Field(ge=-90, le=90)
 
 
 class PlaceAward(BaseModel):
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
-    annee_de_notification: date | None = None
+    annee_de_notification: int | None = None
     entite_publique: str
     entite_d_achat: str | None = None
     code_postal_entite_d_achat: str | None = None
@@ -23,13 +30,20 @@ class PlaceAward(BaseModel):
     tranche_budgetaire: str | None = None
     montant: Decimal | None = None
     attributaire_est_une_pme: str | None = None
-    geocode_att: tuple[float, float] | None = None
+    geocode_att: PlaceGeoPoint | None = None
 
     @field_validator("entite_publique", "nom_attributaire", "objet_du_marche")
     @classmethod
     def _required_text(cls, value: str) -> str:
         if not value:
             raise ValueError("required PLACE text field cannot be blank")
+        return value
+
+    @field_validator("annee_de_notification")
+    @classmethod
+    def _valid_notification_year(cls, value: int | None) -> int | None:
+        if value is not None and not 1900 <= value <= 2100:
+            raise ValueError("PLACE notification year is outside supported bounds")
         return value
 
     @field_validator("montant")

--- a/src/cip/adapters/sources/place_awards/schemas.py
+++ b/src/cip/adapters/sources/place_awards/schemas.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class PlaceAward(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    annee_de_notification: date | None = None
+    entite_publique: str
+    entite_d_achat: str | None = None
+    code_postal_entite_d_achat: str | None = None
+    nom_attributaire: str
+    siret_attributaire: str | None = None
+    date_de_notification: date
+    code_postal_attributaire: str | None = None
+    ville: str | None = None
+    nature_du_marche: str | None = None
+    objet_du_marche: str
+    tranche_budgetaire: str | None = None
+    montant: Decimal | None = None
+    attributaire_est_une_pme: str | None = None
+    geocode_att: tuple[float, float] | None = None
+
+    @field_validator("entite_publique", "nom_attributaire", "objet_du_marche")
+    @classmethod
+    def _required_text(cls, value: str) -> str:
+        if not value:
+            raise ValueError("required PLACE text field cannot be blank")
+        return value
+
+    @field_validator("montant")
+    @classmethod
+    def _non_negative_amount(cls, value: Decimal | None) -> Decimal | None:
+        if value is not None and value < 0:
+            raise ValueError("PLACE amount cannot be negative")
+        return value
+
+    def buyer_name(self) -> str:
+        return self.entite_d_achat or self.entite_publique
+
+    def searchable_text(self) -> str:
+        return " ".join(
+            value
+            for value in (
+                self.entite_publique,
+                self.entite_d_achat,
+                self.nature_du_marche,
+                self.objet_du_marche,
+                self.nom_attributaire,
+            )
+            if value
+        )
+
+
+class PlaceAwardsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    total_count: int
+    results: tuple[PlaceAward, ...]
+
+    @field_validator("total_count")
+    @classmethod
+    def _non_negative_total(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("PLACE total_count cannot be negative")
+        return value

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -37,6 +37,9 @@ from cip.modules.collection_orchestration.application.passive_infrastructure_reg
     register_passive_infrastructure_adapters,
 )
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.collection_orchestration.application.procurement_funding_registration import (
+    register_procurement_funding_adapters,
+)
 from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
 from cip.modules.collection_orchestration.application.reference_adapter import (
     ReferencePortfolioAdapter,
@@ -96,6 +99,11 @@ def build_runtime_adapters(
         inputs.recruitee_sites,
         inputs.teamtailor_accounts,
         teamtailor_token_provider=teamtailor_token_provider,
+        timeout_seconds=timeout_seconds,
+    )
+    register_procurement_funding_adapters(
+        adapters,
+        entries_by_id,
         timeout_seconds=timeout_seconds,
     )
     register_identity_adapters(

--- a/src/cip/modules/collection_orchestration/application/ademe_funding_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/ademe_funding_adapter.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.ademe_funding.client import (
+    AdemeFundingClient,
+    AdemeFundingResponseError,
+)
+from cip.adapters.sources.ademe_funding.collector import (
+    AdemeFundingCheckpoint,
+    AdemeFundingCollectionDeniedError,
+    AdemeFundingPaginationError,
+    AdemeFundingSchemaError,
+    collect_ademe_funding,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class AdemeFundingAdapter:
+    source_id = "ademe-financial-aid"
+    adapter_id = "ademe-data-fair-financial-aid-api"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("ADEME funding adapter requires its source policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_ademe_funding(
+                    AdemeFundingClient(
+                        http_client,
+                        lines_url=self._entry.policy.base_url,
+                    ),
+                    self._entry,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except AdemeFundingCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except AdemeFundingSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except AdemeFundingPaginationError as exc:
+            raise _execution_error(exc, "unsafe_pagination", retryable=False) from exc
+        except AdemeFundingResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"ADEME funding returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={"next_url": batch.checkpoint.next_url},
+            not_modified=batch.not_modified,
+            corporate_change_claims=batch.claims,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> AdemeFundingCheckpoint | None:
+    if payload is None:
+        return None
+    value = payload.get("next_url")
+    if value is not None and not isinstance(value, str):
+        raise AdapterExecutionError(
+            "ADEME next_url checkpoint must be a string or null",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    return AdemeFundingCheckpoint(next_url=value)
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/collection_orchestration/application/place_awards_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/place_awards_adapter.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.place_awards.client import (
+    PlaceAwardsClient,
+    PlaceSourceResponseError,
+)
+from cip.adapters.sources.place_awards.collector import (
+    PlaceCheckpoint,
+    PlaceCollectionDeniedError,
+    PlaceSourceSchemaError,
+    PlaceSourceWindowError,
+    collect_place_awards,
+)
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class PlaceAwardsAdapter:
+    source_id = "place-awards"
+    adapter_id = "place-open-data-awards-api"
+    data_category = DataCategory.CONTRACT_AWARD
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("PLACE adapter requires its source policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_place_awards(
+                    PlaceAwardsClient(
+                        http_client,
+                        records_url=self._entry.policy.base_url,
+                    ),
+                    self._entry,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except PlaceCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except PlaceSourceSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except PlaceSourceWindowError as exc:
+            raise _execution_error(exc, "source_window_exceeded", retryable=False) from exc
+        except PlaceSourceResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"PLACE returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={
+                "latest_source_record_key": batch.checkpoint.latest_source_record_key,
+                "latest_notification_date": batch.checkpoint.latest_notification_date,
+            },
+            not_modified=batch.not_modified,
+            procurement_organizations=batch.buyers,
+            procurement_projections=batch.procurement,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> PlaceCheckpoint | None:
+    if payload is None:
+        return None
+    key = payload.get("latest_source_record_key")
+    date_value = payload.get("latest_notification_date")
+    if key is not None and not isinstance(key, str):
+        raise _invalid_checkpoint()
+    if date_value is not None and not isinstance(date_value, str):
+        raise _invalid_checkpoint()
+    return PlaceCheckpoint(key, date_value)
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "PLACE checkpoint fields must be strings or null",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/collection_orchestration/application/ports.py
+++ b/src/cip/modules/collection_orchestration/application/ports.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Protocol
 from uuid import UUID
 
+from cip.modules.corporate_changes.domain.models import ChangeClaimSnapshot
 from cip.modules.evidence.domain.entities import Evidence
 from cip.modules.incident_intelligence.domain.models import IncidentClaimSnapshot
 from cip.modules.opportunities.domain.entities import CommercialSignal
@@ -53,6 +54,7 @@ class AdapterCollectionBatch:
     vulnerability_snapshots: tuple[VulnerabilitySnapshot, ...] = ()
     passive_exposure_projections: tuple[PassiveObservationSnapshot, ...] = ()
     incident_claims: tuple[IncidentClaimSnapshot, ...] = ()
+    corporate_change_claims: tuple[ChangeClaimSnapshot, ...] = ()
     threat_indicator_snapshots: tuple[IndicatorSnapshot, ...] = ()
     quota_remaining: int | None = None
     request_cost: float = 0.0

--- a/src/cip/modules/collection_orchestration/application/procurement_funding_registration.py
+++ b/src/cip/modules/collection_orchestration/application/procurement_funding_registration.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from cip.modules.collection_orchestration.application.ademe_funding_adapter import (
+    AdemeFundingAdapter,
+)
+from cip.modules.collection_orchestration.application.place_awards_adapter import (
+    PlaceAwardsAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import CollectionAdapter
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+def register_procurement_funding_adapters(
+    adapters: dict[tuple[str, str], CollectionAdapter],
+    entries_by_id: dict[str, SourceRegistryEntry],
+    *,
+    timeout_seconds: float,
+) -> None:
+    for adapter_type in (PlaceAwardsAdapter, AdemeFundingAdapter):
+        entry = entries_by_id.get(adapter_type.source_id)
+        if entry is None:
+            continue
+        adapter = adapter_type(entry, timeout_seconds=timeout_seconds)
+        identity = (adapter.source_id, adapter.adapter_id)
+        if identity in adapters:
+            raise ValueError(f"duplicate runtime adapter: {identity[0]}/{identity[1]}")
+        adapters[identity] = adapter

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -138,6 +138,7 @@ def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
         settings.source_registry_path,
         settings.identity_source_registry_path,
         settings.decp_source_registry_path,
+        settings.procurement_funding_source_registry_path,
         settings.public_web_source_registry_path,
         settings.vulnerability_source_registry_path,
         settings.search_archive_source_registry_path,
@@ -157,6 +158,7 @@ def _load_portfolio(settings: Settings) -> tuple[SourceCatalogEntry, ...]:
     return load_source_portfolio_bundle(
         settings.source_portfolio_path,
         settings.decp_source_portfolio_path,
+        settings.procurement_funding_source_portfolio_path,
         settings.public_web_source_portfolio_path,
         settings.vulnerability_source_portfolio_path,
         settings.search_archive_source_portfolio_path,
@@ -215,6 +217,7 @@ def _load_schedules(settings: Settings) -> tuple[SourceSchedule, ...]:
     return load_collection_schedule_bundle(
         settings.collection_schedule_path,
         settings.decp_collection_schedule_path,
+        settings.procurement_funding_collection_schedule_path,
         settings.public_web_collection_schedule_path,
         settings.vulnerability_collection_schedule_path,
         settings.search_archive_collection_schedule_path,

--- a/src/cip/modules/collection_orchestration/application/worker.py
+++ b/src/cip/modules/collection_orchestration/application/worker.py
@@ -22,6 +22,7 @@ from cip.modules.collection_orchestration.infrastructure.repository import (
     complete_job,
     fail_job,
 )
+from cip.modules.corporate_changes.infrastructure.projections import persist_change_claims
 from cip.modules.data_governance.domain.retention import RetentionPolicy
 from cip.modules.incident_intelligence.infrastructure.projections import persist_incident_claims
 from cip.modules.opportunities.infrastructure.projections import (
@@ -202,6 +203,7 @@ def _complete_success(
             now=now,
         )
         persist_incident_claims(session, batch.incident_claims, now=now)
+        persist_change_claims(session, batch.corporate_change_claims, now=now)
         persist_indicator_snapshots(
             session,
             batch.threat_indicator_snapshots,

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -25,6 +25,9 @@ class Settings(BaseSettings):
     source_registry_path: Path = Path("policies/sources.example.yml")
     identity_source_registry_path: Path = Path("policies/identity_sources.yml")
     decp_source_registry_path: Path = Path("policies/sources.decp.yml")
+    procurement_funding_source_registry_path: Path = Path(
+        "policies/sources.procurement_funding.yml"
+    )
     public_web_source_registry_path: Path = Path("policies/sources.public_web.yml")
     vulnerability_source_registry_path: Path = Path("policies/sources.vulnerability.yml")
     search_archive_source_registry_path: Path = Path(
@@ -52,6 +55,9 @@ class Settings(BaseSettings):
     provider_onboarding_registry_path: Path = Path("policies/provider_onboarding.yml")
     source_portfolio_path: Path = Path("policies/source_portfolio.yml")
     decp_source_portfolio_path: Path = Path("policies/source_portfolio.decp.yml")
+    procurement_funding_source_portfolio_path: Path = Path(
+        "policies/source_portfolio.procurement_funding.yml"
+    )
     public_web_source_portfolio_path: Path = Path(
         "policies/source_portfolio.public_web.yml"
     )
@@ -116,6 +122,9 @@ class Settings(BaseSettings):
     retention_policy_path: Path = Path("policies/retention.yml")
     collection_schedule_path: Path = Path("policies/collection_schedules.yml")
     decp_collection_schedule_path: Path = Path("policies/collection_schedules.decp.yml")
+    procurement_funding_collection_schedule_path: Path = Path(
+        "policies/collection_schedules.procurement_funding.yml"
+    )
     public_web_collection_schedule_path: Path = Path(
         "policies/collection_schedules.public_web.yml"
     )

--- a/tests/unit/adapters/ademe_funding/test_source.py
+++ b/tests/unit/adapters/ademe_funding/test_source.py
@@ -40,6 +40,10 @@ BASE_URL = (
     "https://data.ademe.fr/data-fair/api/v1/datasets/"
     "les-aides-financieres-de-l'ademe/lines"
 )
+SELECT_QUERY = (
+    "size=100&select=_id%2CnomBeneficiaire%2Cobjet%2Cnature%2C"
+    "dateConvention%2Cmontant"
+)
 
 
 class StubAdemeClient:
@@ -48,7 +52,7 @@ class StubAdemeClient:
         self.urls: list[str] = []
 
     def first_page_url(self) -> str:
-        return f"{BASE_URL}?size=100&select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant"
+        return f"{BASE_URL}?{SELECT_QUERY}"
 
     def fetch_url(self, url: str) -> AdemeFundingFetchResult:
         self.urls.append(url)
@@ -64,6 +68,8 @@ def test_schema_and_mapper_create_official_unresolved_funding_claim() -> None:
         retention_until=NOW + timedelta(days=365),
     )
 
+    assert line.nom == "Example SAS"
+    assert line.date == "2026-08-01"
     assert observation.source_id == "ademe-financial-aid"
     assert observation.source_record_type == "public_funding_award"
     assert claim.event_type is ChangeEventType.FUNDING
@@ -75,7 +81,7 @@ def test_schema_and_mapper_create_official_unresolved_funding_claim() -> None:
 
 
 def test_mapper_marks_old_or_unparseable_event_dates_historical() -> None:
-    old = AdemeFundingLine.model_validate(_line(date="2024-01-01"))
+    old = AdemeFundingLine.model_validate(_line(dateConvention="2024-01-01"))
     _observation, claim = map_ademe_funding_line(
         old,
         collection_job_id=uuid4(),
@@ -84,7 +90,7 @@ def test_mapper_marks_old_or_unparseable_event_dates_historical() -> None:
     )
     assert claim.historical_only is True
 
-    unknown = AdemeFundingLine.model_validate(_line(date="Période 2026"))
+    unknown = AdemeFundingLine.model_validate(_line(dateConvention="Période 2026"))
     _observation, claim = map_ademe_funding_line(
         unknown,
         collection_job_id=uuid4(),
@@ -97,7 +103,7 @@ def test_mapper_marks_old_or_unparseable_event_dates_historical() -> None:
 
 def test_schema_rejects_blank_fields_negative_amount_and_negative_total() -> None:
     with pytest.raises(ValidationError):
-        AdemeFundingLine.model_validate(_line(nom=" "))
+        AdemeFundingLine.model_validate(_line(nomBeneficiaire=" "))
     with pytest.raises(ValidationError):
         AdemeFundingLine.model_validate(_line(montant=-1))
     with pytest.raises(ValidationError):
@@ -109,7 +115,9 @@ def test_client_builds_public_selected_field_query() -> None:
         client = AdemeFundingClient(http_client, lines_url=BASE_URL)
         url = client.first_page_url()
     assert "size=100" in url
-    assert "select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant" in url
+    assert "nomBeneficiaire" in url
+    assert "dateConvention" in url
+    assert "select=_id%2CnomBeneficiaire" in url
 
 
 def test_client_rejects_non_json_and_oversized_response() -> None:
@@ -137,14 +145,16 @@ def test_client_rejects_non_json_and_oversized_response() -> None:
 
 
 def test_collector_follows_safe_cursor_and_persists_next_checkpoint() -> None:
-    first_url = f"{BASE_URL}?size=100&select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant"
+    first_url = f"{BASE_URL}?{SELECT_QUERY}"
     second_url = f"{BASE_URL}?after=cursor-1"
     client = StubAdemeClient(
         {
             first_url: {"total": 2, "results": [_line()], "next": second_url},
             second_url: {
                 "total": 2,
-                "results": [_line(_id="aid-2", nom="Other SAS")],
+                "results": [
+                    _line(_id="aid-2", nomBeneficiaire="Other SAS")
+                ],
                 "next": None,
             },
         }
@@ -175,7 +185,7 @@ def test_collector_follows_safe_cursor_and_persists_next_checkpoint() -> None:
 
 
 def test_collector_rejects_policy_schema_and_unsafe_pagination() -> None:
-    first_url = f"{BASE_URL}?size=100&select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant"
+    first_url = f"{BASE_URL}?{SELECT_QUERY}"
     denied = replace(
         _entry(),
         policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
@@ -233,10 +243,10 @@ def _entry() -> SourceRegistryEntry:
 def _line(**changes: object) -> dict[str, object]:
     payload: dict[str, object] = {
         "_id": "aid-1",
-        "nom": "Example SAS",
+        "nomBeneficiaire": "Example SAS",
         "objet": "Programme de transformation industrielle",
-        "nature": "Subvention",
-        "date": "2026-08-01",
+        "nature": "aide en numéraire",
+        "dateConvention": "2026-08-01",
         "montant": 125000,
     }
     payload.update(changes)

--- a/tests/unit/adapters/ademe_funding/test_source.py
+++ b/tests/unit/adapters/ademe_funding/test_source.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.ademe_funding.client import (
+    AdemeFundingClient,
+    AdemeFundingFetchResult,
+    AdemeFundingResponseError,
+)
+from cip.adapters.sources.ademe_funding.collector import (
+    AdemeFundingCheckpoint,
+    AdemeFundingCollectionDeniedError,
+    AdemeFundingPaginationError,
+    AdemeFundingSchemaError,
+    collect_ademe_funding,
+)
+from cip.adapters.sources.ademe_funding.mapper import map_ademe_funding_line
+from cip.adapters.sources.ademe_funding.schemas import AdemeFundingLine, AdemeFundingResponse
+from cip.modules.corporate_changes.domain.models import (
+    ChangeClaimType,
+    ChangeEventType,
+    OrganizationLinkStatus,
+)
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 8, 0, tzinfo=UTC)
+BASE_URL = (
+    "https://data.ademe.fr/data-fair/api/v1/datasets/"
+    "les-aides-financieres-de-l'ademe/lines"
+)
+
+
+class StubAdemeClient:
+    def __init__(self, pages: dict[str, dict[str, object]]) -> None:
+        self.pages = pages
+        self.urls: list[str] = []
+
+    def first_page_url(self) -> str:
+        return f"{BASE_URL}?size=100&select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant"
+
+    def fetch_url(self, url: str) -> AdemeFundingFetchResult:
+        self.urls.append(url)
+        return AdemeFundingFetchResult(json.dumps(self.pages[url]).encode(), url)
+
+
+def test_schema_and_mapper_create_official_unresolved_funding_claim() -> None:
+    line = AdemeFundingLine.model_validate(_line())
+    observation, claim = map_ademe_funding_line(
+        line,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+    assert observation.source_id == "ademe-financial-aid"
+    assert observation.source_record_type == "public_funding_award"
+    assert claim.event_type is ChangeEventType.FUNDING
+    assert claim.claim_type is ChangeClaimType.CONFIRMATION
+    assert claim.organization_link_status is OrganizationLinkStatus.UNRESOLVED
+    assert claim.organization_id is None
+    assert claim.claimed_organization_name == "Example SAS"
+    assert claim.event_at is not None
+
+
+def test_mapper_marks_old_or_unparseable_event_dates_historical() -> None:
+    old = AdemeFundingLine.model_validate(_line(date="2024-01-01"))
+    _observation, claim = map_ademe_funding_line(
+        old,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert claim.historical_only is True
+
+    unknown = AdemeFundingLine.model_validate(_line(date="Période 2026"))
+    _observation, claim = map_ademe_funding_line(
+        unknown,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert claim.event_at is None
+    assert claim.historical_only is True
+
+
+def test_schema_rejects_blank_fields_negative_amount_and_negative_total() -> None:
+    with pytest.raises(ValidationError):
+        AdemeFundingLine.model_validate(_line(nom=" "))
+    with pytest.raises(ValidationError):
+        AdemeFundingLine.model_validate(_line(montant=-1))
+    with pytest.raises(ValidationError):
+        AdemeFundingResponse.model_validate({"total": -1, "results": []})
+
+
+def test_client_builds_public_selected_field_query() -> None:
+    client = AdemeFundingClient(httpx.Client(), lines_url=BASE_URL)
+    try:
+        url = client.first_page_url()
+    finally:
+        client._client.close()  # noqa: SLF001
+    assert "size=100" in url
+    assert "select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant" in url
+
+
+def test_client_rejects_non_json_and_oversized_response() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(200, headers={"content-type": "text/html"}, text="bad")
+    )
+    with httpx.Client(transport=transport) as http_client:
+        with pytest.raises(AdemeFundingResponseError, match="content type"):
+            AdemeFundingClient(http_client, lines_url=BASE_URL).fetch_url(BASE_URL)
+
+    oversized = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/json", "content-length": "10"},
+            content=b"{}",
+        )
+    )
+    with httpx.Client(transport=oversized) as http_client:
+        client = AdemeFundingClient(http_client, lines_url=BASE_URL)
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(AdemeFundingResponseError, match="response exceeds"):
+            client.fetch_url(BASE_URL)
+
+
+def test_collector_follows_safe_cursor_and_persists_next_checkpoint() -> None:
+    first_url = f"{BASE_URL}?size=100&select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant"
+    second_url = f"{BASE_URL}?after=cursor-1"
+    client = StubAdemeClient(
+        {
+            first_url: {"total": 2, "results": [_line()], "next": second_url},
+            second_url: {
+                "total": 2,
+                "results": [_line(_id="aid-2", nom="Other SAS")],
+                "next": None,
+            },
+        }
+    )
+    batch = collect_ademe_funding(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+        max_pages=1,
+    )
+    assert len(batch.observations) == 1
+    assert len(batch.claims) == 1
+    assert batch.checkpoint.next_url == second_url
+
+    resumed = collect_ademe_funding(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+        checkpoint=AdemeFundingCheckpoint(second_url),
+        max_pages=1,
+    )
+    assert resumed.observations[0].source_record_key == "aid-2"
+    assert resumed.checkpoint.next_url is None
+
+
+def test_collector_rejects_policy_schema_and_unsafe_pagination() -> None:
+    first_url = f"{BASE_URL}?size=100&select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant"
+    denied = replace(
+        _entry(),
+        policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
+    )
+    with pytest.raises(AdemeFundingCollectionDeniedError, match="source_not_enabled"):
+        collect_ademe_funding(
+            StubAdemeClient({first_url: {"total": 0, "results": []}}),  # type: ignore[arg-type]
+            denied,
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+    with pytest.raises(AdemeFundingSchemaError, match="schema validation"):
+        _collect(StubAdemeClient({first_url: {"bad": True}}))
+
+    malicious = StubAdemeClient(
+        {
+            first_url: {
+                "total": 1,
+                "results": [_line()],
+                "next": "https://evil.example/lines?after=x",
+            }
+        }
+    )
+    with pytest.raises(AdemeFundingPaginationError, match="provider host"):
+        collect_ademe_funding(
+            malicious,  # type: ignore[arg-type]
+            _entry(),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+            max_pages=2,
+        )
+
+
+def _collect(client: StubAdemeClient) -> object:
+    return collect_ademe_funding(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.procurement_funding.yml"))
+        if entry.policy.id == "ademe-financial-aid"
+    )
+
+
+def _line(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "_id": "aid-1",
+        "nom": "Example SAS",
+        "objet": "Programme de transformation industrielle",
+        "nature": "Subvention",
+        "date": "2026-08-01",
+        "montant": 125000,
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/adapters/ademe_funding/test_source.py
+++ b/tests/unit/adapters/ademe_funding/test_source.py
@@ -105,11 +105,9 @@ def test_schema_rejects_blank_fields_negative_amount_and_negative_total() -> Non
 
 
 def test_client_builds_public_selected_field_query() -> None:
-    client = AdemeFundingClient(httpx.Client(), lines_url=BASE_URL)
-    try:
+    with httpx.Client() as http_client:
+        client = AdemeFundingClient(http_client, lines_url=BASE_URL)
         url = client.first_page_url()
-    finally:
-        client._client.close()  # noqa: SLF001
     assert "size=100" in url
     assert "select=_id%2Cnom%2Cobjet%2Cnature%2Cdate%2Cmontant" in url
 
@@ -118,9 +116,11 @@ def test_client_rejects_non_json_and_oversized_response() -> None:
     transport = httpx.MockTransport(
         lambda _: httpx.Response(200, headers={"content-type": "text/html"}, text="bad")
     )
-    with httpx.Client(transport=transport) as http_client:
-        with pytest.raises(AdemeFundingResponseError, match="content type"):
-            AdemeFundingClient(http_client, lines_url=BASE_URL).fetch_url(BASE_URL)
+    with (
+        httpx.Client(transport=transport) as http_client,
+        pytest.raises(AdemeFundingResponseError, match="content type"),
+    ):
+        AdemeFundingClient(http_client, lines_url=BASE_URL).fetch_url(BASE_URL)
 
     oversized = httpx.MockTransport(
         lambda _: httpx.Response(

--- a/tests/unit/adapters/place_awards/test_live_provider_edge_cases.py
+++ b/tests/unit/adapters/place_awards/test_live_provider_edge_cases.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from cip.adapters.sources.place_awards.mapper import map_place_award
+from cip.adapters.sources.place_awards.schemas import PlaceAward
+
+NOW = datetime(2026, 8, 11, 8, 30, tzinfo=UTC)
+
+
+def test_missing_live_awardee_keeps_contract_without_invented_party() -> None:
+    award = PlaceAward.model_validate(
+        {
+            "annee_de_notification": "2017",
+            "entite_publique": "Ministère exemple",
+            "entite_d_achat": "Service des achats",
+            "code_postal_entite_d_achat": "75001",
+            "nom_attributaire": None,
+            "siret_attributaire": None,
+            "date_de_notification": "2017-04-03",
+            "code_postal_attributaire": None,
+            "ville": None,
+            "nature_du_marche": "Services",
+            "objet_du_marche": "Prestations de maintenance",
+            "tranche_budgetaire": None,
+            "montant": 25000,
+            "attributaire_est_une_pme": None,
+            "geocode_att": {"lon": 2.35, "lat": 48.85},
+        }
+    )
+    mapped = map_place_award(
+        award,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=3650),
+    )
+
+    assert mapped.observation.source_record_type == "procurement_award"
+    assert mapped.procurement.contract is not None
+    assert mapped.procurement.contract.parties == ()

--- a/tests/unit/adapters/place_awards/test_source.py
+++ b/tests/unit/adapters/place_awards/test_source.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.place_awards.client import (
+    PlaceAwardsClient,
+    PlaceFetchResult,
+    PlaceSourceResponseError,
+)
+from cip.adapters.sources.place_awards.collector import (
+    PlaceCheckpoint,
+    PlaceCollectionDeniedError,
+    PlaceSourceSchemaError,
+    PlaceSourceWindowError,
+    collect_place_awards,
+)
+from cip.adapters.sources.place_awards.mapper import map_place_award
+from cip.adapters.sources.place_awards.schemas import PlaceAward, PlaceAwardsResponse
+from cip.modules.procurement_history.domain.models import ProcurementPublicationKind
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 8, 0, tzinfo=UTC)
+
+
+class StubPlaceClient:
+    PAGE_SIZE = 100
+
+    def __init__(self, pages: list[dict[str, object]]) -> None:
+        self.pages = pages
+        self.offsets: list[int] = []
+
+    def fetch_page(self, *, offset: int) -> PlaceFetchResult:
+        self.offsets.append(offset)
+        index = offset // self.PAGE_SIZE
+        payload = self.pages[index] if index < len(self.pages) else {
+            "total_count": 0,
+            "results": [],
+        }
+        return PlaceFetchResult(json.dumps(payload).encode())
+
+
+def test_schema_and_mapper_preserve_award_history_without_cyber_filter() -> None:
+    award = PlaceAward.model_validate(_award(objet_du_marche="Fourniture de mobilier"))
+    mapped = map_place_award(
+        award,
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+    assert mapped.observation.source_id == "place-awards"
+    assert mapped.observation.source_record_type == "procurement_award"
+    assert mapped.procurement.publication.kind is ProcurementPublicationKind.AWARD
+    assert mapped.procurement.contract is not None
+    assert mapped.procurement.contract.title == "Fourniture de mobilier"
+    assert mapped.procurement.contract.service_families == ()
+    assert mapped.procurement.contract.parties[0].official_identifier == "SIRET:12345678901234"
+    assert mapped.buyer.canonical_name == "Service des achats"
+
+
+def test_schema_rejects_blank_required_and_negative_amount() -> None:
+    with pytest.raises(ValidationError):
+        PlaceAward.model_validate(_award(objet_du_marche=" "))
+    with pytest.raises(ValidationError):
+        PlaceAward.model_validate(_award(montant=-1))
+    with pytest.raises(ValidationError):
+        PlaceAwardsResponse.model_validate({"total_count": -1, "results": []})
+
+
+def test_client_uses_selected_fields_and_bounded_offset() -> None:
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"total_count": 1, "results": [_award()]},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        client = PlaceAwardsClient(http_client, records_url="https://example.test/records")
+        response = client.fetch_page(offset=0)
+    assert PlaceAwardsResponse.model_validate_json(response.body).total_count == 1
+    assert "select=" in captured["url"]
+    assert "limit=100" in captured["url"]
+
+    with pytest.raises(ValueError, match="page boundary"):
+        client.fetch_page(offset=1)
+
+
+def test_client_rejects_non_json_and_oversized_response() -> None:
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(200, headers={"content-type": "text/html"}, text="bad")
+    )
+    with httpx.Client(transport=transport) as http_client:
+        with pytest.raises(PlaceSourceResponseError, match="content type"):
+            PlaceAwardsClient(http_client, records_url="https://example.test").fetch_page(
+                offset=0
+            )
+
+    oversized = httpx.MockTransport(
+        lambda _: httpx.Response(
+            200,
+            headers={"content-type": "application/json", "content-length": "10"},
+            content=b"{}",
+        )
+    )
+    with httpx.Client(transport=oversized) as http_client:
+        client = PlaceAwardsClient(http_client, records_url="https://example.test")
+        client.MAX_RESPONSE_BYTES = 2
+        with pytest.raises(PlaceSourceResponseError, match="response exceeds"):
+            client.fetch_page(offset=0)
+
+
+def test_collector_emits_all_awards_and_stops_at_checkpoint() -> None:
+    first = PlaceAward.model_validate(_award()).model_dump(mode="json")
+    second = PlaceAward.model_validate(
+        _award(
+            nom_attributaire="Other",
+            siret_attributaire="99999999999999",
+            objet_du_marche="Maintenance réseau",
+        )
+    ).model_dump(mode="json")
+    first_mapping = map_place_award(
+        PlaceAward.model_validate(first),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    batch = collect_place_awards(
+        StubPlaceClient([{"total_count": 2, "results": [first, second]}]),  # type: ignore[arg-type]
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+        checkpoint=PlaceCheckpoint(first_mapping.observation.source_record_key, "2026-08-10"),
+    )
+    assert batch.not_modified is True
+    assert batch.observations == ()
+
+    fresh = collect_place_awards(
+        StubPlaceClient([{"total_count": 2, "results": [first, second]}]),  # type: ignore[arg-type]
+        _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert len(fresh.observations) == 2
+    assert len(fresh.procurement) == 2
+    assert len(fresh.buyers) == 1
+
+
+def test_collector_fails_closed_on_policy_schema_and_window() -> None:
+    denied = replace(
+        _entry(),
+        policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
+    )
+    with pytest.raises(PlaceCollectionDeniedError, match="source_not_enabled"):
+        _collect(StubPlaceClient([]), entry=denied)
+
+    with pytest.raises(PlaceSourceSchemaError, match="schema validation"):
+        _collect(StubPlaceClient([{"total_count": 1, "results": [{"bad": True}]}]))
+
+    full_page = [_award(nom_attributaire=f"Awardee {index}") for index in range(100)]
+    with pytest.raises(PlaceSourceWindowError, match="checkpoint"):
+        collect_place_awards(
+            StubPlaceClient([{"total_count": 500, "results": full_page}]),  # type: ignore[arg-type]
+            _entry(),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+            checkpoint=PlaceCheckpoint("missing", "2020-01-01"),
+            max_pages=1,
+        )
+
+
+def _collect(
+    client: StubPlaceClient,
+    *,
+    entry: SourceRegistryEntry | None = None,
+) -> object:
+    return collect_place_awards(
+        client,  # type: ignore[arg-type]
+        entry or _entry(),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.procurement_funding.yml"))
+        if entry.policy.id == "place-awards"
+    )
+
+
+def _award(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "annee_de_notification": "2026-01-01",
+        "entite_publique": "Ministère exemple",
+        "entite_d_achat": "Service des achats",
+        "code_postal_entite_d_achat": "75001",
+        "nom_attributaire": "Example SAS",
+        "siret_attributaire": "12345678901234",
+        "date_de_notification": "2026-08-10",
+        "code_postal_attributaire": "75002",
+        "ville": "Paris",
+        "nature_du_marche": "Services",
+        "objet_du_marche": "SOC et SIEM",
+        "tranche_budgetaire": "100000-500000",
+        "montant": 250000,
+        "attributaire_est_une_pme": "Oui",
+        "geocode_att": [48.85, 2.35],
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/adapters/place_awards/test_source.py
+++ b/tests/unit/adapters/place_awards/test_source.py
@@ -60,6 +60,10 @@ def test_schema_and_mapper_preserve_award_history_without_cyber_filter() -> None
         retention_until=NOW + timedelta(days=365),
     )
 
+    assert award.annee_de_notification == 2026
+    assert award.geocode_att is not None
+    assert award.geocode_att.lon == 2.35
+    assert award.geocode_att.lat == 48.85
     assert mapped.observation.source_id == "place-awards"
     assert mapped.observation.source_record_type == "procurement_award"
     assert mapped.procurement.publication.kind is ProcurementPublicationKind.AWARD
@@ -70,11 +74,15 @@ def test_schema_and_mapper_preserve_award_history_without_cyber_filter() -> None
     assert mapped.buyer.canonical_name == "Service des achats"
 
 
-def test_schema_rejects_blank_required_and_negative_amount() -> None:
+def test_schema_rejects_blank_required_negative_amount_and_invalid_live_fields() -> None:
     with pytest.raises(ValidationError):
         PlaceAward.model_validate(_award(objet_du_marche=" "))
     with pytest.raises(ValidationError):
         PlaceAward.model_validate(_award(montant=-1))
+    with pytest.raises(ValidationError):
+        PlaceAward.model_validate(_award(annee_de_notification="2201"))
+    with pytest.raises(ValidationError):
+        PlaceAward.model_validate(_award(geocode_att={"lon": 200, "lat": 48.85}))
     with pytest.raises(ValidationError):
         PlaceAwardsResponse.model_validate({"total_count": -1, "results": []})
 
@@ -213,7 +221,7 @@ def _entry() -> SourceRegistryEntry:
 
 def _award(**changes: object) -> dict[str, object]:
     payload: dict[str, object] = {
-        "annee_de_notification": "2026-01-01",
+        "annee_de_notification": "2026",
         "entite_publique": "Ministère exemple",
         "entite_d_achat": "Service des achats",
         "code_postal_entite_d_achat": "75001",
@@ -227,7 +235,7 @@ def _award(**changes: object) -> dict[str, object]:
         "tranche_budgetaire": "100000-500000",
         "montant": 250000,
         "attributaire_est_une_pme": "Oui",
-        "geocode_att": [48.85, 2.35],
+        "geocode_att": {"lon": 2.35, "lat": 48.85},
     }
     payload.update(changes)
     return payload

--- a/tests/unit/adapters/place_awards/test_source.py
+++ b/tests/unit/adapters/place_awards/test_source.py
@@ -105,11 +105,13 @@ def test_client_rejects_non_json_and_oversized_response() -> None:
     transport = httpx.MockTransport(
         lambda _: httpx.Response(200, headers={"content-type": "text/html"}, text="bad")
     )
-    with httpx.Client(transport=transport) as http_client:
-        with pytest.raises(PlaceSourceResponseError, match="content type"):
-            PlaceAwardsClient(http_client, records_url="https://example.test").fetch_page(
-                offset=0
-            )
+    with (
+        httpx.Client(transport=transport) as http_client,
+        pytest.raises(PlaceSourceResponseError, match="content type"),
+    ):
+        PlaceAwardsClient(http_client, records_url="https://example.test").fetch_page(
+            offset=0
+        )
 
     oversized = httpx.MockTransport(
         lambda _: httpx.Response(

--- a/tests/unit/collection_orchestration/test_runtime_and_metrics.py
+++ b/tests/unit/collection_orchestration/test_runtime_and_metrics.py
@@ -75,10 +75,11 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
     get_metadata().create_all(create_database_engine(settings.database_url))
 
     runtime = build_collection_runtime(settings)
-    assert run_scheduler_once(runtime, now=NOW) == 12
+    assert run_scheduler_once(runtime, now=NOW) == 14
     assert run_scheduler_once(runtime, now=NOW) == 0
 
     expected_sources = (
+        "ademe-financial-aid",
         "ashby-job-board",
         "boamp",
         "cisa-kev",
@@ -88,6 +89,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         "internet-archive-cdx",
         "lever-job-board",
         "nvd-vulnerabilities",
+        "place-awards",
         "recruitee-careers-site",
         "smartrecruiters-job-board",
         "ted-search",
@@ -103,6 +105,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         for source in sources.values()
     )
     assert {(job.source_id, job.adapter_id) for job in jobs} == {
+        ("ademe-financial-aid", "ademe-data-fair-financial-aid-api"),
         ("ashby-job-board", "ashby-public-job-postings-api"),
         ("boamp", "boamp-explore-api"),
         ("cisa-kev", "cisa-kev-feed"),
@@ -112,6 +115,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         ("internet-archive-cdx", "internet-archive-cdx"),
         ("lever-job-board", "lever-postings-api"),
         ("nvd-vulnerabilities", "nvd-cve-api"),
+        ("place-awards", "place-open-data-awards-api"),
         ("recruitee-careers-site", "recruitee-careers-site-api"),
         ("smartrecruiters-job-board", "smartrecruiters-posting-api"),
         ("ted-search", "ted-search-api"),

--- a/tests/unit/collection_orchestration/test_sa12_adapter_contracts.py
+++ b/tests/unit/collection_orchestration/test_sa12_adapter_contracts.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.ademe_funding.collector import (
+    AdemeFundingCheckpoint,
+    AdemeFundingCollectionBatch,
+    AdemeFundingCollectionDeniedError,
+    AdemeFundingPaginationError,
+    AdemeFundingSchemaError,
+)
+from cip.adapters.sources.ademe_funding.client import AdemeFundingResponseError
+from cip.adapters.sources.place_awards.client import PlaceSourceResponseError
+from cip.adapters.sources.place_awards.collector import (
+    PlaceCheckpoint,
+    PlaceCollectionBatch,
+    PlaceCollectionDeniedError,
+    PlaceSourceSchemaError,
+    PlaceSourceWindowError,
+)
+from cip.modules.collection_orchestration.application import (
+    ademe_funding_adapter as ademe_module,
+)
+from cip.modules.collection_orchestration.application import (
+    place_awards_adapter as place_module,
+)
+from cip.modules.collection_orchestration.application.ademe_funding_adapter import (
+    AdemeFundingAdapter,
+)
+from cip.modules.collection_orchestration.application.place_awards_adapter import (
+    PlaceAwardsAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 8, 30, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+POLICY_PATH = Path("policies/sources.procurement_funding.yml")
+
+
+def test_place_adapter_success_hydrates_checkpoint_and_returns_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = PlaceCollectionBatch(
+        observations=(),
+        buyers=(),
+        procurement=(),
+        checkpoint=PlaceCheckpoint("new-key", "2026-08-10"),
+        not_modified=False,
+    )
+    seen: dict[str, object] = {}
+
+    def fake_collect(*args: object, **kwargs: object) -> PlaceCollectionBatch:
+        seen["checkpoint"] = kwargs["checkpoint"]
+        return expected
+
+    monkeypatch.setattr(place_module, "collect_place_awards", fake_collect)
+    batch = PlaceAwardsAdapter(_entry("place-awards")).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload={
+            "latest_source_record_key": "old-key",
+            "latest_notification_date": "2026-08-01",
+        },
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+    checkpoint = seen["checkpoint"]
+    assert isinstance(checkpoint, PlaceCheckpoint)
+    assert checkpoint.latest_source_record_key == "old-key"
+    assert batch.checkpoint_payload == {
+        "latest_source_record_key": "new-key",
+        "latest_notification_date": "2026-08-10",
+    }
+    assert batch.not_modified is False
+
+
+def test_ademe_adapter_success_hydrates_checkpoint_and_returns_claims(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expected = AdemeFundingCollectionBatch(
+        observations=(),
+        claims=(),
+        checkpoint=AdemeFundingCheckpoint("https://data.ademe.fr/next"),
+        not_modified=False,
+    )
+    seen: dict[str, object] = {}
+
+    def fake_collect(*args: object, **kwargs: object) -> AdemeFundingCollectionBatch:
+        seen["checkpoint"] = kwargs["checkpoint"]
+        return expected
+
+    monkeypatch.setattr(ademe_module, "collect_ademe_funding", fake_collect)
+    batch = AdemeFundingAdapter(_entry("ademe-financial-aid")).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload={"next_url": "https://data.ademe.fr/old"},
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+    checkpoint = seen["checkpoint"]
+    assert isinstance(checkpoint, AdemeFundingCheckpoint)
+    assert checkpoint.next_url == "https://data.ademe.fr/old"
+    assert batch.checkpoint_payload == {"next_url": "https://data.ademe.fr/next"}
+    assert batch.corporate_change_claims == ()
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_code", "retryable"),
+    [
+        (lambda: PlaceCollectionDeniedError("denied"), "source_policy_denied", False),
+        (lambda: PlaceSourceSchemaError("drift"), "source_schema_drift", False),
+        (lambda: PlaceSourceWindowError("window"), "source_window_exceeded", False),
+        (lambda: PlaceSourceResponseError("unsafe"), "unsafe_source_response", True),
+        (lambda: httpx.ReadTimeout("timeout"), "source_transport_error", True),
+    ],
+)
+def test_place_adapter_maps_provider_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    factory: Callable[[], Exception],
+    expected_code: str,
+    retryable: bool,
+) -> None:
+    def fail(*args: object, **kwargs: object) -> PlaceCollectionBatch:
+        raise factory()
+
+    monkeypatch.setattr(place_module, "collect_place_awards", fail)
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect_place()
+    assert exc_info.value.error_code == expected_code
+    assert exc_info.value.retryable is retryable
+
+
+@pytest.mark.parametrize(
+    ("factory", "expected_code", "retryable"),
+    [
+        (lambda: AdemeFundingCollectionDeniedError("denied"), "source_policy_denied", False),
+        (lambda: AdemeFundingSchemaError("drift"), "source_schema_drift", False),
+        (lambda: AdemeFundingPaginationError("cursor"), "unsafe_pagination", False),
+        (lambda: AdemeFundingResponseError("unsafe"), "unsafe_source_response", True),
+        (lambda: httpx.ConnectError("transport"), "source_transport_error", True),
+    ],
+)
+def test_ademe_adapter_maps_provider_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    factory: Callable[[], Exception],
+    expected_code: str,
+    retryable: bool,
+) -> None:
+    def fail(*args: object, **kwargs: object) -> AdemeFundingCollectionBatch:
+        raise factory()
+
+    monkeypatch.setattr(ademe_module, "collect_ademe_funding", fail)
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect_ademe()
+    assert exc_info.value.error_code == expected_code
+    assert exc_info.value.retryable is retryable
+
+
+@pytest.mark.parametrize(
+    ("status", "retryable"),
+    [(400, False), (429, True), (503, True)],
+)
+def test_place_adapter_maps_http_status(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    retryable: bool,
+) -> None:
+    error = _http_status_error(status)
+
+    def fail(*args: object, **kwargs: object) -> PlaceCollectionBatch:
+        raise error
+
+    monkeypatch.setattr(place_module, "collect_place_awards", fail)
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect_place()
+    assert exc_info.value.error_code == f"http_{status}"
+    assert exc_info.value.retryable is retryable
+
+
+@pytest.mark.parametrize(
+    ("status", "retryable"),
+    [(404, False), (429, True), (500, True)],
+)
+def test_ademe_adapter_maps_http_status(
+    monkeypatch: pytest.MonkeyPatch,
+    status: int,
+    retryable: bool,
+) -> None:
+    error = _http_status_error(status)
+
+    def fail(*args: object, **kwargs: object) -> AdemeFundingCollectionBatch:
+        raise error
+
+    monkeypatch.setattr(ademe_module, "collect_ademe_funding", fail)
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect_ademe()
+    assert exc_info.value.error_code == f"http_{status}"
+    assert exc_info.value.retryable is retryable
+
+
+def test_adapters_reject_wrong_policy_timeout_and_checkpoint() -> None:
+    place_entry = _entry("place-awards")
+    ademe_entry = _entry("ademe-financial-aid")
+
+    with pytest.raises(ValueError, match="source policy"):
+        PlaceAwardsAdapter(ademe_entry)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        PlaceAwardsAdapter(place_entry, timeout_seconds=0)
+    with pytest.raises(ValueError, match="source policy"):
+        AdemeFundingAdapter(place_entry)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        AdemeFundingAdapter(ademe_entry, timeout_seconds=0)
+
+    with pytest.raises(AdapterExecutionError) as place_error:
+        PlaceAwardsAdapter(place_entry).collect(
+            collection_job_id=uuid4(),
+            checkpoint_payload={"latest_source_record_key": 123},
+            collected_at=NOW,
+            retention_until=RETENTION,
+        )
+    assert place_error.value.error_code == "invalid_checkpoint"
+
+    with pytest.raises(AdapterExecutionError) as ademe_error:
+        AdemeFundingAdapter(ademe_entry).collect(
+            collection_job_id=uuid4(),
+            checkpoint_payload={"next_url": 123},
+            collected_at=NOW,
+            retention_until=RETENTION,
+        )
+    assert ademe_error.value.error_code == "invalid_checkpoint"
+
+
+def _collect_place() -> object:
+    return PlaceAwardsAdapter(_entry("place-awards")).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _collect_ademe() -> object:
+    return AdemeFundingAdapter(_entry("ademe-financial-aid")).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _entry(source_id: str) -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == source_id
+    )
+
+
+def _http_status_error(status: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://provider.example/resource")
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError("status", request=request, response=response)

--- a/tests/unit/collection_orchestration/test_sa12_adapter_contracts.py
+++ b/tests/unit/collection_orchestration/test_sa12_adapter_contracts.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import httpx
 import pytest
 
+from cip.adapters.sources.ademe_funding.client import AdemeFundingResponseError
 from cip.adapters.sources.ademe_funding.collector import (
     AdemeFundingCheckpoint,
     AdemeFundingCollectionBatch,
@@ -15,7 +16,6 @@ from cip.adapters.sources.ademe_funding.collector import (
     AdemeFundingPaginationError,
     AdemeFundingSchemaError,
 )
-from cip.adapters.sources.ademe_funding.client import AdemeFundingResponseError
 from cip.adapters.sources.place_awards.client import PlaceSourceResponseError
 from cip.adapters.sources.place_awards.collector import (
     PlaceCheckpoint,

--- a/tests/unit/source_activation/test_sa12_procurement_funding_activation.py
+++ b/tests/unit/source_activation/test_sa12_procurement_funding_activation.py
@@ -8,6 +8,7 @@ from cip.modules.source_activation.domain.models import (
     ActivationStage,
 )
 from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+from cip.modules.source_governance.domain.models import SourceStatus
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
 from cip.modules.source_portfolio.infrastructure.registry_bundle import (
     load_source_portfolio_bundle,
@@ -42,12 +43,12 @@ def test_sa12_source_governance_is_enabled_and_provider_specific() -> None:
     entries = {entry.policy.id: entry for entry in load_source_registry(POLICY_PATH)}
 
     place = entries["place-awards"]
-    assert place.policy.enabled
+    assert place.policy.status is SourceStatus.ENABLED
     assert place.authorization.automated_collection_allowed
     assert place.authorization.approved_hosts == frozenset({"data.economie.gouv.fr"})
 
     ademe = entries["ademe-financial-aid"]
-    assert ademe.policy.enabled
+    assert ademe.policy.status is SourceStatus.ENABLED
     assert ademe.authorization.automated_collection_allowed
     assert ademe.authorization.approved_hosts == frozenset({"data.ademe.fr"})
 

--- a/tests/unit/source_activation/test_sa12_procurement_funding_activation.py
+++ b/tests/unit/source_activation/test_sa12_procurement_funding_activation.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+from cip.modules.collection_orchestration.infrastructure.schedule_bundle import (
+    load_collection_schedule_bundle,
+)
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationStage,
+)
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_portfolio.infrastructure.registry_bundle import (
+    load_source_portfolio_bundle,
+)
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+POLICY_PATH = Path("policies/sources.procurement_funding.yml")
+PORTFOLIO_PATH = Path("policies/source_portfolio.procurement_funding.yml")
+SCHEDULE_PATH = Path("policies/collection_schedules.procurement_funding.yml")
+LIVE_WORKFLOW_PATH = Path(".github/workflows/sa12-live-validation.yml")
+LIVE_SCRIPT_PATH = Path("scripts/live_validate_sa12.py")
+
+
+def test_sa12_place_and_ademe_are_real_live_integrations() -> None:
+    records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
+
+    for source_id in ("place-awards", "ademe-financial-aid"):
+        record = records[source_id]
+        assert record.disposition is ActivationDisposition.ACTIVE
+        assert record.activation_wave == "SA-12"
+        assert record.is_fully_integrated
+        assert {
+            ActivationStage.ADAPTER_PRESENT,
+            ActivationStage.AUTHORIZED,
+            ActivationStage.EXECUTABLE,
+            ActivationStage.SCHEDULED,
+            ActivationStage.LIVE_TESTED,
+        } <= record.stages
+
+
+def test_sa12_source_governance_is_enabled_and_provider_specific() -> None:
+    entries = {entry.policy.id: entry for entry in load_source_registry(POLICY_PATH)}
+
+    place = entries["place-awards"]
+    assert place.policy.enabled
+    assert place.authorization.automated_collection_allowed
+    assert place.authorization.approved_hosts == frozenset({"data.economie.gouv.fr"})
+
+    ademe = entries["ademe-financial-aid"]
+    assert ademe.policy.enabled
+    assert ademe.authorization.automated_collection_allowed
+    assert ademe.authorization.approved_hosts == frozenset({"data.ademe.fr"})
+
+
+def test_sa12_portfolio_and_schedules_are_executable() -> None:
+    portfolio = {
+        entry.source_id: entry
+        for entry in load_source_portfolio_bundle(PORTFOLIO_PATH)
+    }
+    schedules = {
+        schedule.source_id: schedule
+        for schedule in load_collection_schedule_bundle(SCHEDULE_PATH)
+    }
+
+    assert portfolio["place-awards"].executable is True
+    assert portfolio["place-awards"].adapter is not None
+    assert portfolio["place-awards"].adapter.adapter_id == "place-open-data-awards-api"
+    assert schedules["place-awards"].enabled is True
+
+    assert portfolio["ademe-financial-aid"].executable is True
+    assert portfolio["ademe-financial-aid"].adapter is not None
+    assert (
+        portfolio["ademe-financial-aid"].adapter.adapter_id
+        == "ademe-data-fair-financial-aid-api"
+    )
+    assert schedules["ademe-financial-aid"].enabled is True
+
+
+def test_sa12_live_gate_executes_production_adapters_and_requires_real_data() -> None:
+    workflow = LIVE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = LIVE_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "Controlled PLACE and ADEME live validation" in workflow
+    assert "python scripts/live_validate_sa12.py" in workflow
+    assert "PlaceAwardsAdapter(" in script
+    assert "AdemeFundingAdapter(" in script
+    assert "place_count < 1" in script
+    assert "ademe_count < 1" in script
+    assert "place_batch.procurement_projections" in script
+    assert "ademe_batch.corporate_change_claims" in script


### PR DESCRIPTION
Implements issue #103 incrementally.

Current scope:
- real PLACE public award-history API adapter mapped to canonical procurement history;
- real ADEME Data Fair financial-aid adapter mapped to official corporate funding claims;
- raw observation preservation and bounded checkpoint/cursor collection;
- corporate-change claims carried through the existing collection worker and persisted through the existing reconciliation path;
- dedicated governance, source portfolio, schedules and pre-live Source Activation records.

Still draft until deterministic tests, controlled live provider validation, source-activation reconciliation and exact-head full CI are green. `live_tested` is intentionally not set yet.