### PR TITLE
SA-14: add governed GitHub code-search metadata

### DIFF
--- a/.github/workflows/sa14-live-validation.yml
+++ b/.github/workflows/sa14-live-validation.yml
@@ -31,3 +31,25 @@ jobs:
 
       - name: Controlled Common Crawl live validation
         run: python scripts/live_validate_sa14.py
+
+  live-github-code-search:
+    if: github.event.pull_request.head.ref == 'agent/sa14-github-code-search-metadata'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled GitHub code-search live validation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/live_validate_sa14_github_code_search.py

--- a/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
+++ b/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
@@ -41,7 +41,7 @@ The WARC filename/offset/length are retained only as archive-index provenance. T
 
 Each accepted capture emits an immutable `RawObservation` and a quarantined Lot 12 `ARCHIVE_SNAPSHOT` public-footprint projection. The projection contains no claims. Common Crawl historical presence is not current deployment, exposure, vulnerability, compromise, need, opportunity, or outreach authorization.
 
-## Target and checkpoint semantics
+## Common Crawl target and checkpoint semantics
 
 Common Crawl reuses the existing `PublicWebTarget` scope rather than introducing a parallel organization-target model.
 
@@ -54,7 +54,7 @@ The checkpoint contains:
 
 The provider collection list may still be checked on a later schedule run, but an unchanged crawl ID prevents a duplicate capture query for the same target/prefix.
 
-## Provider governance
+## Common Crawl provider governance
 
 Only these Common Crawl provider paths are authorized:
 
@@ -63,7 +63,7 @@ Only these Common Crawl provider paths are authorized:
 
 Raw crawled content is not authorized by this source path. Common Crawl's terms also make clear that third-party crawled content may have separate rights and must not be treated as provider-verified truth.
 
-## Controlled live validation
+## Common Crawl controlled live validation
 
 The dedicated `.github/workflows/sa14-live-validation.yml` workflow runs `scripts/live_validate_sa14.py` against the production adapter itself. The controlled target is Common Crawl's own public domain, so provider behavior is tested without using a prospect organization as a test target.
 
@@ -76,20 +76,114 @@ The successful provider proof on source head `142208db3d42bc956d672297c2e7ef0408
 
 The exact one-for-one observation/projection count proves that live provider index records survive the real adapter boundary while preserving the metadata-only quarantine boundary. It does not make those historical URLs factual evidence of current organization state.
 
-This controlled proof justified adding `live_tested` to Common Crawl Source Activation. Because this documentation and activation change modify the branch head, the dedicated live workflow and complete repository CI must pass again on the exact final merge candidate.
+This controlled proof justified adding `live_tested` to Common Crawl Source Activation. The Common Crawl tranche was later exact-SHA validated and squash-merged on `main`.
+
+## GitHub REST code-search metadata
+
+Source id: `github-code-search-metadata`.
+
+The second SA-14 tranche adds a dedicated authenticated GitHub REST Code Search capability. It is intentionally separate from Priority B-2 `github-public-org-repositories`:
+
+- B-2 enumerates public repository metadata for exact configured organizations and never performs global code search;
+- SA-14 code search uses GitHub's `/search/code` endpoint only for explicitly configured `github_org` targets and explicitly approved query templates;
+- the two adapters have independent source identities, authorization semantics, quotas and runtime credentials.
+
+GitHub Code Search is not used as a source-code ingestion path. CIP never follows the returned content/blob API URLs and never retrieves or stores the matched file contents.
+
+### Query governance
+
+Checked-in templates are stored in `policies/github_code_search_templates.yml` and are disabled by default.
+
+A template is rejected before runtime unless it:
+
+- contains exactly one `{organization}` placeholder;
+- contains the exact `org:{organization}` qualifier;
+- avoids secret-hunting terms including `password`, `secret`, `token`, `credential` and `private_key`.
+
+The checked-in `developer_ecosystem_targets.yml` registry also remains empty by default. Consequently, source registration alone cannot initiate a GitHub search.
+
+A production request requires all of the following:
+
+1. an enabled canonical-organization-bound `github_org` target;
+2. an enabled approved code-search template;
+3. Source Governance authorization for `/search/code` and purpose `code-search-discovery`;
+4. a connected Provider Onboarding `api_token` secret;
+5. an explicit runtime invocation or deployment-enabled schedule.
+
+The checked-in schedule remains `enabled: false`.
+
+### Provider and response bounds
+
+The production client uses:
+
+- `GET https://api.github.com/search/code`;
+- `X-GitHub-Api-Version: 2026-03-10`;
+- `Accept: application/vnd.github+json`;
+- bearer authentication supplied through the existing `connected_secret_supplier` path;
+- `per_page=20` and `page=1`;
+- a maximum response body of 2 MiB;
+- redirects disabled;
+- explicit rejection of provider responses marked `incomplete_results=true`.
+
+HTTP quota/rate failures are typed and retryable where appropriate. Schema drift, unsafe response size and invalid checkpoints fail closed.
+
+### Persisted fields and evidence boundary
+
+The provider may use indexed source code internally to answer the search, but CIP persists only bounded result metadata:
+
+- public repository full name;
+- repository/path identity;
+- file SHA;
+- GitHub HTML result URL;
+- query-template identity/version;
+- result rank.
+
+Private repositories, results outside the exact configured organization and non-`github.com` HTML URLs are discarded.
+
+Each accepted hit emits one immutable `RawObservation` and one quarantined Lot 12 `SEARCH_RESULT` projection. The generated excerpt explicitly states `file content not retrieved`. No candidate `PublicClaim`, `CommercialSignal`, need hypothesis, opportunity or outreach action is created.
+
+A code-search hit therefore means only that GitHub's public search index returned metadata matching an approved organization-scoped query. It does not prove production deployment, technology use, exposure, vulnerability applicability, compromise, security maturity, commercial need or contact authorization.
+
+### Provider Onboarding
+
+Runtime credentials are not read directly from environment variables by the adapter. Production composition uses the existing Provider Onboarding mechanism:
+
+`github-code-search-metadata / api_token -> connected_secret_supplier -> GitHubCodeSearchAdapter`.
+
+The GitHub Actions live workflow is a controlled validation exception: it passes the ephemeral workflow `GITHUB_TOKEN` to the production adapter through the same adapter token-provider boundary. The token itself is never persisted by CIP.
+
+### Controlled live validation
+
+The dedicated SA-14 workflow exercised the real production adapter on source head `1d3079ab9f5a5a464e537b08e7ac4af778bc5b77` using the public GitHub organization `github` as a non-prospect controlled target and the query:
+
+`security org:github filename:SECURITY.md`
+
+The real provider returned the configured maximum page:
+
+- observations: `20`;
+- quarantined projections: `20`;
+- claims: `0`;
+- file-content fetches: `0`.
+
+The same live proof passed again after the Ruff-only formatting correction on head `ad1a2e572ce7cd559104851e45b9fbd3bafda21d`.
+
+This proves the authenticated provider path, organization filtering, metadata mapping and quarantine boundary. It does not turn the returned search hits into factual claims about the target organization.
+
+Because adding this documentation and the `live_tested` Source Activation stage changes the branch head, both the complete repository CI and the dedicated GitHub code-search live workflow must pass again on the exact final merge candidate before the PR may leave draft.
 
 ## GDELT migration boundary
 
 GDELT remains a high-value SA-14 event/news-discovery candidate. In 2026 the provider announced migration of the API ecosystem toward GDELT 5 / Spanner. SA-14 will not create a new production adapter against a legacy contract merely to mark the candidate complete. GDELT will be revisited against the current documented public interface once the migration provides a stable provider-specific execution contract.
 
