### PR TITLE
SA-14: add governed Common Crawl archive discovery

### DIFF
--- a/.github/workflows/sa14-live-validation.yml
+++ b/.github/workflows/sa14-live-validation.yml
@@ -1,0 +1,33 @@
+name: SA-14 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa14-live-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-common-crawl:
+    if: github.event.pull_request.head.ref == 'agent/sa14-common-crawl-discovery'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled Common Crawl live validation
+        run: python scripts/live_validate_sa14.py

--- a/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
+++ b/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
@@ -1,0 +1,69 @@
+# SA-14 — Search, dorks, and archive discovery expansion
+
+## Objective
+
+SA-14 expands governed discovery without creating a second research subsystem. Search/archive metadata remains a lead that must be followed through an approved retrieval path before it can support a factual claim or commercial conclusion.
+
+Existing Brave Search and Internet Archive/CDX adapters remain authoritative. SA-14 adds provider-specific capabilities only where they provide distinct coverage.
+
+## Common Crawl URL Index
+
+Source id: `common-crawl-index`.
+
+The first SA-14 tranche uses Common Crawl's public CDXJ URL Index through `index.commoncrawl.org`. It does not download WARC bodies.
+
+The adapter first retrieves `collinfo.json`, validates collection metadata and chooses the newest valid `CC-MAIN-YYYY-WW` collection dynamically. It then queries only the exact approved target/path prefix selected from the existing governed `PublicWebTarget` registry.
+
+Provider requests are bounded to 50 capture records and a 2 MB response. A descriptive User-Agent is supplied. Results outside the target's existing crawl scope are discarded even if returned by the provider.
+
+Selected fields are limited to:
+
+- timestamp;
+- original URL;
+- MIME type;
+- HTTP status;
+- digest;
+- WARC record length;
+- WARC offset;
+- WARC filename.
+
+The WARC filename/offset/length are retained only as archive-index provenance. This tranche never follows them to `data.commoncrawl.org` and never stores the crawled page body.
+
+Each accepted capture emits an immutable `RawObservation` and a quarantined Lot 12 `ARCHIVE_SNAPSHOT` public-footprint projection. The projection contains no claims. Common Crawl historical presence is not current deployment, exposure, vulnerability, compromise, need, opportunity, or outreach authorization.
+
+## Target and checkpoint semantics
+
+Common Crawl reuses the existing `PublicWebTarget` scope rather than introducing a parallel organization-target model.
+
+The adapter expands each enabled target into exact allowed path prefixes. A target/prefix pair is queried using an index wildcard scoped to that origin and prefix. Returned URLs are independently checked through the target's `CrawlScope` before persistence.
+
+The checkpoint contains:
+
+- the next target/prefix index;
+- the last processed Common Crawl collection ID per target/prefix pair.
+
+The provider collection list may still be checked on a later schedule run, but an unchanged crawl ID prevents a duplicate capture query for the same target/prefix.
+
+## Provider governance
+
+Only these Common Crawl provider paths are authorized:
+
+- `/collinfo.json` for published collection metadata;
+- `/CC-MAIN-...-index` for bounded CDXJ index queries.
+
+Raw crawled content is not authorized by this source path. Common Crawl's terms also make clear that third-party crawled content may have separate rights and must not be treated as provider-verified truth.
+
+## GDELT migration boundary
+
+GDELT remains a high-value SA-14 event/news-discovery candidate. In 2026 the provider announced migration of the API ecosystem toward GDELT 5 / Spanner. SA-14 will not create a new production adapter against a legacy contract merely to mark the candidate complete. GDELT will be revisited against the current documented public interface once the migration provides a stable provider-specific execution contract.
+
+## Completion gate for the Common Crawl tranche
+
+Common Crawl may receive `live_tested` only when:
+
+1. source governance, portfolio, schedule and runtime registration agree on the same provider identity;
+2. deterministic tests cover collection selection, target scope, schema drift, checkpoint replay and failure classification;
+3. the production adapter obtains non-empty metadata from a controlled approved target through the real Common Crawl service;
+4. each live capture maps one-for-one into a raw observation and a quarantined public-footprint projection with zero claims;
+5. no WARC body is fetched;
+6. the complete repository CI and dedicated SA-14 live workflow pass on the exact final PR head.

--- a/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
+++ b/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
@@ -12,7 +12,17 @@ Source id: `common-crawl-index`.
 
 The first SA-14 tranche uses Common Crawl's public CDXJ URL Index through `index.commoncrawl.org`. It does not download WARC bodies.
 
-The adapter first retrieves `collinfo.json`, validates collection metadata and chooses the newest valid `CC-MAIN-YYYY-WW` collection dynamically. It then queries only the exact approved target/path prefix selected from the existing governed `PublicWebTarget` registry.
+The adapter first retrieves `collinfo.json`, validates collection metadata and chooses the newest collection by the provider's `to` timestamp. It then queries only the exact approved target/path prefix selected from the existing governed `PublicWebTarget` registry.
+
+### Published collection identity forms
+
+Controlled live validation exposed historical collection identities that are still present in the provider's current `collinfo.json`. The implementation therefore validates the complete published family rather than assuming every historical record follows the modern naming convention:
+
+- modern crawl: `CC-MAIN-YYYY-WW`, for example `CC-MAIN-2026-30`;
+- annual legacy crawl: `CC-MAIN-2012`;
+- legacy range crawl: `CC-MAIN-2009-2010` and `CC-MAIN-2008-2009`.
+
+These forms are locked through deterministic regression tests. The newest crawl is selected from provider chronology, not by lexically comparing these heterogeneous identifiers.
 
 Provider requests are bounded to 50 capture records and a 2 MB response. A descriptive User-Agent is supplied. Results outside the target's existing crawl scope are discarded even if returned by the provider.
 
@@ -53,17 +63,33 @@ Only these Common Crawl provider paths are authorized:
 
 Raw crawled content is not authorized by this source path. Common Crawl's terms also make clear that third-party crawled content may have separate rights and must not be treated as provider-verified truth.
 
+## Controlled live validation
+
+The dedicated `.github/workflows/sa14-live-validation.yml` workflow runs `scripts/live_validate_sa14.py` against the production adapter itself. The controlled target is Common Crawl's own public domain, so provider behavior is tested without using a prospect organization as a test target.
+
+The successful provider proof on source head `142208db3d42bc956d672297c2e7ef0408c086b9` used current crawl `CC-MAIN-2026-30` and produced:
+
+- Common Crawl index observations: `43`;
+- quarantined public-footprint projections: `43`;
+- claims: `0`;
+- WARC bodies retrieved: `0`.
+
+The exact one-for-one observation/projection count proves that live provider index records survive the real adapter boundary while preserving the metadata-only quarantine boundary. It does not make those historical URLs factual evidence of current organization state.
+
+This controlled proof justified adding `live_tested` to Common Crawl Source Activation. Because this documentation and activation change modify the branch head, the dedicated live workflow and complete repository CI must pass again on the exact final merge candidate.
+
 ## GDELT migration boundary
 
 GDELT remains a high-value SA-14 event/news-discovery candidate. In 2026 the provider announced migration of the API ecosystem toward GDELT 5 / Spanner. SA-14 will not create a new production adapter against a legacy contract merely to mark the candidate complete. GDELT will be revisited against the current documented public interface once the migration provides a stable provider-specific execution contract.
 
 ## Completion gate for the Common Crawl tranche
 
-Common Crawl may receive `live_tested` only when:
+Common Crawl may be squash-merged only when:
 
 1. source governance, portfolio, schedule and runtime registration agree on the same provider identity;
