### PR TITLE
SA-11: activate BRREG public company identity

### DIFF
--- a/.github/workflows/sa11-live-validation.yml
+++ b/.github/workflows/sa11-live-validation.yml
@@ -1,0 +1,33 @@
+name: SA-11 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa11-live-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-public-company-identity:
+    if: github.event.pull_request.head.ref == 'agent/sa11-company-identity-registry-expansion'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled BRREG live validation
+        run: python scripts/live_validate_sa11.py

--- a/policies/organization_identity_targets.yml
+++ b/policies/organization_identity_targets.yml
@@ -12,4 +12,5 @@ targets:
     siren: null
     siret: null
     lei: null
+    foreign_registration: null
     enabled: false

--- a/policies/source_activation.company_identity_expansion.yml
+++ b/policies/source_activation.company_identity_expansion.yml
@@ -7,7 +7,7 @@ sources:
     disposition: active
     activation_wave: SA-11
     requires_schedule: false
-    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable, live_tested]
 
   - source_id: sirene-api
     display_name: INSEE Sirene API direct connector candidate

--- a/policies/source_activation.company_identity_expansion.yml
+++ b/policies/source_activation.company_identity_expansion.yml
@@ -1,0 +1,48 @@
+version: 1
+
+sources:
+  - source_id: brreg-enhetsregisteret
+    display_name: Brønnøysundregistrene Enhetsregisteret Open Data
+    category: organization_identity
+    disposition: active
+    activation_wave: SA-11
+    requires_schedule: false
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable]
+
+  - source_id: sirene-api
+    display_name: INSEE Sirene API direct connector candidate
+    category: organization_identity
+    disposition: manual
+    activation_wave: SA-11
+    requires_schedule: false
+    reason: >-
+      INSEE confirms current Sirene open-data API availability, but the direct
+      connector remains intentionally unpromoted until its exact deployed
+      connection mode and incremental value beyond the existing Sirene-backed
+      Recherche d'entreprises adapter are locked provider-specifically.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: inpi-rne
+    display_name: INPI Registre national des entreprises
+    category: organization_identity
+    disposition: blocked
+    activation_wave: SA-11
+    requires_schedule: false
+    reason: >-
+      Official RNE API/SFTP access requires technical identifiers provisioned
+      through an authenticated INPI account. No deployment credentials or
+      reviewed access grant are present, so no executable or live-tested stage
+      may be claimed.
+    stages: [catalogued, reviewed, mapped]
+
+  - source_id: opencorporates-licensed
+    display_name: OpenCorporates licensed company-data candidate
+    category: organization_identity
+    disposition: blocked
+    activation_wave: SA-11
+    requires_schedule: false
+    reason: >-
+      No repository evidence proves a product-use licence, credentials, approved
+      fields, retention conditions or customer-facing incorporation rights.
+      A public website or unauthorised scraping route is not a substitute.
+    stages: [catalogued, reviewed, mapped]

--- a/policies/source_portfolio.company_identity_expansion.yml
+++ b/policies/source_portfolio.company_identity_expansion.yml
@@ -1,0 +1,24 @@
+version: 1
+
+sources:
+  - source_id: brreg-enhetsregisteret
+    display_name: Brønnøysundregistrene Enhetsregisteret Open Data
+    canonical_url: https://data.brreg.no/enhetsregisteret/api/enheter
+    category: organization_identity
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases: [organization_resolution]
+    monthly_cost_limit: 0
+    metadata:
+      activation_requires: explicit_norwegian_registration_target
+      scheduled_by_default: false
+      personal_role_endpoints: prohibited
+    adapter:
+      adapter_id: brreg-enhetsregisteret-entity
+      adapter_version: "1"
+      provider_schema_version: brreg-enhet-v2
+      modes: [entity_lookup, priority_refresh]
+      canonical_output_types: [identity_claim]
+      supports_corrections: true
+      max_page_size: 1
+      cost_per_request: 0

--- a/policies/sources.company_identity_expansion.yml
+++ b/policies/sources.company_identity_expansion.yml
@@ -1,0 +1,50 @@
+version: 1
+reviewed_at: 2026-08-11
+
+sources:
+  - id: brreg-enhetsregisteret
+    name: Brønnøysundregistrene Enhetsregisteret Open Data
+    base_url: https://data.brreg.no/enhetsregisteret/api/enheter
+    status: enabled
+    source_type: api
+    owner: Brønnøysundregistrene
+    terms_url: https://data.brreg.no/enhetsregisteret/api/dokumentasjon/en/index.html
+    licence: Norwegian Licence for Open Government Data (NLOD) 2.0
+    allowed_data_categories:
+      - organization_metadata
+    prohibited_data_categories:
+      - professional_contact
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: 30
+    retention_days: 1825
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: brreg-enhetsregisteret-open-data-nlod-2026-08-11
+      reviewed_at: 2026-08-11T09:55:00Z
+      expires_at: null
+      approved_hosts:
+        - data.brreg.no
+      approved_path_prefixes:
+        - /enhetsregisteret/api/enheter/
+      approved_purposes:
+        - organization-identity-resolution
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: low
+      expected_stability: high
+    notes: >-
+      Uses only exact public entity lookups by Norwegian organisation number.
+      Person-role endpoints, Maskinporten-authorized endpoints, personal identifiers,
+      beneficial-owner data and name-only automatic matching are outside scope.
+      A 410 response is treated as a fail-closed public-disclosure removal signal.