-## Completion gate for the Common Crawl tranche
+## Completion gate for the GitHub code-search tranche
 
-Common Crawl may be squash-merged only when:
+GitHub Code Search may be squash-merged only when:
 
-1. source governance, portfolio, schedule and runtime registration agree on the same provider identity;
-2. deterministic tests cover collection selection, target scope, schema drift, historical collection identities, checkpoint replay and failure classification;
-3. the production adapter obtains non-empty metadata from a controlled approved target through the real Common Crawl service;
-4. each live capture maps one-for-one into a raw observation and a quarantined public-footprint projection with zero claims;
-5. no WARC body is fetched;
-6. the complete repository CI and dedicated SA-14 live workflow pass on the exact final PR head;
-7. reviews and review threads are clear before squash merge.
+1. Source Governance, Provider Onboarding, portfolio, runtime registration and the disabled-by-default schedule agree on `github-code-search-metadata` / `github-rest-code-search`;
+2. target and template registries remain fail-closed by default;
+3. deterministic tests cover query scope, secret-hunting rejection, token absence, no-target/no-network behavior, exact-organization filtering, private/non-GitHub rejection, checkpoint validation, provider schema drift, incomplete results and rate-limit classification;
+4. the production adapter obtains non-empty metadata through the real GitHub Code Search endpoint using a controlled non-prospect organization;
+5. every retained live hit maps one-for-one to a raw observation and quarantined projection with zero claims and zero source-code retrieval;
+6. `live_tested` is recorded only after the controlled provider proof;
+7. complete backend/frontend CI and the dedicated live workflow pass on the exact final PR head;
+8. reviews and review threads are clear before squash merge.

--- a/policies/collection_schedules.search_archives.yml
+++ b/policies/collection_schedules.search_archives.yml
@@ -36,3 +36,15 @@ schedules:
       max_delay_seconds: 7200
       circuit_failure_threshold: 3
       circuit_reset_seconds: 14400
+
+  - source_id: github-code-search-metadata
+    adapter_id: github-rest-code-search
+    enabled: false
+    interval_seconds: 86400
+    lease_seconds: 180
+    retry:
+      max_attempts: 2
+      base_delay_seconds: 900
+      max_delay_seconds: 7200
+      circuit_failure_threshold: 2
+      circuit_reset_seconds: 7200

--- a/policies/github_code_search_templates.yml
+++ b/policies/github_code_search_templates.yml
@@ -1,0 +1,20 @@
+version: 1
+
+templates:
+  - id: security-policy-metadata
+    version: 1
+    query_pattern: "security org:{organization} filename:SECURITY.md"
+    purpose: public-security-policy-discovery
+    enabled: false
+
+  - id: dependency-automation-metadata
+    version: 1
+    query_pattern: "updates org:{organization} filename:dependabot.yml"
+    purpose: public-dependency-automation-discovery
+    enabled: false
+
+  - id: code-ownership-metadata
+    version: 1
+    query_pattern: "owners org:{organization} filename:CODEOWNERS"
+    purpose: public-code-ownership-discovery
+    enabled: false

--- a/policies/provider_onboarding.yml
+++ b/policies/provider_onboarding.yml
@@ -191,6 +191,23 @@ providers:
     automatic_onboarding: false
     blocked_reason: null
 
+  - source_id: github-code-search-metadata
+    display_name: GitHub REST Code Search Metadata
+    auth_mode: api_key
+    documentation_url: https://docs.github.com/en/rest/search/search#search-code
+    signup_url: https://github.com/settings/tokens
+    console_url: https://github.com/settings/tokens
+    required_secret_names:
+      - api_token
+    human_actions:
+      - sign_in
+      - accept_provider_terms
+      - retrieve_technical_credentials
+      - register_secret_reference
+      - enable_source_policy
+    automatic_onboarding: false
+    blocked_reason: null
+
   - source_id: internet-archive-cdx
     display_name: Internet Archive CDX
     auth_mode: none

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -15,3 +15,18 @@ sources:
       - executable
       - scheduled
       - live_tested