-2. deterministic tests cover collection selection, target scope, schema drift, checkpoint replay and failure classification;
+2. deterministic tests cover collection selection, target scope, schema drift, historical collection identities, checkpoint replay and failure classification;
 3. the production adapter obtains non-empty metadata from a controlled approved target through the real Common Crawl service;
 4. each live capture maps one-for-one into a raw observation and a quarantined public-footprint projection with zero claims;
 5. no WARC body is fetched;
-6. the complete repository CI and dedicated SA-14 live workflow pass on the exact final PR head.
+6. the complete repository CI and dedicated SA-14 live workflow pass on the exact final PR head;
+7. reviews and review threads are clear before squash merge.

--- a/policies/collection_schedules.search_archives.yml
+++ b/policies/collection_schedules.search_archives.yml
@@ -24,3 +24,15 @@ schedules:
       max_delay_seconds: 3600
       circuit_failure_threshold: 3
       circuit_reset_seconds: 3600
+
+  - source_id: common-crawl-index
+    adapter_id: common-crawl-cdxj-index
+    enabled: true
+    interval_seconds: 604800
+    lease_seconds: 180
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 600
+      max_delay_seconds: 7200
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 14400

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -1,0 +1,16 @@
+version: 1
+
+sources:
+  - source_id: common-crawl-index
+    display_name: Common Crawl CDXJ URL Index
+    category: corporate_public_footprint
+    disposition: active
+    activation_wave: SA-14
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable
+      - scheduled

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -14,3 +14,4 @@ sources:
       - authorized
       - executable
       - scheduled
+      - live_tested

--- a/policies/source_portfolio.search_archives.yml
+++ b/policies/source_portfolio.search_archives.yml
@@ -65,3 +65,37 @@ sources:
       supports_retractions: false
       max_page_size: 50
       cost_per_request: 0