--- a/scripts/live_validate_sa11.py
+++ b/scripts/live_validate_sa11.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.modules.collection_orchestration.application.brreg_identity_adapter import (
+    BrregIdentityAdapter,
+)
+from cip.modules.organizations.domain.identifiers import IdentifierScheme
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+POLICY_PATH = Path("policies/sources.company_identity_expansion.yml")
+VALIDATION_ORG_NUMBER = "974760673"
+
+
+def main() -> None:
+    entry = next(
+        item
+        for item in load_source_registry(POLICY_PATH)
+        if item.policy.id == "brreg-enhetsregisteret"
+    )
+    target = OrganizationIdentityTarget(
+        id="brreg-source-operator-live-validation",
+        organization_id=UUID("7f3ea686-13c2-5c32-9a20-d3ed5c6fab2c"),
+        canonical_name="Brønnøysundregistrene",
+        country_code="NO",
+        query="Brønnøysundregistrene",
+        foreign_registration=VALIDATION_ORG_NUMBER,
+        enabled=True,
+    )
+    now = datetime.now(UTC)
+    batch = BrregIdentityAdapter(entry, (target,), timeout_seconds=30).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=365),
+    )
+    if len(batch.observations) != 1 or len(batch.identity_projections) != 1:
+        raise RuntimeError("BRREG live validation did not return one canonical entity")
+    projection = batch.identity_projections[0]
+    identifiers = projection.identity.identifiers
+    if not identifiers or identifiers[0].scheme is not IdentifierScheme.FOREIGN_REGISTRATION:
+        raise RuntimeError("BRREG live validation lost the official organisation identifier")
+    if identifiers[0].value != VALIDATION_ORG_NUMBER:
+        raise RuntimeError("BRREG live validation returned an unexpected organisation")
+    if projection.attached_organization is None:
+        raise RuntimeError("BRREG exact identifier did not auto-attach validation target")
+    if batch.not_modified:
+        raise RuntimeError("BRREG first live collection unexpectedly reported not-modified")
+    print(
+        "SA-11 BRREG live validation passed: "
+        f"observations={len(batch.observations)} "
+        f"identity_projections={len(batch.identity_projections)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/brreg_identity/__init__.py
+++ b/src/cip/adapters/sources/brreg_identity/__init__.py
@@ -1,0 +1,1 @@
+"""Brønnøysundregistrene public company-identity adapter."""

--- a/src/cip/adapters/sources/brreg_identity/client.py
+++ b/src/cip/adapters/sources/brreg_identity/client.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import quote
+
+import httpx
+
+
+class BrregSourceResponseError(RuntimeError):
+    """BRREG returned an unsafe or unusable response."""
+
+
+class BrregEntityRemovedError(RuntimeError):
+    """BRREG reports that an entity was removed from public disclosure."""
+
+
+@dataclass(frozen=True, slots=True)
+class BrregFetchResult:
+    body: bytes
+    request_url: str
+
+
+class BrregIdentityClient:
+    MAX_RESPONSE_BYTES = 1_000_000
+    ACCEPT = "application/vnd.brreg.enhetsregisteret.enhet.v2+json"
+
+    def __init__(self, client: httpx.Client, *, entities_url: str) -> None:
+        self._client = client
+        self._entities_url = entities_url.rstrip("/")
+
+    def entity_url(self, registration_number: str) -> str:
+        normalized = "".join(character for character in registration_number if character.isdigit())
+        if len(normalized) != 9:
+            raise ValueError("BRREG organisation number must contain 9 digits")
+        return f"{self._entities_url}/{quote(normalized, safe='')}"
+
+    def fetch_entity(self, registration_number: str) -> BrregFetchResult:
+        url = self.entity_url(registration_number)
+        response = self._client.get(url, headers={"Accept": self.ACCEPT})
+        if response.status_code == 410:
+            raise BrregEntityRemovedError("BRREG entity removed from public disclosure")
+        response.raise_for_status()
+        _validate_content_type(response)
+        _validate_size(response, max_bytes=self.MAX_RESPONSE_BYTES)
+        return BrregFetchResult(body=response.content, request_url=str(response.url))
+
+
+def _validate_content_type(response: httpx.Response) -> None:
+    content_type = response.headers.get("content-type", "").split(";", maxsplit=1)[0].strip()
+    allowed = {
+        "application/json",
+        "application/vnd.brreg.enhetsregisteret.enhet.v2+json",
+    }
+    if content_type not in allowed:
+        raise BrregSourceResponseError(
+            f"unexpected content type: {content_type or 'missing'}"
+        )
+
+
+def _validate_size(response: httpx.Response, *, max_bytes: int) -> None:
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as exc:
+            raise BrregSourceResponseError("invalid Content-Length") from exc
+        if declared_size > max_bytes:
+            raise BrregSourceResponseError("response exceeds configured size limit")
+    if len(response.content) > max_bytes:
+        raise BrregSourceResponseError("response body exceeds configured size limit")

--- a/src/cip/adapters/sources/brreg_identity/collector.py
+++ b/src/cip/adapters/sources/brreg_identity/collector.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from types import MappingProxyType
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from cip.adapters.sources.brreg_identity.client import BrregIdentityClient
+from cip.adapters.sources.brreg_identity.mapper import map_brreg_entity
+from cip.adapters.sources.brreg_identity.schemas import BrregEntity
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.modules.organizations.application.identity import IdentityProjection
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+
+class BrregCollectionDeniedError(RuntimeError):
+    """Source governance denied BRREG collection."""
+
+
+class BrregSourceSchemaError(RuntimeError):
+    """BRREG payload no longer matches the governed entity schema."""
+
+
+@dataclass(frozen=True, slots=True)
+class BrregCheckpoint:
+    fingerprints: dict[str, str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fingerprints", MappingProxyType(dict(self.fingerprints)))
+
+
+@dataclass(frozen=True, slots=True)
+class BrregCollectionBatch:
+    observations: tuple[RawObservation, ...]
+    projections: tuple[IdentityProjection, ...]
+    checkpoint: BrregCheckpoint
+    not_modified: bool
+
+
+def collect_brreg_entities(
+    client: BrregIdentityClient,
+    entry: SourceRegistryEntry,
+    targets: tuple[OrganizationIdentityTarget, ...],
+    *,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    checkpoint: BrregCheckpoint | None = None,
+) -> BrregCollectionBatch:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    previous = dict(checkpoint.fingerprints) if checkpoint else {}
+    current = dict(previous)
+    observations: list[RawObservation] = []
+    projections: list[IdentityProjection] = []
+    selected = tuple(
+        target
+        for target in targets
+        if target.enabled
+        and target.country_code == "NO"
+        and target.foreign_registration is not None
+    )
+    for target in selected:
+        registration = target.foreign_registration
+        if registration is None:
+            continue
+        target_url = client.entity_url(registration)
+        _authorize(entry, target_url, collected_at=collected)
+        fetched = client.fetch_entity(registration)
+        entity = _parse_entity(fetched.body)
+        observation, projection, fingerprint = map_brreg_entity(
+            target,
+            entity,
+            request_url=fetched.request_url,
+            collection_job_id=collection_job_id,
+            collected_at=collected,
+            retention_until=retention_until,
+        )
+        current[target.id] = fingerprint
+        if previous.get(target.id) == fingerprint:
+            continue
+        observations.append(observation)
+        projections.append(projection)
+    return BrregCollectionBatch(
+        observations=tuple(observations),
+        projections=tuple(projections),
+        checkpoint=BrregCheckpoint(current),
+        not_modified=not observations,
+    )
+
+
+def _authorize(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    *,
+    collected_at: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.ORGANIZATION_METADATA,
+            target_url=target_url,
+            purpose="organization-identity-resolution",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=collected_at,
+    )
+    if not decision.allowed:
+        raise BrregCollectionDeniedError(decision.reason.value)
+
+
+def _parse_entity(body: bytes) -> BrregEntity:
+    try:
+        return BrregEntity.model_validate_json(body)
+    except ValidationError as exc:
+        raise BrregSourceSchemaError("BRREG entity schema validation failed") from exc

--- a/src/cip/adapters/sources/brreg_identity/mapper.py
+++ b/src/cip/adapters/sources/brreg_identity/mapper.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from hashlib import sha256
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from cip.adapters.sources.brreg_identity.schemas import BrregEntity
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.modules.evidence.domain.entities import Evidence
+from cip.modules.organizations.application.identity import IdentityProjection
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.organizations.domain.identifiers import IdentifierScheme, OfficialIdentifier
+from cip.modules.organizations.domain.identity import (
+    IdentityKind,
+    IdentityStatus,
+    MatchState,
+    OrganizationIdentity,
+)
+from cip.modules.organizations.domain.matching import build_merge_candidate
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.shared.kernel.time import require_aware_utc
+
+SOURCE_ID = "brreg-enhetsregisteret"
+ADAPTER_ID = "brreg-enhetsregisteret-entity"
+ADAPTER_VERSION = "1.0.0"
+SCHEMA_FINGERPRINT = "brreg-enhet-v2-selected-v1"
+
+
+def map_brreg_entity(
+    target: OrganizationIdentityTarget,
+    entity: BrregEntity,
+    *,
+    request_url: str,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+) -> tuple[RawObservation, IdentityProjection, str]:
+    collected = require_aware_utc(collected_at, field_name="collected_at")
+    identifier = OfficialIdentifier(
+        scheme=IdentifierScheme.FOREIGN_REGISTRATION,
+        value=entity.organisasjonsnummer,
+        source_id=SOURCE_ID,
+        verified_at=collected,
+        issuing_country="NO",
+    )
+    if target.country_code != "NO":
+        raise ValueError("BRREG mapping requires a Norwegian target")
+    if target.foreign_registration != identifier.value:
+        raise ValueError("BRREG response organisation number does not match target")
+    address = entity.business_address()
+    identity = OrganizationIdentity(
+        id=OrganizationIdentity.deterministic_id(identifier.exact_key),
+        kind=IdentityKind.LEGAL_UNIT,
+        official_name=entity.navn,
+        country_code="NO",
+        source_id=SOURCE_ID,
+        source_record_key=f"legal-unit:{identifier.value}",
+        source_url=request_url,
+        confidence=0.99,
+        observed_at=collected,
+        status=IdentityStatus.CEASED if entity.slettedato else IdentityStatus.ACTIVE,
+        identifiers=(identifier,),
+        aliases=entity.aliases(),
+        legal_form=entity.organisasjonsform.kode,
+        activity_code=entity.naeringskode1.kode if entity.naeringskode1 else None,
+        address=address.single_line() if address else None,
+        postal_code=address.postnummer if address else None,
+        city=address.poststed if address else None,
+        valid_from=entity.registreringsdatoEnhetsregisteret or entity.stiftelsesdato,
+        valid_until=entity.slettedato,
+    )
+    target_organization = Organization(
+        id=target.organization_id,
+        canonical_name=target.canonical_name,
+        legal_name=target.canonical_name,
+        country_code=target.country_code,
+        created_at=collected,
+        updated_at=collected,
+    )
+    candidate = build_merge_candidate(
+        identity,
+        target_organization,
+        known_identifiers=target.known_identifiers(
+            source_id="target-registry",
+            verified_at=collected,
+        ),
+        target_postal_code=target.postal_code,
+    )
+    attached = (
+        target_organization
+        if candidate is not None and candidate.state is MatchState.AUTO_CONFIRMED
+        else None
+    )
+    payload_hash = _fingerprint(entity)
+    evidence = Evidence(
+        id=uuid5(NAMESPACE_URL, f"{SOURCE_ID}:evidence:{identifier.value}"),
+        source_id=SOURCE_ID,
+        source_record_key=identity.source_record_key,
+        source_url=request_url,
+        summary=(
+            f"Official Norwegian Central Coordinating Register entity record for "
+            f"{entity.navn} with organisation number {identifier.value}."
+        ),
+        confidence=0.99,
+        collected_at=collected,
+        observed_at=collected,
+        content_hash_sha256=payload_hash,
+        raw_storage_permitted=False,
+        retention_until=retention_until,
+    )
+    observation = RawObservation(
+        source_id=SOURCE_ID,
+        adapter_id=ADAPTER_ID,
+        adapter_version=ADAPTER_VERSION,
+        collection_job_id=collection_job_id,
+        source_record_type="organization_identity",
+        source_record_key=identity.source_record_key,
+        source_url=request_url,
+        payload_hash_sha256=payload_hash,
+        data_categories=frozenset({DataCategory.ORGANIZATION_METADATA}),
+        collected_at=collected,
+        source_updated_at=collected,
+        schema_fingerprint=SCHEMA_FINGERPRINT,
+        content_language="no",
+        classification="internal",
+        retention_until=retention_until,
+    )
+    projection = IdentityProjection(
+        identity=identity,
+        evidence=evidence,
+        attached_organization=attached,
+        candidate_organizations=() if attached else (target_organization,),
+        merge_candidates=(candidate,) if candidate is not None else (),
+    )
+    return observation, projection, payload_hash
+
+
+def _fingerprint(entity: BrregEntity) -> str:
+    payload = entity.model_dump(mode="json", exclude_none=True)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return sha256(encoded).hexdigest()

--- a/src/cip/adapters/sources/brreg_identity/schemas.py
+++ b/src/cip/adapters/sources/brreg_identity/schemas.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class BrregLink(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    href: str
+
+
+class BrregLinks(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class BrregOrganizationForm(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kode: str
+    beskrivelse: str | None = None
+    utgaatt: date | None = None
+    _links: BrregLinks | None = None
+
+
+class BrregIndustryCode(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kode: str
+    beskrivelse: str | None = None
+
+
+class BrregAddress(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kommune: str | None = None
+    landkode: str | None = None
+    postnummer: str | None = None
+    adresse: tuple[str, ...] = ()
+    land: str | None = None
+    kommunenummer: str | None = None
+    poststed: str | None = None
+
+    def single_line(self) -> str | None:
+        parts = [*self.adresse]
+        locality = " ".join(
+            value for value in (self.postnummer, self.poststed) if value
+        ).strip()
+        if locality:
+            parts.append(locality)
+        normalized = ", ".join(value.strip() for value in parts if value.strip())
+        return normalized or None
+
+
+class BrregHistoricalName(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    navn: str
+    fraDato: str | None = None
+    tilDato: str | None = None
+
+
+class BrregEntity(BaseModel):
+    model_config = ConfigDict(extra="allow", str_strip_whitespace=True)
+
+    respons_klasse: str | None = None
+    organisasjonsnummer: str
+    navn: str
+    organisasjonsform: BrregOrganizationForm
+    historiskeNavn: tuple[BrregHistoricalName, ...] = ()
+    postadresse: BrregAddress | None = None
+    forretningsadresse: BrregAddress | None = None
+    registreringsdatoEnhetsregisteret: date | None = None
+    stiftelsesdato: date | None = None
+    slettedato: date | None = None
+    registrertIForetaksregisteret: bool | None = None
+    konkurs: bool | None = None
+    underAvvikling: bool | None = None
+    underTvangsavviklingEllerTvangsopplosning: bool | None = None
+    naeringskode1: BrregIndustryCode | None = None
+    naeringskode2: BrregIndustryCode | None = None
+    naeringskode3: BrregIndustryCode | None = None
+    antallAnsatte: int | None = None
+    overordnetEnhet: str | None = None
+    hjemmeside: str | None = None
+    _links: BrregLinks | None = None
+
+    @field_validator("organisasjonsnummer")
+    @classmethod
+    def _valid_org_number(cls, value: str) -> str:
+        normalized = "".join(character for character in value if character.isdigit())
+        if len(normalized) != 9:
+            raise ValueError("BRREG organisation number must contain 9 digits")
+        return normalized
+
+    @field_validator("navn")
+    @classmethod
+    def _required_name(cls, value: str) -> str:
+        if not value:
+            raise ValueError("BRREG entity name cannot be blank")
+        return value
+
+    @field_validator("antallAnsatte")
+    @classmethod
+    def _non_negative_employees(cls, value: int | None) -> int | None:
+        if value is not None and value < 0:
+            raise ValueError("BRREG employee count cannot be negative")
+        return value
+
+    def aliases(self) -> tuple[str, ...]:
+        values = [item.navn for item in self.historiskeNavn if item.navn != self.navn]
+        return tuple(dict.fromkeys(values))
+
+    def business_address(self) -> BrregAddress | None:
+        return self.forretningsadresse or self.postadresse

--- a/src/cip/adapters/sources/brreg_identity/schemas.py
+++ b/src/cip/adapters/sources/brreg_identity/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class BrregLink(BaseModel):
@@ -11,17 +11,13 @@ class BrregLink(BaseModel):
     href: str
 
 
-class BrregLinks(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
-
 class BrregOrganizationForm(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     kode: str
     beskrivelse: str | None = None
     utgaatt: date | None = None
-    _links: BrregLinks | None = None
+    links: dict[str, BrregLink] | None = Field(default=None, alias="_links")
 
 
 class BrregIndustryCode(BaseModel):
@@ -62,7 +58,7 @@ class BrregHistoricalName(BaseModel):
 
 
 class BrregEntity(BaseModel):
-    model_config = ConfigDict(extra="allow", str_strip_whitespace=True)
+    model_config = ConfigDict(extra="allow", str_strip_whitespace=True, populate_by_name=True)
 
     respons_klasse: str | None = None
     organisasjonsnummer: str
@@ -84,7 +80,7 @@ class BrregEntity(BaseModel):
     antallAnsatte: int | None = None
     overordnetEnhet: str | None = None
     hjemmeside: str | None = None
-    _links: BrregLinks | None = None
+    links: dict[str, BrregLink] | None = Field(default=None, alias="_links")
 
     @field_validator("organisasjonsnummer")
     @classmethod

--- a/src/cip/adapters/sources/organization_identity/registry.py
+++ b/src/cip/adapters/sources/organization_identity/registry.py
@@ -27,6 +27,7 @@ class OrganizationIdentityTarget:
     siren: str | None = None
     siret: str | None = None
     lei: str | None = None
+    foreign_registration: str | None = None
     enabled: bool = True
 
     def __post_init__(self) -> None:
@@ -42,10 +43,11 @@ class OrganizationIdentityTarget:
         if self.postal_code is not None:
             postal_code = self.postal_code.strip()
             object.__setattr__(self, "postal_code", postal_code or None)
-        for field_name, scheme in (
-            ("siren", IdentifierScheme.SIREN),
-            ("siret", IdentifierScheme.SIRET),
-            ("lei", IdentifierScheme.LEI),
+        for field_name, scheme, issuing_country in (
+            ("siren", IdentifierScheme.SIREN, "FR"),
+            ("siret", IdentifierScheme.SIRET, "FR"),
+            ("lei", IdentifierScheme.LEI, None),
+            ("foreign_registration", IdentifierScheme.FOREIGN_REGISTRATION, country),
         ):
             value = getattr(self, field_name)
             if value is None:
@@ -55,7 +57,7 @@ class OrganizationIdentityTarget:
                 value=value,
                 source_id="target-registry",
                 verified_at=_REGISTRY_TIME,
-                issuing_country="FR" if scheme is not IdentifierScheme.LEI else None,
+                issuing_country=issuing_country,
             )
             object.__setattr__(self, field_name, identifier.value)
 
@@ -66,10 +68,15 @@ class OrganizationIdentityTarget:
         verified_at: datetime,
     ) -> tuple[OfficialIdentifier, ...]:
         identifiers: list[OfficialIdentifier] = []
-        for value, scheme in (
-            (self.siren, IdentifierScheme.SIREN),
-            (self.siret, IdentifierScheme.SIRET),
-            (self.lei, IdentifierScheme.LEI),
+        for value, scheme, issuing_country in (
+            (self.siren, IdentifierScheme.SIREN, "FR"),
+            (self.siret, IdentifierScheme.SIRET, "FR"),
+            (self.lei, IdentifierScheme.LEI, None),
+            (
+                self.foreign_registration,
+                IdentifierScheme.FOREIGN_REGISTRATION,
+                self.country_code,
+            ),
         ):
             if value is None:
                 continue
@@ -79,7 +86,7 @@ class OrganizationIdentityTarget:
                     value=value,
                     source_id=source_id,
                     verified_at=verified_at,
-                    issuing_country="FR" if scheme is not IdentifierScheme.LEI else None,
+                    issuing_country=issuing_country,
                 )
             )
         return tuple(identifiers)
@@ -132,6 +139,7 @@ def _parse_target(payload: dict[str, Any]) -> OrganizationIdentityTarget:
         siren=_optional_string(payload, "siren"),
         siret=_optional_string(payload, "siret"),
         lei=_optional_string(payload, "lei"),
+        foreign_registration=_optional_string(payload, "foreign_registration"),
         enabled=enabled,
     )
 
@@ -158,7 +166,8 @@ def _optional_string(payload: dict[str, Any], key: str) -> str | None:
         return None
     if not isinstance(value, str):
         raise ValueError(f"{key} must be a string or null")
-    return value
+    normalized = value.strip()
+    return normalized or None
 
 
 def _positive_int(payload: dict[str, Any], key: str) -> int:

--- a/src/cip/modules/collection_orchestration/application/brreg_identity_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/brreg_identity_adapter.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.brreg_identity.client import (
+    BrregEntityRemovedError,
+    BrregIdentityClient,
+    BrregSourceResponseError,
+)
+from cip.adapters.sources.brreg_identity.collector import (
+    BrregCheckpoint,
+    BrregCollectionDeniedError,
+    BrregSourceSchemaError,
+    collect_brreg_entities,
+)
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.source_governance.domain.models import DataCategory
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class BrregIdentityAdapter:
+    source_id = "brreg-enhetsregisteret"
+    adapter_id = "brreg-enhetsregisteret-entity"
+    data_category = DataCategory.ORGANIZATION_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[OrganizationIdentityTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("BRREG adapter requires its source policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._targets = targets
+        self._timeout_seconds = timeout_seconds
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+            ) as http_client:
+                batch = collect_brreg_entities(
+                    BrregIdentityClient(
+                        http_client,
+                        entities_url=self._entry.policy.base_url,
+                    ),
+                    self._entry,
+                    self._targets,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    checkpoint=checkpoint,
+                )
+        except BrregCollectionDeniedError as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except BrregSourceSchemaError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except BrregEntityRemovedError as exc:
+            raise _execution_error(exc, "source_record_removed", retryable=False) from exc
+        except BrregSourceResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"BRREG returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            checkpoint_payload={"fingerprints": dict(batch.checkpoint.fingerprints)},
+            not_modified=batch.not_modified,
+            identity_projections=batch.projections,
+        )
+
+
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> BrregCheckpoint | None:
+    if payload is None:
+        return None
+    raw = payload.get("fingerprints")
+    if not isinstance(raw, dict):
+        raise _invalid_checkpoint()
+    fingerprints: dict[str, str] = {}
+    for target_id, fingerprint in raw.items():
+        if not isinstance(target_id, str) or not isinstance(fingerprint, str):
+            raise _invalid_checkpoint()
+        fingerprints[target_id] = fingerprint
+    return BrregCheckpoint(fingerprints)
+
+
+def _invalid_checkpoint() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "BRREG checkpoint fingerprints must contain string target/hash values",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/src/cip/modules/collection_orchestration/application/identity_adapters.py
+++ b/src/cip/modules/collection_orchestration/application/identity_adapters.py
@@ -6,6 +6,9 @@ from cip.adapters.sources.organization_identity.registry import OrganizationIden
 from cip.modules.collection_orchestration.application.bodacc_identity_adapter import (
     BodaccIdentityAdapter,
 )
+from cip.modules.collection_orchestration.application.brreg_identity_adapter import (
+    BrregIdentityAdapter,
+)
 from cip.modules.collection_orchestration.application.gleif_adapter import GleifAdapter
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.collection_orchestration.application.recherche_entreprises_adapter import (
@@ -21,6 +24,16 @@ def register_identity_adapters(
     *,
     timeout_seconds: float,
 ) -> None:
+    brreg_entry = entries_by_id.get(BrregIdentityAdapter.source_id)
+    if brreg_entry is not None:
+        _register(
+            adapters,
+            BrregIdentityAdapter(
+                brreg_entry,
+                targets,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
     if not any(target.enabled for target in targets):
         return
     recherche_entry = entries_by_id.get(RechercheEntreprisesAdapter.source_id)

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -137,6 +137,7 @@ def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
     return load_source_registry_bundle(
         settings.source_registry_path,
         settings.identity_source_registry_path,
+        settings.company_identity_expansion_source_registry_path,
         settings.decp_source_registry_path,
         settings.procurement_funding_source_registry_path,
         settings.public_web_source_registry_path,
@@ -157,6 +158,7 @@ def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
 def _load_portfolio(settings: Settings) -> tuple[SourceCatalogEntry, ...]:
     return load_source_portfolio_bundle(
         settings.source_portfolio_path,
+        settings.company_identity_expansion_source_portfolio_path,
         settings.decp_source_portfolio_path,
         settings.procurement_funding_source_portfolio_path,
         settings.public_web_source_portfolio_path,

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -24,6 +24,9 @@ class Settings(BaseSettings):
     )
     source_registry_path: Path = Path("policies/sources.example.yml")
     identity_source_registry_path: Path = Path("policies/identity_sources.yml")
+    company_identity_expansion_source_registry_path: Path = Path(
+        "policies/sources.company_identity_expansion.yml"
+    )
     decp_source_registry_path: Path = Path("policies/sources.decp.yml")
     procurement_funding_source_registry_path: Path = Path(
         "policies/sources.procurement_funding.yml"
@@ -54,6 +57,9 @@ class Settings(BaseSettings):
     ats_source_registry_path: Path = Path("policies/sources.ats_expansion.yml")
     provider_onboarding_registry_path: Path = Path("policies/provider_onboarding.yml")
     source_portfolio_path: Path = Path("policies/source_portfolio.yml")
+    company_identity_expansion_source_portfolio_path: Path = Path(
+        "policies/source_portfolio.company_identity_expansion.yml"
+    )
     decp_source_portfolio_path: Path = Path("policies/source_portfolio.decp.yml")
     procurement_funding_source_portfolio_path: Path = Path(
         "policies/source_portfolio.procurement_funding.yml"

--- a/tests/unit/adapters/brreg_identity/test_source.py
+++ b/tests/unit/adapters/brreg_identity/test_source.py
@@ -23,9 +23,11 @@ from cip.adapters.sources.brreg_identity.collector import (
 )
 from cip.adapters.sources.brreg_identity.mapper import map_brreg_entity
 from cip.adapters.sources.brreg_identity.schemas import BrregEntity
-from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
-from cip.modules.organizations.domain.identity import MatchMethod
+from cip.adapters.sources.organization_identity.registry import (
+    OrganizationIdentityTarget,
+)
 from cip.modules.organizations.domain.identifiers import IdentifierScheme
+from cip.modules.organizations.domain.identity import MatchMethod
 from cip.modules.source_governance.domain.models import SourceStatus
 from cip.modules.source_governance.infrastructure.registry import (
     SourceRegistryEntry,
@@ -73,6 +75,8 @@ def test_schema_and_mapper_attach_only_on_exact_norwegian_registration() -> None
     assert projection.identity.address == "Havnegata 48, 8900 BRØNNØYSUND"
     assert projection.attached_organization is not None
     assert projection.merge_candidates[0].method is MatchMethod.EXACT_IDENTIFIER
+    assert entity.organisasjonsform.links is not None
+    assert "self" in entity.organisasjonsform.links
     assert len(fingerprint) == 64
 
 
@@ -180,11 +184,13 @@ def test_client_handles_public_media_type_size_and_legal_removal() -> None:
     assert result.request_url.endswith("/974760673")
 
     removed = httpx.MockTransport(lambda request: httpx.Response(410, request=request))
-    with httpx.Client(transport=removed) as http_client:
-        with pytest.raises(BrregEntityRemovedError, match="removed"):
-            BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
-                "974760673"
-            )
+    with (
+        httpx.Client(transport=removed) as http_client,
+        pytest.raises(BrregEntityRemovedError, match="removed"),
+    ):
+        BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
+            "974760673"
+        )
 
     non_json = httpx.MockTransport(
         lambda request: httpx.Response(
@@ -194,11 +200,13 @@ def test_client_handles_public_media_type_size_and_legal_removal() -> None:
             request=request,
         )
     )
-    with httpx.Client(transport=non_json) as http_client:
-        with pytest.raises(BrregSourceResponseError, match="content type"):
-            BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
-                "974760673"
-            )
+    with (
+        httpx.Client(transport=non_json) as http_client,
+        pytest.raises(BrregSourceResponseError, match="content type"),
+    ):
+        BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
+            "974760673"
+        )
 
 
 def _target() -> OrganizationIdentityTarget:
@@ -217,7 +225,9 @@ def _target() -> OrganizationIdentityTarget:
 def _entry() -> SourceRegistryEntry:
     return next(
         entry
-        for entry in load_source_registry(Path("policies/sources.company_identity_expansion.yml"))
+        for entry in load_source_registry(
+            Path("policies/sources.company_identity_expansion.yml")
+        )
         if entry.policy.id == "brreg-enhetsregisteret"
     )
 
@@ -227,8 +237,21 @@ def _entity(**changes: object) -> dict[str, object]:
         "respons_klasse": "Enhet",
         "organisasjonsnummer": "974760673",
         "navn": "BRØNNØYSUNDREGISTRENE",
-        "organisasjonsform": {"kode": "ORGL", "beskrivelse": "Organisasjonsledd"},
-        "historiskeNavn": [{"navn": "BRØNNØYSUNDREGISTRENE", "fraDato": "1998-01-16 19:22:18"}],
+        "organisasjonsform": {
+            "kode": "ORGL",
+            "beskrivelse": "Organisasjonsledd",
+            "_links": {
+                "self": {
+                    "href": (
+                        "https://data.brreg.no/enhetsregisteret/api/"
+                        "organisasjonsformer/ORGL"
+                    )
+                }
+            },
+        },
+        "historiskeNavn": [
+            {"navn": "BRØNNØYSUNDREGISTRENE", "fraDato": "1998-01-16 19:22:18"}
+        ],
         "forretningsadresse": {
             "land": "Norge",
             "landkode": "NO",
@@ -243,7 +266,10 @@ def _entity(**changes: object) -> dict[str, object]:
         "konkurs": False,
         "underAvvikling": False,
         "underTvangsavviklingEllerTvangsopplosning": False,
-        "naeringskode1": {"kode": "84.110", "beskrivelse": "Generell offentlig administrasjon"},
+        "naeringskode1": {
+            "kode": "84.110",
+            "beskrivelse": "Generell offentlig administrasjon",
+        },
         "antallAnsatte": 590,
         "_links": {"self": {"href": f"{ENTITIES_URL}/974760673"}},
     }

--- a/tests/unit/adapters/brreg_identity/test_source.py
+++ b/tests/unit/adapters/brreg_identity/test_source.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.brreg_identity.client import (
+    BrregEntityRemovedError,
+    BrregFetchResult,
+    BrregIdentityClient,
+    BrregSourceResponseError,
+)
+from cip.adapters.sources.brreg_identity.collector import (
+    BrregCheckpoint,
+    BrregCollectionDeniedError,
+    collect_brreg_entities,
+)
+from cip.adapters.sources.brreg_identity.mapper import map_brreg_entity
+from cip.adapters.sources.brreg_identity.schemas import BrregEntity
+from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
+from cip.modules.organizations.domain.identity import MatchMethod
+from cip.modules.organizations.domain.identifiers import IdentifierScheme
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 10, 0, tzinfo=UTC)
+ENTITIES_URL = "https://data.brreg.no/enhetsregisteret/api/enheter"
+
+
+class StubBrregClient:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.calls: list[str] = []
+
+    def entity_url(self, registration_number: str) -> str:
+        return f"{ENTITIES_URL}/{registration_number}"
+
+    def fetch_entity(self, registration_number: str) -> BrregFetchResult:
+        self.calls.append(registration_number)
+        return BrregFetchResult(
+            body=json.dumps(self.payload).encode(),
+            request_url=self.entity_url(registration_number),
+        )
+
+
+def test_schema_and_mapper_attach_only_on_exact_norwegian_registration() -> None:
+    target = _target()
+    entity = BrregEntity.model_validate(_entity())
+    observation, projection, fingerprint = map_brreg_entity(
+        target,
+        entity,
+        request_url=f"{ENTITIES_URL}/974760673",
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+
+    assert observation.source_id == "brreg-enhetsregisteret"
+    assert projection.identity.country_code == "NO"
+    assert projection.identity.identifiers[0].scheme is IdentifierScheme.FOREIGN_REGISTRATION
+    assert projection.identity.identifiers[0].value == "974760673"
+    assert projection.identity.official_name == "BRØNNØYSUNDREGISTRENE"
+    assert projection.identity.activity_code == "84.110"
+    assert projection.identity.address == "Havnegata 48, 8900 BRØNNØYSUND"
+    assert projection.attached_organization is not None
+    assert projection.merge_candidates[0].method is MatchMethod.EXACT_IDENTIFIER
+    assert len(fingerprint) == 64
+
+
+def test_mapper_rejects_wrong_target_registration_even_when_name_matches() -> None:
+    target = replace(_target(), foreign_registration="917625026")
+    with pytest.raises(ValueError, match="does not match target"):
+        map_brreg_entity(
+            target,
+            BrregEntity.model_validate(_entity()),
+            request_url=f"{ENTITIES_URL}/974760673",
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+
+def test_schema_rejects_bad_org_number_blank_name_and_negative_employees() -> None:
+    with pytest.raises(ValidationError):
+        BrregEntity.model_validate(_entity(organisasjonsnummer="123"))
+    with pytest.raises(ValidationError):
+        BrregEntity.model_validate(_entity(navn=" "))
+    with pytest.raises(ValidationError):
+        BrregEntity.model_validate(_entity(antallAnsatte=-1))
+
+
+def test_collector_is_idempotent_and_governed() -> None:
+    client = StubBrregClient(_entity())
+    first = collect_brreg_entities(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        (_target(),),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert len(first.observations) == 1
+    assert len(first.projections) == 1
+    assert first.not_modified is False
+    assert client.calls == ["974760673"]
+
+    second = collect_brreg_entities(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        (_target(),),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+        checkpoint=BrregCheckpoint(dict(first.checkpoint.fingerprints)),
+    )
+    assert second.observations == ()
+    assert second.projections == ()
+    assert second.not_modified is True
+
+    denied = replace(
+        _entry(),
+        policy=replace(_entry().policy, status=SourceStatus.QUARANTINED),
+    )
+    with pytest.raises(BrregCollectionDeniedError, match="source_not_enabled"):
+        collect_brreg_entities(
+            client,  # type: ignore[arg-type]
+            denied,
+            (_target(),),
+            collection_job_id=uuid4(),
+            collected_at=NOW,
+            retention_until=NOW + timedelta(days=365),
+        )
+
+
+def test_collector_ignores_disabled_or_non_norwegian_targets() -> None:
+    client = StubBrregClient(_entity())
+    batch = collect_brreg_entities(
+        client,  # type: ignore[arg-type]
+        _entry(),
+        (
+            replace(_target(), enabled=False),
+            replace(
+                _target(),
+                id="fr",
+                organization_id=UUID("86fe6126-5731-5c4d-a206-69a6a736cae5"),
+                country_code="FR",
+                foreign_registration="974760673",
+            ),
+        ),
+        collection_job_id=uuid4(),
+        collected_at=NOW,
+        retention_until=NOW + timedelta(days=365),
+    )
+    assert batch.not_modified is True
+    assert client.calls == []
+
+
+def test_client_handles_public_media_type_size_and_legal_removal() -> None:
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            headers={"content-type": BrregIdentityClient.ACCEPT},
+            json=_entity(),
+            request=request,
+        )
+    )
+    with httpx.Client(transport=transport) as http_client:
+        result = BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
+            "974 760 673"
+        )
+    assert result.request_url.endswith("/974760673")
+
+    removed = httpx.MockTransport(lambda request: httpx.Response(410, request=request))
+    with httpx.Client(transport=removed) as http_client:
+        with pytest.raises(BrregEntityRemovedError, match="removed"):
+            BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
+                "974760673"
+            )
+
+    non_json = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            headers={"content-type": "text/html"},
+            text="bad",
+            request=request,
+        )
+    )
+    with httpx.Client(transport=non_json) as http_client:
+        with pytest.raises(BrregSourceResponseError, match="content type"):
+            BrregIdentityClient(http_client, entities_url=ENTITIES_URL).fetch_entity(
+                "974760673"
+            )
+
+
+def _target() -> OrganizationIdentityTarget:
+    return OrganizationIdentityTarget(
+        id="brreg-validation",
+        organization_id=UUID("7f3ea686-13c2-5c32-9a20-d3ed5c6fab2c"),
+        canonical_name="Brønnøysundregistrene",
+        country_code="NO",
+        query="Brønnøysundregistrene",
+        postal_code="8900",
+        foreign_registration="974760673",
+        enabled=True,
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(Path("policies/sources.company_identity_expansion.yml"))
+        if entry.policy.id == "brreg-enhetsregisteret"
+    )
+
+
+def _entity(**changes: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "respons_klasse": "Enhet",
+        "organisasjonsnummer": "974760673",
+        "navn": "BRØNNØYSUNDREGISTRENE",
+        "organisasjonsform": {"kode": "ORGL", "beskrivelse": "Organisasjonsledd"},
+        "historiskeNavn": [{"navn": "BRØNNØYSUNDREGISTRENE", "fraDato": "1998-01-16 19:22:18"}],
+        "forretningsadresse": {
+            "land": "Norge",
+            "landkode": "NO",
+            "postnummer": "8900",
+            "poststed": "BRØNNØYSUND",
+            "adresse": ["Havnegata 48"],
+            "kommune": "BRØNNØY",
+            "kommunenummer": "1813",
+        },
+        "registreringsdatoEnhetsregisteret": "1995-03-12",
+        "registrertIForetaksregisteret": False,
+        "konkurs": False,
+        "underAvvikling": False,
+        "underTvangsavviklingEllerTvangsopplosning": False,
+        "naeringskode1": {"kode": "84.110", "beskrivelse": "Generell offentlig administrasjon"},
+        "antallAnsatte": 590,
+        "_links": {"self": {"href": f"{ENTITIES_URL}/974760673"}},
+    }
+    payload.update(changes)
+    return payload

--- a/tests/unit/source_activation/test_sa11_company_identity_activation.py
+++ b/tests/unit/source_activation/test_sa11_company_identity_activation.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from cip.modules.source_activation.domain.models import (
+    ActivationDisposition,
+    ActivationStage,
+)
+from cip.modules.source_activation.infrastructure.inventory import load_activation_inventory
+from cip.modules.source_governance.domain.models import SourceStatus
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_portfolio.infrastructure.registry_bundle import (
+    load_source_portfolio_bundle,
+)
+
+ACTIVATION_PATH = Path("policies/source_activation.yml")
+POLICY_PATH = Path("policies/sources.company_identity_expansion.yml")
+PORTFOLIO_PATH = Path("policies/source_portfolio.company_identity_expansion.yml")
+LIVE_WORKFLOW_PATH = Path(".github/workflows/sa11-live-validation.yml")
+LIVE_SCRIPT_PATH = Path("scripts/live_validate_sa11.py")
+
+
+def test_sa11_brreg_is_fully_integrated_after_live_proof() -> None:
+    records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
+    record = records["brreg-enhetsregisteret"]
+
+    assert record.disposition is ActivationDisposition.ACTIVE
+    assert record.activation_wave == "SA-11"
+    assert record.requires_schedule is False
+    assert record.is_fully_integrated
+    assert {
+        ActivationStage.ADAPTER_PRESENT,
+        ActivationStage.AUTHORIZED,
+        ActivationStage.EXECUTABLE,
+        ActivationStage.LIVE_TESTED,
+    } <= record.stages
+    assert ActivationStage.SCHEDULED not in record.stages
+
+
+def test_sa11_access_controlled_candidates_remain_fail_closed() -> None:
+    records = {record.source_id: record for record in load_activation_inventory(ACTIVATION_PATH)}
+
+    sirene = records["sirene-api"]
+    assert sirene.disposition is ActivationDisposition.MANUAL
+    assert sirene.reason
+    assert ActivationStage.EXECUTABLE not in sirene.stages
+    assert ActivationStage.LIVE_TESTED not in sirene.stages
+
+    for source_id in ("inpi-rne", "opencorporates-licensed"):
+        record = records[source_id]
+        assert record.disposition is ActivationDisposition.BLOCKED
+        assert record.reason
+        assert ActivationStage.ADAPTER_PRESENT not in record.stages
+        assert ActivationStage.EXECUTABLE not in record.stages
+        assert ActivationStage.LIVE_TESTED not in record.stages
+
+
+def test_sa11_brreg_policy_and_portfolio_match_runtime_contract() -> None:
+    entries = {entry.policy.id: entry for entry in load_source_registry(POLICY_PATH)}
+    entry = entries["brreg-enhetsregisteret"]
+    assert entry.policy.status is SourceStatus.ENABLED
+    assert entry.authorization.automated_collection_allowed
+    assert entry.authorization.approved_hosts == frozenset({"data.brreg.no"})
+    assert entry.authorization.approved_path_prefixes == (
+        "/enhetsregisteret/api/enheter/",
+    )
+
+    portfolio = {
+        item.source_id: item
+        for item in load_source_portfolio_bundle(PORTFOLIO_PATH)
+    }
+    source = portfolio["brreg-enhetsregisteret"]
+    assert source.executable is True
+    assert source.adapter is not None
+    assert source.adapter.adapter_id == "brreg-enhetsregisteret-entity"
+    assert source.metadata["scheduled_by_default"] is False
+
+
+def test_sa11_live_gate_executes_production_adapter_without_person_endpoints() -> None:
+    workflow = LIVE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = LIVE_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "Controlled BRREG live validation" in workflow
+    assert "python scripts/live_validate_sa11.py" in workflow
+    assert "BrregIdentityAdapter(" in script
+    assert 'VALIDATION_ORG_NUMBER = "974760673"' in script
+    assert "identity_projections" in script
+    assert "roller" not in script.casefold()
+    assert "maskinporten" not in script.casefold()


### PR DESCRIPTION
Implements issue #104 incrementally.

Current scope:
- provider-specific Brønnøysundregistrene Enhetsregisteret public company-identity adapter;
- exact Norwegian organisation-number targeting using canonical foreign-registration identifiers;
- no name-only automatic merge and no person/role/Maskinporten endpoints;
- governed bounded GET acquisition, canonical identity/evidence/raw-observation mapping, checkpoint idempotency and runtime registration;
- explicit fail-closed dispositions for direct Sirene, INPI/RNE and OpenCorporates pending provider-specific value/access/licence proof;
- controlled BRREG live validation against the public BRREG operator entity only.

Draft until exact-head CI and controlled live validation are green. `live_tested` is intentionally not set yet.