+
+  - source_id: github-code-search-metadata
+    display_name: GitHub REST code-search metadata
+    category: corporate_public_footprint
+    disposition: active
+    activation_wave: SA-14
+    requires_schedule: false
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable
+      - live_tested

--- a/policies/source_portfolio.search_archives.yml
+++ b/policies/source_portfolio.search_archives.yml
@@ -99,3 +99,40 @@ sources:
       supports_retractions: false
       max_page_size: 50
       cost_per_request: 0
+
+  - source_id: github-code-search-metadata
+    display_name: GitHub REST code-search metadata
+    canonical_url: https://api.github.com/search/code
+    category: corporate_public_footprint
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases:
+      - public_evidence_map
+      - organization_research
+      - public_engineering_context
+    candidate_origin: SA-14
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      provider_onboarding_required: true
+      target_registry_required: true
+      query_registry_required: true
+      raw_source_code_storage: false
+      search_result_is_evidence: false
+      automatic_opportunity: forbidden
+      secret_hunting: forbidden
+    adapter:
+      adapter_id: github-rest-code-search
+      adapter_version: "1"
+      provider_schema_version: github-code-search-v1
+      modes: [conditional_refresh, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - public_resource
+        - public_resource_version
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 20
+      cost_per_request: 0

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -114,3 +114,41 @@ sources:
       Target-bound Common Crawl URL-index metadata only. WARC body retrieval is intentionally
       excluded from this source path. A capture proves historical index presence only; it does not
       prove current deployment, exposure, vulnerability, compromise, need, or outreach authority.
+
+  - id: github-code-search-metadata
+    name: GitHub REST code-search metadata
+    base_url: https://api.github.com/search/code
+    status: enabled
+    source_type: search_provider
+    owner: GitHub
+    terms_url: https://docs.github.com/en/site-policy/github-terms/github-terms-of-service
+    licence: GitHub REST API under GitHub Terms; bounded organization-scoped metadata search only
+    allowed_data_categories: [public_result_metadata]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 10
+    retention_days: 90
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_14_SEARCH_ARCHIVES.md#github-code-search-metadata
+      reviewed_at: "2026-08-11T11:35:00+00:00"
+      expires_at: null
+      approved_hosts: [api.github.com]
+      approved_path_prefixes: [/search/code]
+      approved_purposes: [code-search-discovery]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: high
+    notes: >-
+      Authenticated GitHub code-search metadata only, scoped to explicitly configured public
+      organization targets and approved non-secret query templates. File contents, blobs, archives,
+      users, contributors, credentials and private repositories are not retrieved or persisted.
+      Search hits are quarantined discovery leads and never directly prove deployment, exposure,
+      vulnerability applicability, compromise, commercial need, opportunity or outreach authority.

--- a/scripts/live_validate_sa14_github_code_search.py
+++ b/scripts/live_validate_sa14_github_code_search.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from os import environ
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.developer_ecosystem.registry import (
+    DeveloperEcosystemTarget,
+    DeveloperTargetKind,
+)
+from cip.modules.collection_orchestration.application.github_code_search_adapter import (
+    GitHubCodeSearchAdapter,
+)
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+ORG_ID = UUID("7c043f8d-aa93-5c10-94f4-d0ce92fcd5a4")
+
+
+def main() -> None:
+    token = environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required for controlled GitHub code-search live proof")
+    entry = next(
+        item
+        for item in load_source_registry(POLICY_PATH)
+        if item.policy.id == "github-code-search-metadata"
+    )
+    now = datetime.now(UTC)
+    target = DeveloperEcosystemTarget(
+        target_id="github-provider-live",
+        organization_id=ORG_ID,
+        kind=DeveloperTargetKind.GITHUB_ORG,
+        namespace="github",
+        enabled=True,
+    )
+    template = SearchQueryTemplate(
+        id="security-policy-metadata-live",
+        version=1,
+        query_pattern="security org:{organization} filename:SECURITY.md",
+        purpose="public-security-policy-discovery",
+        enabled=True,
+    )
+    batch = GitHubCodeSearchAdapter(
+        entry,
+        (target,),
+        (template,),
+        token_provider=lambda: token,
+        timeout_seconds=30,
+    ).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=90),
+    )
+    observations = len(batch.observations)
+    projections = len(batch.public_footprint_projections)
+    if observations < 1 or projections != observations:
+        raise RuntimeError("GitHub code-search live proof did not preserve metadata hits")
+    if observations > 20:
+        raise RuntimeError("GitHub code-search live proof exceeded bounded page size")
+    if any(projection.claims for projection in batch.public_footprint_projections):
+        raise RuntimeError("GitHub code-search metadata unexpectedly produced claims")
+    if any(
+        projection.resource.retrieval_state.value != "quarantined"
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("GitHub code-search results escaped quarantine")
+    if any(
+        "file content not retrieved" not in (projection.version.excerpt or "")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("GitHub code-search result lost metadata-only boundary")
+    if any(
+        not projection.resource.canonical_url.startswith("https://github.com/github/")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("GitHub code-search live result escaped controlled organization")
+    print(
+        "SA-14 GitHub code-search live validation passed: "
+        f"observations={observations} projections={projections} claims=0 content_fetches=0"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/github_code_search/__init__.py
+++ b/src/cip/adapters/sources/github_code_search/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub code-search metadata adapter contracts."""

--- a/src/cip/adapters/sources/github_code_search/client.py
+++ b/src/cip/adapters/sources/github_code_search/client.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.github_code_search.schemas import GitHubCodeSearchResponse
+
+API_VERSION = "2026-03-10"
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+PER_PAGE = 20
+
+
+class GitHubCodeSearchClientError(RuntimeError):
+    def __init__(self, message: str, *, code: str, retryable: bool) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubCodeSearchResult:
+    response: GitHubCodeSearchResponse
+    request_url: str
+
+
+class GitHubCodeSearchClient:
+    def __init__(
+        self,
+        token: str,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if not token.strip():
+            raise ValueError("GitHub code-search token is required")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._token = token
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def search(self, endpoint_url: str, *, query: str) -> GitHubCodeSearchResult:
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+                transport=self._transport,
+            ) as client:
+                response = client.get(
+                    endpoint_url,
+                    params={"q": query, "per_page": PER_PAGE, "page": 1},
+                    headers={
+                        "Accept": "application/vnd.github+json",
+                        "Authorization": f"Bearer {self._token}",
+                        "X-GitHub-Api-Version": API_VERSION,
+                    },
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise GitHubCodeSearchClientError(
+                f"GitHub code search returned HTTP {status}",
+                code=f"http_{status}",
+                retryable=status in {403, 429} or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise GitHubCodeSearchClientError(
+                str(exc) or type(exc).__name__,
+                code="source_transport_error",
+                retryable=True,
+            ) from exc
+        if len(response.content) > MAX_RESPONSE_BYTES:
+            raise GitHubCodeSearchClientError(
+                "GitHub code-search response exceeds size limit",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        try:
+            parsed = GitHubCodeSearchResponse.model_validate_json(response.content)
+        except ValidationError as exc:
+            raise GitHubCodeSearchClientError(
+                "GitHub code-search response schema changed",
+                code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        if parsed.incomplete_results:
+            raise GitHubCodeSearchClientError(
+                "GitHub code-search result set is incomplete",
+                code="incomplete_provider_results",
+                retryable=True,
+            )
+        if len(parsed.items) > PER_PAGE:
+            raise GitHubCodeSearchClientError(
+                "GitHub code-search returned too many items",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        return GitHubCodeSearchResult(response=parsed, request_url=str(response.url))

--- a/src/cip/adapters/sources/github_code_search/registry.py
+++ b/src/cip/adapters/sources/github_code_search/registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+
+
+class GitHubCodeSearchTemplateRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    id: str = Field(min_length=1, max_length=100)
+    version: int = Field(ge=1)
+    query_pattern: str = Field(min_length=1, max_length=500)
+    purpose: str = Field(min_length=1, max_length=200)
+    enabled: bool = False
+
+    @model_validator(mode="after")
+    def validate_query(self) -> GitHubCodeSearchTemplateRecord:
+        if self.query_pattern.count("{organization}") != 1:
+            raise ValueError("GitHub code-search query requires one {organization} placeholder")
+        if "org:{organization}" not in self.query_pattern:
+            raise ValueError("GitHub code-search query must be organization-scoped")
+        forbidden = ("password", "secret", "token", "credential", "private_key")
+        if any(term in self.query_pattern.casefold() for term in forbidden):
+            raise ValueError("GitHub code-search query may not hunt for secrets")
+        return self
+
+    def to_domain(self) -> SearchQueryTemplate:
+        return SearchQueryTemplate(
+            id=self.id,
+            version=self.version,
+            query_pattern=self.query_pattern,
+            purpose=self.purpose,
+            enabled=self.enabled,
+        )
+
+
+class GitHubCodeSearchTemplateFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    templates: list[GitHubCodeSearchTemplateRecord] = Field(
+        default_factory=list,
+        max_length=50,
+    )
+
+
+def load_github_code_search_templates(path: Path) -> tuple[SearchQueryTemplate, ...]:
+    parsed = GitHubCodeSearchTemplateFile.model_validate(
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+    )
+    templates = tuple(record.to_domain() for record in parsed.templates)
+    ids = [template.id for template in templates]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate GitHub code-search template id")
+    return templates

--- a/src/cip/adapters/sources/github_code_search/schemas.py
+++ b/src/cip/adapters/sources/github_code_search/schemas.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GitHubCodeRepository(BaseModel):
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    id: int = Field(gt=0)
+    name: str = Field(min_length=1, max_length=300)
+    full_name: str = Field(min_length=1, max_length=500)
+    private: bool
+    html_url: str = Field(min_length=1, max_length=2_000)
+
+
+class GitHubCodeSearchItem(BaseModel):
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=500)
+    path: str = Field(min_length=1, max_length=2_000)
+    sha: str = Field(min_length=7, max_length=100)
+    url: str = Field(min_length=1, max_length=2_000)
+    git_url: str = Field(min_length=1, max_length=2_000)
+    html_url: str = Field(min_length=1, max_length=2_000)
+    repository: GitHubCodeRepository
+
+
+class GitHubCodeSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    total_count: int = Field(ge=0)
+    incomplete_results: bool
+    items: tuple[GitHubCodeSearchItem, ...]

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -71,6 +71,7 @@ class AdapterCompositionInputs:
     public_web_targets: tuple[PublicWebTarget, ...]
     developer_ecosystem_targets: tuple[DeveloperEcosystemTarget, ...]
     search_templates: tuple[SearchQueryTemplate, ...]
+    github_code_search_templates: tuple[SearchQueryTemplate, ...]
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
     rdap_targets: tuple[RdapTarget, ...]
@@ -81,6 +82,7 @@ def build_runtime_adapters(
     inputs: AdapterCompositionInputs,
     *,
     brave_token_provider: Callable[[], str | None],
+    github_code_search_token_provider: Callable[[], str | None],
     certspotter_token_provider: Callable[[], str | None],
     phishtank_token_provider: Callable[[], str | None],
     teamtailor_token_provider: Callable[[], str | None],
@@ -129,7 +131,10 @@ def build_runtime_adapters(
         entries_by_id,
         inputs.public_web_targets,
         inputs.search_templates,
+        inputs.developer_ecosystem_targets,
+        inputs.github_code_search_templates,
         brave_token_provider=brave_token_provider,
+        github_code_search_token_provider=github_code_search_token_provider,
         timeout_seconds=timeout_seconds,
     )
     register_vulnerability_adapters(

--- a/src/cip/modules/collection_orchestration/application/github_code_search_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/github_code_search_adapter.py
@@ -106,7 +106,13 @@ class GitHubCodeSearchAdapter:
         )
         projections = tuple(
             map_search_result_lead(
-                _lead(item, target=target, template=template, rank=index, observed_at=collected_at)
+                _lead(
+                    item,
+                    target=target,
+                    template=template,
+                    rank=index,
+                    observed_at=collected_at,
+                )
             )
             for index, item in enumerate(items, start=1)
         )
@@ -193,13 +199,17 @@ def _lead(
     observed_at: datetime,
 ) -> SearchResultLead:
     title = f"{item.repository.full_name}:{item.path}"
+    snippet = (
+        f"GitHub code-search metadata for {title} at {item.sha}; "
+        "file content not retrieved."
+    )
     return SearchResultLead(
         organization_id=target.organization_id,
         source_id=GitHubCodeSearchAdapter.source_id,
         source_record_key=_record_key(item, template),
         target_url=item.html_url,
         title=title,
-        snippet=f"GitHub code-search metadata for {title} at {item.sha}; file content not retrieved.",
+        snippet=snippet,
         rank=rank,
         observed_at=observed_at,
         query_template_id=template.id,

--- a/src/cip/modules/collection_orchestration/application/github_code_search_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/github_code_search_adapter.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from hashlib import sha256
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.developer_ecosystem.registry import (
+    DeveloperEcosystemTarget,
+    DeveloperTargetKind,
+)
+from cip.adapters.sources.github_code_search.client import (
+    GitHubCodeSearchClient,
+    GitHubCodeSearchClientError,
+)
+from cip.adapters.sources.github_code_search.schemas import GitHubCodeSearchItem
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.public_footprint.domain.search import (
+    SearchQueryTemplate,
+    SearchResultLead,
+    map_search_result_lead,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class GitHubCodeSearchAdapter:
+    source_id = "github-code-search-metadata"
+    adapter_id = "github-rest-code-search"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[DeveloperEcosystemTarget, ...],
+        templates: tuple[SearchQueryTemplate, ...],
+        *,
+        token_provider: Callable[[], str | None],
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("GitHub code-search adapter requires its source policy")
+        self._entry = entry
+        self._pairs = _pairs(targets, templates)
+        self._token_provider = token_provider
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        pair, next_index = _next_pair(self._pairs, checkpoint_payload)
+        if pair is None:
+            return _empty_batch()
+        target, template = pair
+        token = self._token_provider()
+        if not token:
+            raise AdapterExecutionError(
+                "GitHub code-search provider is not connected",
+                error_code="provider_not_connected",
+                retryable=False,
+            )
+        query = template.render(target.namespace or "")
+        _authorize(self._entry, collected_at)
+        try:
+            result = GitHubCodeSearchClient(
+                token,
+                timeout_seconds=self._timeout_seconds,
+                transport=self._transport,
+            ).search(self._entry.policy.base_url, query=query)
+        except GitHubCodeSearchClientError as exc:
+            raise AdapterExecutionError(
+                str(exc), error_code=exc.code, retryable=exc.retryable
+            ) from exc
+        items = tuple(
+            item for item in result.response.items if _belongs_to_target(item, target)
+        )
+        observations = tuple(
+            _observation(
+                item,
+                template=template,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+                source_url=result.request_url,
+            )
+            for item in items
+        )
+        projections = tuple(
+            map_search_result_lead(
+                _lead(item, target=target, template=template, rank=index, observed_at=collected_at)
+            )
+            for index, item in enumerate(items, start=1)
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            public_footprint_projections=projections,
+            checkpoint_payload={"pair_index": next_index},
+            not_modified=not items,
+        )
+
+
+def _authorize(entry: SourceRegistryEntry, now: datetime) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=entry.policy.base_url,
+            purpose="code-search-discovery",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def _pairs(
+    targets: tuple[DeveloperEcosystemTarget, ...],
+    templates: tuple[SearchQueryTemplate, ...],
+) -> tuple[tuple[DeveloperEcosystemTarget, SearchQueryTemplate], ...]:
+    return tuple(
+        (target, template)
+        for target in targets
+        if target.enabled and target.kind is DeveloperTargetKind.GITHUB_ORG
+        for template in templates
+        if template.enabled
+    )
+
+
+def _next_pair(
+    pairs: tuple[tuple[DeveloperEcosystemTarget, SearchQueryTemplate], ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[tuple[DeveloperEcosystemTarget, SearchQueryTemplate] | None, int]:
+    if not pairs:
+        return None, 0
+    value = 0 if payload is None else payload.get("pair_index", 0)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise AdapterExecutionError(
+            "invalid GitHub code-search checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(pairs)
+    next_index = 0 if index + 1 >= len(pairs) else index + 1
+    return pairs[index], next_index
+
+
+def _belongs_to_target(
+    item: GitHubCodeSearchItem,
+    target: DeveloperEcosystemTarget,
+) -> bool:
+    namespace = target.namespace or ""
+    if item.repository.private:
+        return False
+    if not item.repository.full_name.casefold().startswith(f"{namespace.casefold()}/"):
+        return False
+    parsed = urlsplit(item.html_url)
+    return parsed.scheme == "https" and parsed.hostname == "github.com"
+
+
+def _lead(
+    item: GitHubCodeSearchItem,
+    *,
+    target: DeveloperEcosystemTarget,
+    template: SearchQueryTemplate,
+    rank: int,
+    observed_at: datetime,
+) -> SearchResultLead:
+    title = f"{item.repository.full_name}:{item.path}"
+    return SearchResultLead(
+        organization_id=target.organization_id,
+        source_id=GitHubCodeSearchAdapter.source_id,
+        source_record_key=_record_key(item, template),
+        target_url=item.html_url,
+        title=title,
+        snippet=f"GitHub code-search metadata for {title} at {item.sha}; file content not retrieved.",
+        rank=rank,
+        observed_at=observed_at,
+        query_template_id=template.id,
+        query_template_version=template.version,
+        candidate_claim=None,
+    )
+
+
+def _observation(
+    item: GitHubCodeSearchItem,
+    *,
+    template: SearchQueryTemplate,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    source_url: str,
+) -> RawObservation:
+    material = (
+        f"{item.repository.full_name}\n{item.path}\n{item.sha}\n{item.html_url}\n{template.id}"
+    ).encode()
+    return RawObservation(
+        source_id=GitHubCodeSearchAdapter.source_id,
+        adapter_id=GitHubCodeSearchAdapter.adapter_id,
+        adapter_version=GitHubCodeSearchAdapter.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="github-code-search-result-metadata",
+        source_url=source_url,
+        payload_hash_sha256=sha256(material).hexdigest(),
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        source_record_key=_record_key(item, template),
+        collected_at=collected_at,
+        retention_until=retention_until,
+        schema_fingerprint="github-rest-code-search:v1",
+    )
+
+
+def _record_key(item: GitHubCodeSearchItem, template: SearchQueryTemplate) -> str:
+    return f"{template.id}:{item.repository.full_name}:{item.path}:{item.sha}"
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"pair_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -12,6 +12,9 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from cip.adapters.sources.ashby.registry import load_ashby_boards
 from cip.adapters.sources.developer_ecosystem.registry import load_developer_ecosystem_targets
+from cip.adapters.sources.github_code_search.registry import (
+    load_github_code_search_templates,
+)
 from cip.adapters.sources.greenhouse.registry import load_greenhouse_boards
 from cip.adapters.sources.incident_catalogs.sec_registry import load_sec_incident_targets
 from cip.adapters.sources.lever.registry import load_lever_sites
@@ -98,6 +101,11 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         brave_token_provider=connected_secret_supplier(
             factory,
             source_id="brave-search-api",
+            secret_name="api_token",
+        ),
+        github_code_search_token_provider=connected_secret_supplier(
+            factory,
+            source_id="github-code-search-metadata",
             secret_name="api_token",
         ),
         certspotter_token_provider=connected_secret_supplier(
@@ -201,6 +209,9 @@ def _load_adapter_inputs(
         ),
         search_templates=load_search_query_templates(
             settings.search_query_template_registry_path
+        ),
+        github_code_search_templates=load_github_code_search_templates(
+            settings.github_code_search_template_registry_path
         ),
         vulnerability_targets=load_vulnerability_query_targets(
             settings.vulnerability_query_target_registry_path

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.archive_cdx_adapter import (
     InternetArchiveCdxAdapter,
@@ -11,6 +12,9 @@ from cip.modules.collection_orchestration.application.brave_search_adapter impor
 )
 from cip.modules.collection_orchestration.application.common_crawl_adapter import (
     CommonCrawlIndexAdapter,
+)
+from cip.modules.collection_orchestration.application.github_code_search_adapter import (
+    GitHubCodeSearchAdapter,
 )
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.public_footprint.domain.search import SearchQueryTemplate
@@ -22,8 +26,11 @@ def register_search_archive_adapters(
     entries_by_id: dict[str, SourceRegistryEntry],
     targets: tuple[PublicWebTarget, ...],
     templates: tuple[SearchQueryTemplate, ...],
+    developer_targets: tuple[DeveloperEcosystemTarget, ...],
+    github_code_search_templates: tuple[SearchQueryTemplate, ...],
     *,
     brave_token_provider: Callable[[], str | None],
+    github_code_search_token_provider: Callable[[], str | None],
     timeout_seconds: float,
 ) -> None:
     brave_entry = entries_by_id.get(BraveSearchAdapter.source_id)
@@ -57,6 +64,19 @@ def register_search_archive_adapters(
             CommonCrawlIndexAdapter(
                 common_crawl_entry,
                 targets,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    github_code_entry = entries_by_id.get(GitHubCodeSearchAdapter.source_id)
+    if github_code_entry is not None:
+        _register(
+            adapters,
+            GitHubCodeSearchAdapter(
+                github_code_entry,
+                developer_targets,
+                github_code_search_templates,
+                token_provider=github_code_search_token_provider,
                 timeout_seconds=timeout_seconds,
             ),
         )

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -117,6 +117,9 @@ class Settings(BaseSettings):
     search_query_template_registry_path: Path = Path(
         "policies/search_query_templates.yml"
     )
+    github_code_search_template_registry_path: Path = Path(
+        "policies/github_code_search_templates.yml"
+    )
     vulnerability_query_target_registry_path: Path = Path(
         "policies/vulnerability_query_targets.yml"
     )

--- a/tests/unit/collection_orchestration/test_github_code_search_adapter.py
+++ b/tests/unit/collection_orchestration/test_github_code_search_adapter.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.developer_ecosystem.registry import (
+    DeveloperEcosystemTarget,
+    DeveloperTargetKind,
+)
+from cip.adapters.sources.github_code_search.registry import (
+    load_github_code_search_templates,
+)
+from cip.modules.collection_orchestration.application.github_code_search_adapter import (
+    GitHubCodeSearchAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=90)
+ORG_ID = UUID("20a6b15f-5453-5a93-9dd4-ea392e6e8a54")
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+TEMPLATE_PATH = Path("policies/github_code_search_templates.yml")
+
+
+def test_checked_in_github_code_search_templates_are_disabled_and_safe() -> None:
+    templates = load_github_code_search_templates(TEMPLATE_PATH)
+    assert len(templates) == 3
+    assert all(template.enabled is False for template in templates)
+    assert all("org:{organization}" in template.query_pattern for template in templates)
+
+
+def test_github_code_search_template_registry_rejects_unsafe_queries(tmp_path: Path) -> None:
+    unsafe = tmp_path / "unsafe.yml"
+    unsafe.write_text(
+        """version: 1
+templates:
+  - id: unsafe
+    version: 1
+    query_pattern: "secret org:{organization}"
+    purpose: unsafe
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="may not hunt for secrets"):
+        load_github_code_search_templates(unsafe)
+
+    unscoped = tmp_path / "unscoped.yml"
+    unscoped.write_text(
+        """version: 1
+templates:
+  - id: unscoped
+    version: 1
+    query_pattern: "SECURITY.md {organization}"
+    purpose: unsafe
+    enabled: true
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="must be organization-scoped"):
+        load_github_code_search_templates(unscoped)
+
+
+def test_github_code_search_without_enabled_target_performs_no_network_or_secret_read() -> None:
+    secret_reads: list[int] = []
+
+    def token_provider() -> str | None:
+        secret_reads.append(1)
+        return "token"
+
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without an enabled target")
+
+    adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(enabled=False),),
+        (_template(),),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(fail_network),
+    )
+    batch = _collect(adapter)
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert secret_reads == []
+
+
+def test_github_code_search_requires_connected_token_before_network() -> None:
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without provider token")
+
+    adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        token_provider=lambda: None,
+        transport=httpx.MockTransport(fail_network),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "provider_not_connected"
+    assert exc_info.value.retryable is False
+
+
+def test_github_code_search_maps_only_public_exact_org_metadata() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "total_count": 4,
+                "incomplete_results": False,
+                "items": [
+                    _item("github/example", "SECURITY.md"),
+                    _item("other/example", "SECURITY.md", sha="b" * 40),
+                    _item("github/private", "SECURITY.md", private=True, sha="c" * 40),
+                    _item(
+                        "github/evil",
+                        "SECURITY.md",
+                        html_url="https://evil.example/github/evil/blob/main/SECURITY.md",
+                        sha="d" * 40,
+                    ),
+                ],
+            },
+            request=request,
+        )
+
+    adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        token_provider=lambda: "live-token",
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.path == "/search/code"
+    assert request.url.params["q"] == "security org:github filename:SECURITY.md"
+    assert request.url.params["per_page"] == "20"
+    assert request.url.params["page"] == "1"
+    assert request.headers["Authorization"] == "Bearer live-token"
+    assert request.headers["X-GitHub-Api-Version"] == "2026-03-10"
+
+    assert len(batch.observations) == 1
+    assert len(batch.public_footprint_projections) == 1
+    projection = batch.public_footprint_projections[0]
+    assert projection.claims == ()
+    assert projection.resource.canonical_url.startswith(
+        "https://github.com/github/example/blob/"
+    )
+    assert projection.resource.retrieval_state.value == "quarantined"
+    assert "file content not retrieved" in (projection.version.excerpt or "")
+    assert batch.checkpoint_payload == {"pair_index": 0}
+
+
+def test_github_code_search_rejects_invalid_checkpoint() -> None:
+    adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        token_provider=lambda: "token",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter, checkpoint_payload={"pair_index": True})
+    assert exc_info.value.error_code == "invalid_checkpoint"
+
+
+def test_github_code_search_classifies_schema_rate_limit_and_incomplete_results() -> None:
+    def malformed(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not-json", request=request)
+
+    malformed_adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        token_provider=lambda: "token",
+        transport=httpx.MockTransport(malformed),
+    )
+    with pytest.raises(AdapterExecutionError) as schema_info:
+        _collect(malformed_adapter)
+    assert schema_info.value.error_code == "source_schema_drift"
+
+    def rate_limited(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, request=request)
+
+    rate_adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        token_provider=lambda: "token",
+        transport=httpx.MockTransport(rate_limited),
+    )
+    with pytest.raises(AdapterExecutionError) as rate_info:
+        _collect(rate_adapter)
+    assert rate_info.value.error_code == "http_429"
+    assert rate_info.value.retryable is True
+
+    def incomplete(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"total_count": 1, "incomplete_results": True, "items": []},
+            request=request,
+        )
+
+    incomplete_adapter = GitHubCodeSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        token_provider=lambda: "token",
+        transport=httpx.MockTransport(incomplete),
+    )
+    with pytest.raises(AdapterExecutionError) as incomplete_info:
+        _collect(incomplete_adapter)
+    assert incomplete_info.value.error_code == "incomplete_provider_results"
+    assert incomplete_info.value.retryable is True
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == "github-code-search-metadata"
+    )
+
+
+def _target(*, enabled: bool = True) -> DeveloperEcosystemTarget:
+    return DeveloperEcosystemTarget(
+        target_id="github-code-search-live",
+        organization_id=ORG_ID,
+        kind=DeveloperTargetKind.GITHUB_ORG,
+        namespace="github",
+        enabled=enabled,
+    )
+
+
+def _template() -> SearchQueryTemplate:
+    return SearchQueryTemplate(
+        id="security-policy-metadata",
+        version=1,
+        query_pattern="security org:{organization} filename:SECURITY.md",
+        purpose="public-security-policy-discovery",
+        enabled=True,
+    )
+
+
+def _collect(
+    adapter: GitHubCodeSearchAdapter,
+    *,
+    checkpoint_payload: dict[str, object] | None = None,
+):
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint_payload,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _item(
+    full_name: str,
+    path: str,
+    *,
+    private: bool = False,
+    html_url: str | None = None,
+    sha: str = "a" * 40,
+) -> dict[str, object]:
+    repo_name = full_name.split("/", maxsplit=1)[1]
+    item_html = html_url or f"https://github.com/{full_name}/blob/{sha}/{path}"
+    return {
+        "name": path.rsplit("/", maxsplit=1)[-1],
+        "path": path,
+        "sha": sha,
+        "url": f"https://api.github.com/repositories/1/contents/{path}",
+        "git_url": f"https://api.github.com/repositories/1/git/blobs/{sha}",
+        "html_url": item_html,
+        "repository": {
+            "id": 1,
+            "name": repo_name,
+            "full_name": full_name,
+            "private": private,
+            "html_url": f"https://github.com/{full_name}",
+        },
+    }

--- a/tests/unit/provider_onboarding/test_provider_registry.py
+++ b/tests/unit/provider_onboarding/test_provider_registry.py
@@ -13,7 +13,7 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     profiles = load_provider_profiles(Path("policies/provider_onboarding.yml"))
     by_source = {profile.source_id: profile for profile in profiles}
 
-    assert len(profiles) == 23
+    assert len(profiles) == 24
     assert by_source["cisa-kev"].initial_state is OnboardingState.CONNECTED
     assert by_source["ashby-job-board"].auth_mode is AuthMode.NONE
     assert by_source["ashby-job-board"].initial_state is OnboardingState.CONNECTED
@@ -27,6 +27,14 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     assert by_source["brave-search-api"].auth_mode is AuthMode.API_KEY
     assert by_source["brave-search-api"].required_secret_names == ("api_token",)
     assert by_source["brave-search-api"].initial_state is OnboardingState.NOT_CONFIGURED
+    assert by_source["github-code-search-metadata"].auth_mode is AuthMode.API_KEY
+    assert by_source["github-code-search-metadata"].required_secret_names == (
+        "api_token",
+    )
+    assert (
+        by_source["github-code-search-metadata"].initial_state
+        is OnboardingState.NOT_CONFIGURED
+    )
     assert by_source["internet-archive-cdx"].initial_state is OnboardingState.CONNECTED
     assert by_source["cloudflare-doh"].auth_mode is AuthMode.NONE
     assert by_source["cloudflare-doh"].initial_state is OnboardingState.CONNECTED


### PR DESCRIPTION
Second implementation tranche for issue #108.

Final scope implemented:
- dedicated `github-code-search-metadata` source and `github-rest-code-search` adapter, separate from Priority B-2 GitHub organization/repository metadata;
- authenticated bounded `GET /search/code` client using GitHub API version `2026-03-10`, `per_page=20`, 2 MiB response cap, redirects disabled, typed HTTP/schema/transport failures and rejection of incomplete provider result sets;
- organization-bound execution using the existing `DeveloperEcosystemTarget` registry; checked-in targets remain empty by default;
- dedicated versioned query-template registry requiring exact `org:{organization}` scope and rejecting secret-hunting terms such as `password`, `secret`, `token`, `credential`, and `private_key`; checked-in templates remain disabled by default;
- runtime secret injection through existing Provider Onboarding / `connected_secret_supplier` as `github-code-search-metadata/api_token`;
- Source Governance, Provider Onboarding, source portfolio and disabled-by-default schedule wired into the shared runtime;
- metadata-only mapping through existing Lot 12 `SearchResultLead`: repository/path/SHA/GitHub HTML URL plus an explicit `file content not retrieved` summary;
- no blob/content endpoint fetch, repository archive fetch, users/contributors, private repositories, file contents, automatic claims/signals/needs/opportunities/outreach;
- results outside the exact configured organization, private repositories and non-`github.com` HTML URLs are discarded;
- deterministic tests cover query safety/scope, missing token, no-target/no-network behavior, exact-org filtering, private/non-GitHub rejection, checkpoint validation, schema drift, rate limits and incomplete provider results;
- dedicated SA-14 live workflow uses a GitHub Actions ephemeral `GITHUB_TOKEN` and public `github` organization as a controlled non-prospect target.

Controlled provider proof: `20 observations -> 20 quarantined projections -> 0 claims -> 0 file-content fetches` using the real production adapter and GitHub REST provider. Source Activation records `live_tested` but intentionally not `scheduled`; the checked-in production schedule remains disabled until deployment explicitly provisions a governed target, approved template, provider token and execution.

Final exact merge candidate: `2e50593607048551d8f3259ff6962fe771358442`.

On this exact SHA:
- SA-14 live GitHub Code Search validation: PASS;
- dependency consistency / pip-audit: PASS;
- Ruff: PASS;
- strict Mypy: PASS on 652 source files;
- architecture/release contracts: 36 PASS;
- Alembic upgrade -> downgrade base -> upgrade: PASS;
- pytest: 1362 PASS;
- branch-aware repository coverage: 90.06% (required >=90%);
- frontend audit/typecheck/build: PASS;
- reviews: none; review threads: none.

Issue #108 intentionally remains open after this tranche for remaining SA-14 search/archive candidates, including a second approved web-search provider, publication/patent/standards search, and GDELT when the GDELT 5 execution contract is stable enough for a provider-specific implementation.

Ready to squash-merge only at exact head `2e50593607048551d8f3259ff6962fe771358442`.