+
+  - source_id: common-crawl-index
+    display_name: Common Crawl CDXJ URL Index
+    canonical_url: https://index.commoncrawl.org
+    category: corporate_public_footprint
+    status: executable
+    freshness_max_age_seconds: 604800
+    commercial_use_cases:
+      - public_evidence_map
+      - change_history
+      - historical_public_discovery
+    candidate_origin: SA-14
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      raw_archive_body_storage: false
+      historical_metadata_only: true
+      search_result_is_evidence: false
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: common-crawl-cdxj-index
+      adapter_version: "1"
+      provider_schema_version: common-crawl-cdxj-v1
+      modes: [incremental_cursor, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - public_resource
+        - public_resource_version
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 50
+      cost_per_request: 0

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -1,5 +1,5 @@
 version: 1
-reviewed_at: 2026-08-09
+reviewed_at: 2026-08-11
 
 sources:
   - id: brave-search-api
@@ -76,3 +76,41 @@ sources:
     notes: >-
       CDX index metadata only. Archived body retrieval is a separate acquisition path and archive
       timestamps never imply current conditions.
+
+  - id: common-crawl-index
+    name: Common Crawl CDXJ URL Index discovery
+    base_url: https://index.commoncrawl.org/collinfo.json
+    status: enabled
+    source_type: api
+    owner: Common Crawl Foundation
+    terms_url: https://commoncrawl.org/terms-of-use
+    licence: Common Crawl Terms of Use; third-party crawled-content rights remain source-specific
+    allowed_data_categories: [public_result_metadata]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 2
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_14_SEARCH_ARCHIVES.md#common-crawl-index
+      reviewed_at: "2026-08-11T10:35:00+00:00"
+      expires_at: null
+      approved_hosts: [index.commoncrawl.org]
+      approved_path_prefixes:
+        - /collinfo.json
+        - /CC-MAIN-
+      approved_purposes: [archive-discovery]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: high
+    notes: >-
+      Target-bound Common Crawl URL-index metadata only. WARC body retrieval is intentionally
+      excluded from this source path. A capture proves historical index presence only; it does not
+      prove current deployment, exposure, vulnerability, compromise, need, or outreach authority.

--- a/scripts/live_validate_sa14.py
+++ b/scripts/live_validate_sa14.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.common_crawl_adapter import (
+    CommonCrawlIndexAdapter,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+ORG_ID = UUID("7a0b182e-353e-5a61-8be4-703e935e227d")
+
+
+def main() -> None:
+    entry = next(
+        item
+        for item in load_source_registry(POLICY_PATH)
+        if item.policy.id == "common-crawl-index"
+    )
+    now = datetime.now(UTC)
+    target = PublicWebTarget(
+        id="common-crawl-provider-live",
+        organization_id=ORG_ID,
+        canonical_name="Common Crawl Foundation",
+        base_url="https://commoncrawl.org",
+        sitemap_urls=("https://commoncrawl.org/sitemap.xml",),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="sa14-controlled-common-crawl-provider-target",
+        authorization_reviewed_at=now,
+        terms_url="https://commoncrawl.org/terms-of-use",
+        max_pages=50,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=0,
+    )
+    batch = CommonCrawlIndexAdapter(entry, (target,), timeout_seconds=30).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=365),
+    )
+    observations = len(batch.observations)
+    projections = len(batch.public_footprint_projections)
+    if observations < 1 or projections != observations:
+        raise RuntimeError("Common Crawl live validation did not preserve index captures")
+    if any(projection.claims for projection in batch.public_footprint_projections):
+        raise RuntimeError("Common Crawl index metadata unexpectedly produced claims")
+    if any(
+        projection.resource.retrieval_state.value != "quarantined"
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Common Crawl captures escaped quarantine")
+    if any(
+        "WARC body not retrieved" not in (projection.version.excerpt or "")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Common Crawl capture lost metadata-only boundary")
+    crawl_ids = batch.checkpoint_payload.get("crawl_ids", {})
+    print(
+        "SA-14 live validation passed: "
+        f"common_crawl_observations={observations} "
+        f"common_crawl_projections={projections} "
+        f"crawl_ids={crawl_ids}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/common_crawl/__init__.py
+++ b/src/cip/adapters/sources/common_crawl/__init__.py
@@ -1,0 +1,1 @@
+"""Common Crawl URL-index acquisition contracts."""

--- a/src/cip/adapters/sources/common_crawl/client.py
+++ b/src/cip/adapters/sources/common_crawl/client.py
@@ -11,7 +11,6 @@ from pydantic import ValidationError
 from cip.adapters.sources.common_crawl.schemas import (
     CommonCrawlCapture,
     CommonCrawlCollection,
-    crawl_sort_key,
 )
 
 MAX_RESPONSE_BYTES = 2 * 1024 * 1024
@@ -59,8 +58,7 @@ class CommonCrawlClient:
 
     def latest_collection(self, collection_url: str) -> CommonCrawlCollection:
         body, _ = self._get(collection_url)
-        collections = _parse_collections(body)
-        collection = max(collections, key=lambda item: crawl_sort_key(item.id))
+        collection = max(_parse_collections(body), key=lambda item: item.to_at)
         _validate_collection_endpoint(collection)
         return collection
 

--- a/src/cip/adapters/sources/common_crawl/client.py
+++ b/src/cip/adapters/sources/common_crawl/client.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.common_crawl.schemas import (
+    CommonCrawlCapture,
+    CommonCrawlCollection,
+    crawl_sort_key,
+)
+
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_CAPTURES = 50
+CAPTURE_FIELDS = (
+    "timestamp",
+    "url",
+    "mime",
+    "status",
+    "digest",
+    "length",
+    "offset",
+    "filename",
+)
+USER_AGENT = (
+    "cyber-intelligence-platform/0.24 "
+    "(+https://github.com/tobianahillel-afk/cyber-intelligence-platform)"
+)
+
+
+class CommonCrawlClientError(RuntimeError):
+    def __init__(self, message: str, *, code: str, retryable: bool) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class CommonCrawlCaptureResult:
+    captures: tuple[CommonCrawlCapture, ...]
+    request_url: str
+
+
+class CommonCrawlClient:
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def latest_collection(self, collection_url: str) -> CommonCrawlCollection:
+        body, _ = self._get(collection_url)
+        collections = _parse_collections(body)
+        collection = max(collections, key=lambda item: crawl_sort_key(item.id))
+        _validate_collection_endpoint(collection)
+        return collection
+
+    def captures(
+        self,
+        collection: CommonCrawlCollection,
+        *,
+        url_pattern: str,
+    ) -> CommonCrawlCaptureResult:
+        params: dict[str, str | int] = {
+            "url": url_pattern,
+            "output": "json",
+            "filter": "status:200",
+            "collapse": "digest",
+            "limit": MAX_CAPTURES,
+            "fl": ",".join(CAPTURE_FIELDS),
+        }
+        body, request_url = self._get(collection.cdx_api, params=params)
+        return CommonCrawlCaptureResult(
+            captures=_parse_captures(body),
+            request_url=request_url,
+        )
+
+    def _get(
+        self,
+        url: str,
+        *,
+        params: Mapping[str, str | int] | None = None,
+    ) -> tuple[bytes, str]:
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+                transport=self._transport,
+                headers={"User-Agent": USER_AGENT},
+            ) as client:
+                response = client.get(url, params=params)
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise CommonCrawlClientError(
+                f"Common Crawl returned HTTP {status}",
+                code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise CommonCrawlClientError(
+                str(exc) or type(exc).__name__,
+                code="source_transport_error",
+                retryable=True,
+            ) from exc
+        if len(response.content) > MAX_RESPONSE_BYTES:
+            raise CommonCrawlClientError(
+                "Common Crawl response exceeds size limit",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        return response.content, str(response.url)
+
+
+def _parse_collections(body: bytes) -> tuple[CommonCrawlCollection, ...]:
+    try:
+        raw = json.loads(body)
+        if not isinstance(raw, list) or not raw:
+            raise ValueError("collection list must be non-empty")
+        return tuple(CommonCrawlCollection.model_validate(item) for item in raw)
+    except (json.JSONDecodeError, TypeError, ValueError, ValidationError) as exc:
+        raise CommonCrawlClientError(
+            "Common Crawl collection metadata changed",
+            code="source_schema_drift",
+            retryable=False,
+        ) from exc
+
+
+def _parse_captures(body: bytes) -> tuple[CommonCrawlCapture, ...]:
+    try:
+        lines = body.decode("utf-8").splitlines()[:MAX_CAPTURES]
+    except UnicodeDecodeError as exc:
+        raise _capture_schema_error(exc) from exc
+    captures: list[CommonCrawlCapture] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            captures.append(CommonCrawlCapture.model_validate(json.loads(line)))
+        except (json.JSONDecodeError, ValidationError) as exc:
+            raise _capture_schema_error(exc) from exc
+    return tuple(captures)
+
+
+def _validate_collection_endpoint(collection: CommonCrawlCollection) -> None:
+    parsed = urlsplit(collection.cdx_api)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "index.commoncrawl.org"
+        or parsed.path != f"/{collection.id}-index"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise CommonCrawlClientError(
+            "Common Crawl collection endpoint is outside approved shape",
+            code="unsafe_source_response",
+            retryable=False,
+        )
+
+
+def _capture_schema_error(exc: Exception) -> CommonCrawlClientError:
+    return CommonCrawlClientError(
+        "Common Crawl capture metadata changed",
+        code="source_schema_drift",
+        retryable=False,
+    )

--- a/src/cip/adapters/sources/common_crawl/schemas.py
+++ b/src/cip/adapters/sources/common_crawl/schemas.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_CRAWL_ID = re.compile(r"^CC-MAIN-(\d{4})-(\d{2})$")
+
+
+class CommonCrawlCollection(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    id: str
+    name: str
+    timegate: str
+    cdx_api: str = Field(alias="cdx-api")
+    from_at: datetime = Field(alias="from")
+    to_at: datetime = Field(alias="to")
+
+    @field_validator("id")
+    @classmethod
+    def _valid_crawl_id(cls, value: str) -> str:
+        if _CRAWL_ID.fullmatch(value) is None:
+            raise ValueError("Common Crawl collection id is invalid")
+        return value
+
+
+class CommonCrawlCapture(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    timestamp: str = Field(pattern=r"^\d{14}$")
+    url: str
+    mime: str
+    status: str = Field(pattern=r"^\d{3}$")
+    digest: str
+    length: int = Field(ge=0, le=10_000_000)
+    offset: int = Field(ge=0)
+    filename: str
+
+    @field_validator("url", "mime", "digest", "filename")
+    @classmethod
+    def _required_text(cls, value: str) -> str:
+        if not value:
+            raise ValueError("Common Crawl capture field cannot be blank")
+        return value
+
+
+def crawl_sort_key(crawl_id: str) -> tuple[int, int]:
+    match = _CRAWL_ID.fullmatch(crawl_id)
+    if match is None:
+        raise ValueError("Common Crawl collection id is invalid")
+    return int(match.group(1)), int(match.group(2))

--- a/src/cip/adapters/sources/common_crawl/schemas.py
+++ b/src/cip/adapters/sources/common_crawl/schemas.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-_CRAWL_ID = re.compile(r"^CC-MAIN-(\d{4})-(\d{2})$")
+_CRAWL_ID = re.compile(r"^CC-MAIN-\d{4}(?:-\d{2})?$")
 
 
 class CommonCrawlCollection(BaseModel):
@@ -24,6 +24,13 @@ class CommonCrawlCollection(BaseModel):
         if _CRAWL_ID.fullmatch(value) is None:
             raise ValueError("Common Crawl collection id is invalid")
         return value
+
+    @field_validator("from_at", "to_at")
+    @classmethod
+    def _normalize_provider_time(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
 
 
 class CommonCrawlCapture(BaseModel):
@@ -44,10 +51,3 @@ class CommonCrawlCapture(BaseModel):
         if not value:
             raise ValueError("Common Crawl capture field cannot be blank")
         return value
-
-
-def crawl_sort_key(crawl_id: str) -> tuple[int, int]:
-    match = _CRAWL_ID.fullmatch(crawl_id)
-    if match is None:
-        raise ValueError("Common Crawl collection id is invalid")
-    return int(match.group(1)), int(match.group(2))

--- a/src/cip/adapters/sources/common_crawl/schemas.py
+++ b/src/cip/adapters/sources/common_crawl/schemas.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-_CRAWL_ID = re.compile(r"^CC-MAIN-\d{4}(?:-\d{2})?$")
+_CRAWL_ID = re.compile(r"^CC-MAIN-\d{4}(?:-\d{2}|-\d{4})?$")
 
 
 class CommonCrawlCollection(BaseModel):

--- a/src/cip/modules/collection_orchestration/application/common_crawl_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/common_crawl_adapter.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from hashlib import sha256
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.common_crawl.schemas import (
+    CommonCrawlCapture,
+    CommonCrawlCollection,
+    crawl_sort_key,
+)
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.public_footprint.domain.archive import (
+    CommonCrawlIndexLead,
+    map_common_crawl_index_lead,
+)
+from cip.modules.public_footprint.domain.scope import CrawlUsage
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_CAPTURES = 50
+_FIELDS = ("timestamp", "url", "mime", "status", "digest", "length", "offset", "filename")
+_USER_AGENT = (
+    "cyber-intelligence-platform/0.24 "
+    "(+https://github.com/tobianahillel-afk/cyber-intelligence-platform)"
+)
+
+
+class CommonCrawlIndexAdapter:
+    source_id = "common-crawl-index"
+    adapter_id = "common-crawl-cdxj-index"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[PublicWebTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Common Crawl adapter requires common-crawl-index policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._pairs = _target_prefix_pairs(targets)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        pair, next_index, crawl_ids = _next_pair(self._pairs, checkpoint_payload)
+        if pair is None:
+            return _empty_batch()
+        target, prefix = pair
+        collection_url = self._entry.policy.base_url
+        _authorize(self._entry, collection_url, collected_at)
+        collections = _fetch_collections(
+            collection_url,
+            timeout_seconds=self._timeout_seconds,
+            transport=self._transport,
+        )
+        collection = max(collections, key=lambda item: crawl_sort_key(item.id))
+        _validate_collection_endpoint(collection)
+        previous_crawl = crawl_ids.get(_pair_key(target, prefix))
+        if previous_crawl == collection.id:
+            return _checkpoint_batch(next_index, crawl_ids, target, prefix, collection.id)
+        _authorize(self._entry, collection.cdx_api, collected_at)
+        body, request_url = _fetch_captures(
+            collection.cdx_api,
+            url_pattern=_target_pattern(target, prefix),
+            timeout_seconds=self._timeout_seconds,
+            transport=self._transport,
+        )
+        captures = tuple(
+            capture
+            for capture in _parse_captures(body)
+            if _capture_in_scope(capture, target)
+        )
+        observations = tuple(
+            _observation(
+                capture,
+                collection_id=collection.id,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+                source_url=request_url,
+            )
+            for capture in captures
+        )
+        projections = tuple(
+            map_common_crawl_index_lead(
+                _lead(
+                    capture,
+                    collection_id=collection.id,
+                    target=target,
+                    observed_at=collected_at,
+                    index_url=collection.cdx_api,
+                )
+            )
+            for capture in captures
+        )
+        next_crawl_ids = dict(crawl_ids)
+        next_crawl_ids[_pair_key(target, prefix)] = collection.id
+        return AdapterCollectionBatch(
+            observations=observations,
+            public_footprint_projections=projections,
+            checkpoint_payload={"pair_index": next_index, "crawl_ids": next_crawl_ids},
+            not_modified=not captures,
+        )
+
+
+def _authorize(entry: SourceRegistryEntry, target_url: str, now: datetime) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=target_url,
+            purpose="archive-discovery",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def _fetch_collections(
+    url: str,
+    *,
+    timeout_seconds: float,
+    transport: httpx.BaseTransport | None,
+) -> tuple[CommonCrawlCollection, ...]:
+    body, _ = _get(url, timeout_seconds=timeout_seconds, transport=transport)
+    try:
+        raw = json.loads(body)
+        if not isinstance(raw, list) or not raw:
+            raise ValueError("collection list must be non-empty")
+        return tuple(CommonCrawlCollection.model_validate(item) for item in raw)
+    except (json.JSONDecodeError, TypeError, ValueError, ValidationError) as exc:
+        raise _schema_error("Common Crawl collection metadata changed", exc) from exc
+
+
+def _fetch_captures(
+    url: str,
+    *,
+    url_pattern: str,
+    timeout_seconds: float,
+    transport: httpx.BaseTransport | None,
+) -> tuple[bytes, str]:
+    params: dict[str, str | int] = {
+        "url": url_pattern,
+        "output": "json",
+        "filter": "status:200",
+        "collapse": "digest",
+        "limit": _MAX_CAPTURES,
+        "fl": ",".join(_FIELDS),
+    }
+    return _get(url, params=params, timeout_seconds=timeout_seconds, transport=transport)
+
+
+def _get(
+    url: str,
+    *,
+    params: Mapping[str, str | int] | None = None,
+    timeout_seconds: float,
+    transport: httpx.BaseTransport | None,
+) -> tuple[bytes, str]:
+    try:
+        with httpx.Client(
+            timeout=timeout_seconds,
+            follow_redirects=False,
+            transport=transport,
+            headers={"User-Agent": _USER_AGENT},
+        ) as client:
+            response = client.get(url, params=params)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        raise AdapterExecutionError(
+            f"Common Crawl returned HTTP {status}",
+            error_code=f"http_{status}",
+            retryable=status == 429 or status >= 500,
+        ) from exc
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        raise AdapterExecutionError(
+            str(exc) or type(exc).__name__,
+            error_code="source_transport_error",
+            retryable=True,
+        ) from exc
+    if len(response.content) > _MAX_RESPONSE_BYTES:
+        raise AdapterExecutionError(
+            "Common Crawl response exceeds size limit",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    return response.content, str(response.url)
+
+
+def _parse_captures(body: bytes) -> tuple[CommonCrawlCapture, ...]:
+    captures: list[CommonCrawlCapture] = []
+    for line in body.decode("utf-8").splitlines()[:_MAX_CAPTURES]:
+        if not line.strip():
+            continue
+        try:
+            raw = json.loads(line)
+            captures.append(CommonCrawlCapture.model_validate(raw))
+        except (json.JSONDecodeError, UnicodeDecodeError, ValidationError) as exc:
+            raise _schema_error("Common Crawl capture metadata changed", exc) from exc
+    return tuple(captures)
+
+
+def _validate_collection_endpoint(collection: CommonCrawlCollection) -> None:
+    parsed = urlsplit(collection.cdx_api)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "index.commoncrawl.org"
+        or parsed.path != f"/{collection.id}-index"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise AdapterExecutionError(
+            "Common Crawl collection endpoint is outside approved shape",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+
+
+def _capture_in_scope(capture: CommonCrawlCapture, target: PublicWebTarget) -> bool:
+    return target.crawl_scope.evaluate_target(
+        capture.url,
+        depth=0,
+        redirects=0,
+        usage=CrawlUsage(),
+    ).allowed
+
+
+def _target_prefix_pairs(
+    targets: tuple[PublicWebTarget, ...],
+) -> tuple[tuple[PublicWebTarget, str], ...]:
+    return tuple(
+        (target, prefix)
+        for target in targets
+        if target.enabled
+        for prefix in target.allowed_path_prefixes
+    )
+
+
+def _target_pattern(target: PublicWebTarget, prefix: str) -> str:
+    parsed = urlsplit(target.base_url)
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{origin}/*" if prefix == "/" else f"{origin}{prefix}/*"
+
+
+def _next_pair(
+    pairs: tuple[tuple[PublicWebTarget, str], ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[tuple[PublicWebTarget, str] | None, int, dict[str, str]]:
+    if not pairs:
+        return None, 0, {}
+    index_value = 0 if payload is None else payload.get("pair_index", 0)
+    crawl_value = {} if payload is None else payload.get("crawl_ids", {})
+    if not isinstance(index_value, int) or isinstance(index_value, bool) or index_value < 0:
+        raise _checkpoint_error()
+    if not isinstance(crawl_value, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in crawl_value.items()
+    ):
+        raise _checkpoint_error()
+    valid_keys = {_pair_key(target, prefix) for target, prefix in pairs}
+    crawl_ids = {
+        key: value for key, value in crawl_value.items() if key in valid_keys
+    }
+    index = index_value % len(pairs)
+    next_index = 0 if index + 1 >= len(pairs) else index + 1
+    return pairs[index], next_index, crawl_ids
+
+
+def _pair_key(target: PublicWebTarget, prefix: str) -> str:
+    return f"{target.id}:{prefix}"
+
+
+def _checkpoint_batch(
+    next_index: int,
+    crawl_ids: dict[str, str],
+    target: PublicWebTarget,
+    prefix: str,
+    crawl_id: str,
+) -> AdapterCollectionBatch:
+    next_crawl_ids = dict(crawl_ids)
+    next_crawl_ids[_pair_key(target, prefix)] = crawl_id
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"pair_index": next_index, "crawl_ids": next_crawl_ids},
+        not_modified=True,
+    )
+
+
+def _lead(
+    capture: CommonCrawlCapture,
+    *,
+    collection_id: str,
+    target: PublicWebTarget,
+    observed_at: datetime,
+    index_url: str,
+) -> CommonCrawlIndexLead:
+    capture_at = datetime.strptime(capture.timestamp, "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+    return CommonCrawlIndexLead(
+        organization_id=target.organization_id,
+        source_id=CommonCrawlIndexAdapter.source_id,
+        source_record_key=f"{collection_id}:{capture.timestamp}:{capture.digest}",
+        original_url=capture.url,
+        index_url=index_url,
+        crawl_id=collection_id,
+        capture_at=capture_at,
+        observed_at=observed_at,
+        archived_mime_type=capture.mime,
+        archived_status_code=int(capture.status),
+        archived_length=capture.length,
+        archived_digest=capture.digest,
+        warc_filename=capture.filename,
+        warc_offset=capture.offset,
+        warc_record_length=capture.length,
+    )
+
+
+def _observation(
+    capture: CommonCrawlCapture,
+    *,
+    collection_id: str,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    source_url: str,
+) -> RawObservation:
+    encoded = capture.model_dump_json().encode("utf-8")
+    return RawObservation(
+        source_id=CommonCrawlIndexAdapter.source_id,
+        adapter_id=CommonCrawlIndexAdapter.adapter_id,
+        adapter_version=CommonCrawlIndexAdapter.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="common-crawl-index-capture",
+        source_url=source_url,
+        payload_hash_sha256=sha256(encoded).hexdigest(),
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        source_record_key=f"{collection_id}:{capture.timestamp}:{capture.digest}",
+        collected_at=collected_at,
+        retention_until=retention_until,
+        schema_fingerprint="common-crawl-cdxj:v1",
+    )
+
+
+def _schema_error(message: str, exc: Exception) -> AdapterExecutionError:
+    return AdapterExecutionError(message, error_code="source_schema_drift", retryable=False)
+
+
+def _checkpoint_error() -> AdapterExecutionError:
+    return AdapterExecutionError(
+        "invalid Common Crawl checkpoint",
+        error_code="invalid_checkpoint",
+        retryable=False,
+    )
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"pair_index": 0, "crawl_ids": {}},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/common_crawl_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/common_crawl_adapter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from hashlib import sha256
@@ -8,13 +7,12 @@ from urllib.parse import urlsplit
 from uuid import UUID
 
 import httpx
-from pydantic import ValidationError
 
-from cip.adapters.sources.common_crawl.schemas import (
-    CommonCrawlCapture,
-    CommonCrawlCollection,
-    crawl_sort_key,
+from cip.adapters.sources.common_crawl.client import (
+    CommonCrawlClient,
+    CommonCrawlClientError,
 )
+from cip.adapters.sources.common_crawl.schemas import CommonCrawlCapture
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.ports import (
     AdapterCollectionBatch,
@@ -33,14 +31,6 @@ from cip.modules.source_governance.domain.models import (
 )
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
-_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
-_MAX_CAPTURES = 50
-_FIELDS = ("timestamp", "url", "mime", "status", "digest", "length", "offset", "filename")
-_USER_AGENT = (
-    "cyber-intelligence-platform/0.24 "
-    "(+https://github.com/tobianahillel-afk/cyber-intelligence-platform)"
-)
-
 
 class CommonCrawlIndexAdapter:
     source_id = "common-crawl-index"
@@ -58,12 +48,12 @@ class CommonCrawlIndexAdapter:
     ) -> None:
         if entry.policy.id != self.source_id:
             raise ValueError("Common Crawl adapter requires common-crawl-index policy")
-        if timeout_seconds <= 0:
-            raise ValueError("timeout_seconds must be positive")
         self._entry = entry
         self._pairs = _target_prefix_pairs(targets)
-        self._timeout_seconds = timeout_seconds
-        self._transport = transport
+        self._client = CommonCrawlClient(
+            timeout_seconds=timeout_seconds,
+            transport=transport,
+        )
 
     def collect(
         self,
@@ -77,58 +67,49 @@ class CommonCrawlIndexAdapter:
         if pair is None:
             return _empty_batch()
         target, prefix = pair
-        collection_url = self._entry.policy.base_url
-        _authorize(self._entry, collection_url, collected_at)
-        collections = _fetch_collections(
-            collection_url,
-            timeout_seconds=self._timeout_seconds,
-            transport=self._transport,
-        )
-        collection = max(collections, key=lambda item: crawl_sort_key(item.id))
-        _validate_collection_endpoint(collection)
-        previous_crawl = crawl_ids.get(_pair_key(target, prefix))
-        if previous_crawl == collection.id:
-            return _checkpoint_batch(next_index, crawl_ids, target, prefix, collection.id)
-        _authorize(self._entry, collection.cdx_api, collected_at)
-        body, request_url = _fetch_captures(
-            collection.cdx_api,
-            url_pattern=_target_pattern(target, prefix),
-            timeout_seconds=self._timeout_seconds,
-            transport=self._transport,
-        )
+        try:
+            _authorize(self._entry, self._entry.policy.base_url, collected_at)
+            collection = self._client.latest_collection(self._entry.policy.base_url)
+            if crawl_ids.get(_pair_key(target, prefix)) == collection.id:
+                return _checkpoint_batch(next_index, crawl_ids, target, prefix, collection.id)
+            _authorize(self._entry, collection.cdx_api, collected_at)
+            fetched = self._client.captures(
+                collection,
+                url_pattern=_target_pattern(target, prefix),
+            )
+        except CommonCrawlClientError as exc:
+            raise AdapterExecutionError(
+                str(exc), error_code=exc.code, retryable=exc.retryable
+            ) from exc
         captures = tuple(
-            capture
-            for capture in _parse_captures(body)
-            if _capture_in_scope(capture, target)
-        )
-        observations = tuple(
-            _observation(
-                capture,
-                collection_id=collection.id,
-                collection_job_id=collection_job_id,
-                collected_at=collected_at,
-                retention_until=retention_until,
-                source_url=request_url,
-            )
-            for capture in captures
-        )
-        projections = tuple(
-            map_common_crawl_index_lead(
-                _lead(
-                    capture,
-                    collection_id=collection.id,
-                    target=target,
-                    observed_at=collected_at,
-                    index_url=collection.cdx_api,
-                )
-            )
-            for capture in captures
+            capture for capture in fetched.captures if _capture_in_scope(capture, target)
         )
         next_crawl_ids = dict(crawl_ids)
         next_crawl_ids[_pair_key(target, prefix)] = collection.id
         return AdapterCollectionBatch(
-            observations=observations,
-            public_footprint_projections=projections,
+            observations=tuple(
+                _observation(
+                    capture,
+                    collection_id=collection.id,
+                    collection_job_id=collection_job_id,
+                    collected_at=collected_at,
+                    retention_until=retention_until,
+                    source_url=fetched.request_url,
+                )
+                for capture in captures
+            ),
+            public_footprint_projections=tuple(
+                map_common_crawl_index_lead(
+                    _lead(
+                        capture,
+                        collection_id=collection.id,
+                        target=target,
+                        observed_at=collected_at,
+                        index_url=collection.cdx_api,
+                    )
+                )
+                for capture in captures
+            ),
             checkpoint_payload={"pair_index": next_index, "crawl_ids": next_crawl_ids},
             not_modified=not captures,
         )
@@ -152,107 +133,6 @@ def _authorize(entry: SourceRegistryEntry, target_url: str, now: datetime) -> No
         raise AdapterExecutionError(
             decision.reason.value,
             error_code="source_policy_denied",
-            retryable=False,
-        )
-
-
-def _fetch_collections(
-    url: str,
-    *,
-    timeout_seconds: float,
-    transport: httpx.BaseTransport | None,
-) -> tuple[CommonCrawlCollection, ...]:
-    body, _ = _get(url, timeout_seconds=timeout_seconds, transport=transport)
-    try:
-        raw = json.loads(body)
-        if not isinstance(raw, list) or not raw:
-            raise ValueError("collection list must be non-empty")
-        return tuple(CommonCrawlCollection.model_validate(item) for item in raw)
-    except (json.JSONDecodeError, TypeError, ValueError, ValidationError) as exc:
-        raise _schema_error("Common Crawl collection metadata changed", exc) from exc
-
-
-def _fetch_captures(
-    url: str,
-    *,
-    url_pattern: str,
-    timeout_seconds: float,
-    transport: httpx.BaseTransport | None,
-) -> tuple[bytes, str]:
-    params: dict[str, str | int] = {
-        "url": url_pattern,
-        "output": "json",
-        "filter": "status:200",
-        "collapse": "digest",
-        "limit": _MAX_CAPTURES,
-        "fl": ",".join(_FIELDS),
-    }
-    return _get(url, params=params, timeout_seconds=timeout_seconds, transport=transport)
-
-
-def _get(
-    url: str,
-    *,
-    params: Mapping[str, str | int] | None = None,
-    timeout_seconds: float,
-    transport: httpx.BaseTransport | None,
-) -> tuple[bytes, str]:
-    try:
-        with httpx.Client(
-            timeout=timeout_seconds,
-            follow_redirects=False,
-            transport=transport,
-            headers={"User-Agent": _USER_AGENT},
-        ) as client:
-            response = client.get(url, params=params)
-            response.raise_for_status()
-    except httpx.HTTPStatusError as exc:
-        status = exc.response.status_code
-        raise AdapterExecutionError(
-            f"Common Crawl returned HTTP {status}",
-            error_code=f"http_{status}",
-            retryable=status == 429 or status >= 500,
-        ) from exc
-    except (httpx.TimeoutException, httpx.TransportError) as exc:
-        raise AdapterExecutionError(
-            str(exc) or type(exc).__name__,
-            error_code="source_transport_error",
-            retryable=True,
-        ) from exc
-    if len(response.content) > _MAX_RESPONSE_BYTES:
-        raise AdapterExecutionError(
-            "Common Crawl response exceeds size limit",
-            error_code="unsafe_source_response",
-            retryable=False,
-        )
-    return response.content, str(response.url)
-
-
-def _parse_captures(body: bytes) -> tuple[CommonCrawlCapture, ...]:
-    captures: list[CommonCrawlCapture] = []
-    for line in body.decode("utf-8").splitlines()[:_MAX_CAPTURES]:
-        if not line.strip():
-            continue
-        try:
-            raw = json.loads(line)
-            captures.append(CommonCrawlCapture.model_validate(raw))
-        except (json.JSONDecodeError, UnicodeDecodeError, ValidationError) as exc:
-            raise _schema_error("Common Crawl capture metadata changed", exc) from exc
-    return tuple(captures)
-
-
-def _validate_collection_endpoint(collection: CommonCrawlCollection) -> None:
-    parsed = urlsplit(collection.cdx_api)
-    if (
-        parsed.scheme != "https"
-        or parsed.hostname != "index.commoncrawl.org"
-        or parsed.path != f"/{collection.id}-index"
-        or parsed.query
-        or parsed.fragment
-    ):
-        raise AdapterExecutionError(
-            "Common Crawl collection endpoint is outside approved shape",
-            error_code="unsafe_source_response",
             retryable=False,
         )
 
@@ -299,9 +179,7 @@ def _next_pair(
     ):
         raise _checkpoint_error()
     valid_keys = {_pair_key(target, prefix) for target, prefix in pairs}
-    crawl_ids = {
-        key: value for key, value in crawl_value.items() if key in valid_keys
-    }
+    crawl_ids = {key: value for key, value in crawl_value.items() if key in valid_keys}
     index = index_value % len(pairs)
     next_index = 0 if index + 1 >= len(pairs) else index + 1
     return pairs[index], next_index, crawl_ids
@@ -380,10 +258,6 @@ def _observation(
         retention_until=retention_until,
         schema_fingerprint="common-crawl-cdxj:v1",
     )
-
-
-def _schema_error(message: str, exc: Exception) -> AdapterExecutionError:
-    return AdapterExecutionError(message, error_code="source_schema_drift", retryable=False)
 
 
 def _checkpoint_error() -> AdapterExecutionError:

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -9,6 +9,9 @@ from cip.modules.collection_orchestration.application.archive_cdx_adapter import
 from cip.modules.collection_orchestration.application.brave_search_adapter import (
     BraveSearchAdapter,
 )
+from cip.modules.collection_orchestration.application.common_crawl_adapter import (
+    CommonCrawlIndexAdapter,
+)
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.public_footprint.domain.search import SearchQueryTemplate
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
@@ -42,6 +45,17 @@ def register_search_archive_adapters(
             adapters,
             InternetArchiveCdxAdapter(
                 archive_entry,
+                targets,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    common_crawl_entry = entries_by_id.get(CommonCrawlIndexAdapter.source_id)
+    if common_crawl_entry is not None:
+        _register(
+            adapters,
+            CommonCrawlIndexAdapter(
+                common_crawl_entry,
                 targets,
                 timeout_seconds=timeout_seconds,
             ),

--- a/src/cip/modules/public_footprint/domain/archive.py
+++ b/src/cip/modules/public_footprint/domain/archive.py
@@ -19,6 +19,7 @@ from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
 from cip.shared.kernel.time import require_aware_utc
 
 _ARCHIVE_METADATA_MIME_TYPE = "application/x-archive-index-metadata"
+_COMMON_CRAWL_METADATA_MIME_TYPE = "application/x-common-crawl-index-metadata"
 
 
 @dataclass(frozen=True, slots=True)
@@ -58,6 +59,54 @@ class ArchiveCaptureLead:
             raise ValueError("archive mime type and digest are required")
 
 
+@dataclass(frozen=True, slots=True)
+class CommonCrawlIndexLead:
+    organization_id: UUID
+    source_id: str
+    source_record_key: str
+    original_url: str
+    index_url: str
+    crawl_id: str
+    capture_at: datetime
+    observed_at: datetime
+    archived_mime_type: str
+    archived_status_code: int
+    archived_length: int
+    archived_digest: str
+    warc_filename: str
+    warc_offset: int
+    warc_record_length: int
+
+    def __post_init__(self) -> None:
+        if not self.source_id.strip() or not self.source_record_key.strip():
+            raise ValueError("Common Crawl lead source identity is required")
+        if not self.crawl_id.startswith("CC-MAIN-"):
+            raise ValueError("Common Crawl lead crawl identity is invalid")
+        object.__setattr__(self, "original_url", CanonicalUrl(self.original_url).value)
+        object.__setattr__(self, "index_url", CanonicalUrl(self.index_url).value)
+        object.__setattr__(
+            self,
+            "capture_at",
+            require_aware_utc(self.capture_at, field_name="capture_at"),
+        )
+        object.__setattr__(
+            self,
+            "observed_at",
+            require_aware_utc(self.observed_at, field_name="observed_at"),
+        )
+        if not 100 <= self.archived_status_code <= 599:
+            raise ValueError("Common Crawl status code is invalid")
+        if min(self.archived_length, self.warc_offset, self.warc_record_length) < 0:
+            raise ValueError("Common Crawl lengths and offset cannot be negative")
+        required = (
+            self.archived_mime_type,
+            self.archived_digest,
+            self.warc_filename,
+        )
+        if any(not value.strip() for value in required):
+            raise ValueError("Common Crawl archive metadata is incomplete")
+
+
 def map_archive_capture_lead(lead: ArchiveCaptureLead) -> PublicFootprintProjection:
     resource = PublicResource(
         organization_id=lead.organization_id,
@@ -91,6 +140,40 @@ def map_archive_capture_lead(lead: ArchiveCaptureLead) -> PublicFootprintProject
     return PublicFootprintProjection(resource=resource, version=version, claims=())
 
 
+def map_common_crawl_index_lead(lead: CommonCrawlIndexLead) -> PublicFootprintProjection:
+    resource = PublicResource(
+        organization_id=lead.organization_id,
+        source_id=lead.source_id,
+        source_record_key=lead.source_record_key,
+        canonical_url=lead.original_url,
+        source_url=lead.index_url,
+        kind=PublicResourceKind.ARCHIVE_SNAPSHOT,
+        discovery_method=DiscoveryMethod.ARCHIVE_INDEX,
+        first_discovered_at=lead.observed_at,
+        last_seen_at=lead.observed_at,
+        access_state=ResourceAccessState.UNKNOWN,
+        retrieval_state=ResourceRetrievalState.QUARANTINED,
+        title=f"Common Crawl index capture {lead.capture_at.isoformat()}",
+    )
+    material = _common_crawl_metadata_material(lead)
+    version = PublicResourceVersion(
+        resource_key=resource.identity_key,
+        source_url=lead.index_url,
+        content_hash_sha256=sha256(material).hexdigest(),
+        fetched_at=lead.observed_at,
+        mime_type=_COMMON_CRAWL_METADATA_MIME_TYPE,
+        byte_size=len(material),
+        title=resource.title,
+        excerpt=(
+            f"Common Crawl index metadata from {lead.crawl_id}: "
+            f"{lead.archived_mime_type}, HTTP {lead.archived_status_code}; "
+            "WARC body not retrieved."
+        ),
+        source_locator=f"common-crawl:{lead.crawl_id}:{lead.capture_at.isoformat()}",
+    )
+    return PublicFootprintProjection(resource=resource, version=version, claims=())
+
+
 def _metadata_material(lead: ArchiveCaptureLead) -> bytes:
     return dumps(
         {
@@ -101,6 +184,27 @@ def _metadata_material(lead: ArchiveCaptureLead) -> bytes:
             "capture_at": lead.capture_at.isoformat(),
             "capture_url": lead.capture_url,
             "original_url": lead.original_url,
+        },
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+
+
+def _common_crawl_metadata_material(lead: CommonCrawlIndexLead) -> bytes:
+    return dumps(
+        {
+            "archived_digest": lead.archived_digest,
+            "archived_length": lead.archived_length,
+            "archived_mime_type": lead.archived_mime_type,
+            "archived_status_code": lead.archived_status_code,
+            "capture_at": lead.capture_at.isoformat(),
+            "crawl_id": lead.crawl_id,
+            "index_url": lead.index_url,
+            "original_url": lead.original_url,
+            "warc_filename": lead.warc_filename,
+            "warc_offset": lead.warc_offset,
+            "warc_record_length": lead.warc_record_length,
         },
         ensure_ascii=True,
         separators=(",", ":"),

--- a/tests/unit/collection_orchestration/test_common_crawl_adapter.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_adapter.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.common_crawl_adapter import (
+    CommonCrawlIndexAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 10, 45, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+ORG_ID = UUID("86fe6126-5731-5c4d-a206-69a6a736cae5")
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+
+
+def test_common_crawl_uses_latest_collection_and_maps_only_in_scope() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/collinfo.json":
+            return _json_response(request, _collections())
+        assert request.url.path == "/CC-MAIN-2026-30-index"
+        assert request.url.params["url"] == "https://example.com/public/*"
+        assert request.url.params["limit"] == "50"
+        body = "\n".join(
+            [
+                json.dumps(_capture(url="https://example.com/public/report")),
+                json.dumps(_capture(url="https://example.com/private/secret", digest="OTHER")),
+            ]
+        )
+        return httpx.Response(200, text=body, request=request)
+
+    adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+    assert len(requests) == 2
+    assert len(batch.observations) == 1
+    assert len(batch.public_footprint_projections) == 1
+    projection = batch.public_footprint_projections[0]
+    assert projection.claims == ()
+    assert projection.resource.canonical_url == "https://example.com/public/report"
+    assert projection.resource.retrieval_state.value == "quarantined"
+    assert "WARC body not retrieved" in (projection.version.excerpt or "")
+    assert batch.checkpoint_payload == {
+        "pair_index": 0,
+        "crawl_ids": {"common-crawl-live:/public": "CC-MAIN-2026-30"},
+    }
+
+
+def test_common_crawl_skips_capture_query_for_processed_crawl() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _json_response(request, _collections())
+
+    adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(
+        adapter,
+        checkpoint_payload={
+            "pair_index": 0,
+            "crawl_ids": {"common-crawl-live:/public": "CC-MAIN-2026-30"},
+        },
+    )
+    assert len(requests) == 1
+    assert batch.not_modified is True
+    assert batch.observations == ()
+
+
+def test_common_crawl_without_enabled_targets_performs_no_network() -> None:
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without a target")
+
+    adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(enabled=False),),
+        transport=httpx.MockTransport(fail_network),
+    )
+    batch = _collect(adapter)
+    assert batch.not_modified is True
+    assert batch.checkpoint_payload == {"pair_index": 0, "crawl_ids": {}}
+
+
+def test_common_crawl_rejects_invalid_checkpoint_and_provider_endpoint() -> None:
+    adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(lambda request: _json_response(request, _collections())),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter, checkpoint_payload={"pair_index": True, "crawl_ids": {}})
+    assert exc_info.value.error_code == "invalid_checkpoint"
+
+    def unsafe_collection(request: httpx.Request) -> httpx.Response:
+        payload = _collections()
+        payload[1]["cdx-api"] = "https://evil.example/CC-MAIN-2026-30-index"
+        return _json_response(request, payload)
+
+    unsafe_adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(unsafe_collection),
+    )
+    with pytest.raises(AdapterExecutionError) as unsafe_info:
+        _collect(unsafe_adapter)
+    assert unsafe_info.value.error_code == "unsafe_source_response"
+
+
+def test_common_crawl_classifies_schema_and_http_failures() -> None:
+    def malformed(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not-json", request=request)
+
+    adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(malformed),
+    )
+    with pytest.raises(AdapterExecutionError) as schema_info:
+        _collect(adapter)
+    assert schema_info.value.error_code == "source_schema_drift"
+
+    def rate_limited(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, request=request)
+
+    rate_adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(rate_limited),
+    )
+    with pytest.raises(AdapterExecutionError) as http_info:
+        _collect(rate_adapter)
+    assert http_info.value.error_code == "http_429"
+    assert http_info.value.retryable is True
+
+
+def _collections() -> list[dict[str, str]]:
+    return [
+        {
+            "id": "CC-MAIN-2026-25",
+            "name": "June 2026 Index",
+            "timegate": "https://index.commoncrawl.org/CC-MAIN-2026-25/",
+            "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-25-index",
+            "from": "2026-06-05T21:48:11",
+            "to": "2026-06-18T19:32:05",
+        },
+        {
+            "id": "CC-MAIN-2026-30",
+            "name": "July 2026 Index",
+            "timegate": "https://index.commoncrawl.org/CC-MAIN-2026-30/",
+            "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-30-index",
+            "from": "2026-07-10T07:05:34",
+            "to": "2026-07-23T01:13:28",
+        },
+    ]
+
+
+def _capture(*, url: str, digest: str = "DIGEST") -> dict[str, str]:
+    return {
+        "timestamp": "20260715120000",
+        "url": url,
+        "mime": "text/html",
+        "status": "200",
+        "digest": digest,
+        "length": "1234",
+        "offset": "5678",
+        "filename": "crawl-data/CC-MAIN-2026-30/segments/example/warc/example.warc.gz",
+    }
+
+
+def _target(*, enabled: bool = True) -> PublicWebTarget:
+    return PublicWebTarget(
+        id="common-crawl-live",
+        organization_id=ORG_ID,
+        canonical_name="Controlled Example Target",
+        base_url="https://example.com",
+        sitemap_urls=("https://example.com/sitemap.xml",),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/public",),
+        enabled=enabled,
+        authorization_reference="sa14-controlled-live-example",
+        authorization_reviewed_at=NOW,
+        terms_url="https://example.com/",
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == "common-crawl-index"
+    )
+
+
+def _collect(
+    adapter: CommonCrawlIndexAdapter,
+    *,
+    checkpoint_payload: dict[str, object] | None = None,
+):
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint_payload,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _json_response(request: httpx.Request, payload: object) -> httpx.Response:
+    return httpx.Response(200, json=payload, request=request)

--- a/tests/unit/collection_orchestration/test_common_crawl_schemas.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_schemas.py
@@ -1,0 +1,16 @@
+from cip.adapters.sources.common_crawl.schemas import CommonCrawlCollection
+
+
+def test_common_crawl_accepts_published_legacy_collection_identity() -> None:
+    collection = CommonCrawlCollection.model_validate(
+        {
+            "id": "CC-MAIN-2012",
+            "name": "2012 Index",
+            "timegate": "https://index.commoncrawl.org/CC-MAIN-2012/",
+            "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2012-index",
+            "from": "2012-01-01T00:00:00",
+            "to": "2012-12-31T23:59:59",
+        }
+    )
+    assert collection.id == "CC-MAIN-2012"
+    assert collection.to_at.tzinfo is not None

--- a/tests/unit/collection_orchestration/test_common_crawl_schemas.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_schemas.py
@@ -1,16 +1,41 @@
+import pytest
+
 from cip.adapters.sources.common_crawl.schemas import CommonCrawlCollection
 
 
-def test_common_crawl_accepts_published_legacy_collection_identity() -> None:
+@pytest.mark.parametrize(
+    "crawl_id",
+    (
+        "CC-MAIN-2026-30",
+        "CC-MAIN-2012",
+        "CC-MAIN-2009-2010",
+        "CC-MAIN-2008-2009",
+    ),
+)
+def test_common_crawl_accepts_published_collection_identity_forms(crawl_id: str) -> None:
     collection = CommonCrawlCollection.model_validate(
         {
-            "id": "CC-MAIN-2012",
-            "name": "2012 Index",
-            "timegate": "https://index.commoncrawl.org/CC-MAIN-2012/",
-            "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2012-index",
-            "from": "2012-01-01T00:00:00",
-            "to": "2012-12-31T23:59:59",
+            "id": crawl_id,
+            "name": f"{crawl_id} Index",
+            "timegate": f"https://index.commoncrawl.org/{crawl_id}/",
+            "cdx-api": f"https://index.commoncrawl.org/{crawl_id}-index",
+            "from": "2008-01-01T00:00:00",
+            "to": "2026-12-31T23:59:59",
         }
     )
-    assert collection.id == "CC-MAIN-2012"
+    assert collection.id == crawl_id
     assert collection.to_at.tzinfo is not None
+
+
+def test_common_crawl_rejects_unpublished_collection_identity_shape() -> None:
+    with pytest.raises(ValueError, match="collection id is invalid"):
+        CommonCrawlCollection.model_validate(
+            {
+                "id": "CC-MAIN-anything-goes",
+                "name": "Invalid",
+                "timegate": "https://index.commoncrawl.org/invalid/",
+                "cdx-api": "https://index.commoncrawl.org/invalid-index",
+                "from": "2026-01-01T00:00:00",
+                "to": "2026-01-02T00:00:00",
+            }
+        )

--- a/tests/unit/collection_orchestration/test_runtime_and_metrics.py
+++ b/tests/unit/collection_orchestration/test_runtime_and_metrics.py
@@ -75,7 +75,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
     get_metadata().create_all(create_database_engine(settings.database_url))
 
     runtime = build_collection_runtime(settings)
-    assert run_scheduler_once(runtime, now=NOW) == 15
+    assert run_scheduler_once(runtime, now=NOW) == 16
     assert run_scheduler_once(runtime, now=NOW) == 0
 
     expected_sources = (
@@ -83,6 +83,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         "ashby-job-board",
         "boamp",
         "cisa-kev",
+        "common-crawl-index",
         "cordis-eu-funded-projects",
         "decp",
         "github-global-advisories",
@@ -110,6 +111,7 @@ def test_runtime_syncs_sources_and_schedules_idempotently(tmp_path: Path) -> Non
         ("ashby-job-board", "ashby-public-job-postings-api"),
         ("boamp", "boamp-explore-api"),
         ("cisa-kev", "cisa-kev-feed"),
+        ("common-crawl-index", "common-crawl-cdxj-index"),
         ("cordis-eu-funded-projects", "cordis-horizon-bulk-csv"),
         ("decp", "decp-explore-api"),
         ("github-global-advisories", "github-global-advisories"),


### PR DESCRIPTION
First implementation tranche for issue #108.

Final Common Crawl scope:
- real Common Crawl CDXJ URL Index adapter using `index.commoncrawl.org`;
- latest crawl selected dynamically from current `collinfo.json` provider chronology, with all published historical collection-ID forms explicitly supported and regression-tested (`CC-MAIN-YYYY-WW`, `CC-MAIN-2012`, and historical ranges such as `CC-MAIN-2009-2010`);
- existing governed `PublicWebTarget` scopes reused, expanded per exact allowed path prefix;
- maximum 50 index captures per target/prefix and 2 MB provider-response bounds;
- exact provider endpoint-shape validation and Source Governance before both collection-discovery and CDX network stages;
- descriptive User-Agent and crawl-ID checkpointing per target/prefix to avoid repeated CDX queries against unchanged crawls;
- strict provider schemas for collection metadata and selected capture fields;
- immutable raw observations plus quarantined Lot 12 archive-snapshot projections with zero claims;
- WARC filename/offset/length retained as provenance only; no `data.commoncrawl.org` range fetch and no WARC body storage;
- existing Brave Search and Internet Archive/CDX paths remain authoritative and are not duplicated.

Controlled provider proof selected live crawl `CC-MAIN-2026-30` and mapped 43 real Common Crawl index captures into 43 quarantined public-footprint projections, with zero claims and zero WARC bodies fetched. Provider drift observed from historical collection identities was fixed and locked through deterministic regression tests.

The final exact candidate head is `fa7b6235ea24722d7821877263ec587ef324f976`. On that same SHA, the production-only SA-14 live workflow passed with 43 observations -> 43 quarantined projections, and the complete normal repository CI passed dependency checks/audits, Ruff, strict Mypy, architecture/release contracts, reversible migrations, complete pytest/branch-aware coverage, and frontend audit/typecheck/build.

GDELT remains in SA-14, but its 2026 provider-announced API migration toward GDELT 5 means this PR intentionally does not freeze a new adapter against a legacy interface. Issue #108 stays open after this Common Crawl tranche for the remaining search/archive candidates.

No review threads are open. This PR is ready to squash-merge only at exact head `fa7b6235ea24722d7821877263ec587ef324f976`.