### PR TITLE
SA-14: add governed Crossref publication discovery

### DIFF
--- a/.github/workflows/sa14-live-validation.yml
+++ b/.github/workflows/sa14-live-validation.yml
@@ -53,3 +53,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/live_validate_sa14_github_code_search.py
+
+  live-crossref-publications:
+    if: github.event.pull_request.head.ref == 'agent/sa14-crossref-publication-discovery'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled Crossref publication live validation
+        run: python scripts/live_validate_sa14_crossref.py

--- a/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
+++ b/docs/source_activation/SA_14_SEARCH_ARCHIVES.md
@@ -169,21 +169,91 @@ The same live proof passed again after the Ruff-only formatting correction on he
 
 This proves the authenticated provider path, organization filtering, metadata mapping and quarantine boundary. It does not turn the returned search hits into factual claims about the target organization.
 
-Because adding this documentation and the `live_tested` Source Activation stage changes the branch head, both the complete repository CI and the dedicated GitHub code-search live workflow must pass again on the exact final merge candidate before the PR may leave draft.
+The GitHub Code Search tranche was later exact-SHA validated and squash-merged on `main` at `2050cb19b4edf7ae7b9aaeaf8e58753d1cd7e5cf`.
+
+## Crossref publication metadata
+
+Source id: `crossref-publication-metadata`.
+
+The third SA-14 tranche adds public scholarly-publication discovery through Crossref REST `/works`. It is target-bound by a canonical CIP organization UUID plus an explicit ROR identifier from `policies/crossref_publication_targets.yml`.
+
+The checked-in target registry is empty and the checked-in schedule is `enabled: false`; merely registering the adapter cannot start organization-wide publication collection.
+
+### ROR targeting semantics
+
+The adapter calls Crossref with `filter=ror-id:<configured-ror>` rather than performing a fuzzy organization-name search. This gives a stable external identifier boundary, but the provider's ROR filter may represent contributor affiliation or funding metadata. Consequently, a returned work is only **ROR-associated publication metadata**. It is not automatically asserted to be authored, owned, endorsed or operationally used by the target organization.
+
+The controlled live target uses Goethe University Frankfurt ROR `04cvxnb49` only to exercise the provider path. It is a research-organization validation target, not a prospect or commercial conclusion.
+
+### Provider and response bounds
+
+The production client uses:
+
+- `GET https://api.crossref.org/works`;
+- `filter=ror-id:<configured-ror>`;
+- `rows=20`;
+- `select=DOI,title,type,URL`;
+- `Accept: application/json`;
+- an identifiable CIP User-Agent;
+- a maximum response body of 2 MiB;
+- redirects disabled.
+
+Crossref public REST access requires no provider credential in this capability. HTTP 429 and server failures are typed for retry; transport failures are retryable, while content-type, response-size and schema violations fail closed.
+
+### Data-minimization boundary
+
+The provider response may contain authors, ORCID identifiers, abstracts, references, funding structures or full-text links. Those structures are not part of the Pydantic materialized schema and therefore do not enter the normalized observation material.
+
+CIP persists only:
+
+- configured ROR identifier;
+- DOI;
+- first non-empty title;
+- Crossref work type;
+- canonical HTTPS `doi.org` URL.
+
+A result with an empty first title, whitespace in the DOI or a result URL outside HTTPS `doi.org` is discarded.
+
+Each retained item creates one immutable `RawObservation` and one quarantined Lot 12 `SEARCH_RESULT` projection. The excerpt states `Authors, abstract and full text not retrieved.` No candidate `PublicClaim`, commercial signal, need hypothesis, opportunity or outreach action is created.
+
+### Controlled live validation
+
+The dedicated SA-14 workflow runs `scripts/live_validate_sa14_crossref.py` against the production adapter itself. On source head `f0c4158ad033aae3aa8d25ab56b86fd91f7b4265`, the real Crossref API accepted the bounded ROR query and returned the configured full page:
+
+- observations: `20`;
+- quarantined projections: `20`;
+- claims: `0`;
+- full-text fetches: `0`.
+
+The one-for-one observation/projection result proves that the current provider contract, ROR filter and minimal selected schema work through the production adapter. It does not establish authorship, ownership, endorsement, technology deployment or commercial need for the target organization.
+
+That real provider proof justified adding `live_tested` to Crossref Source Activation. Because the documentation and activation promotion change the branch head, the complete normal repository CI and Crossref live workflow must pass again on the exact final candidate before merge.
 
 ## GDELT migration boundary
 
 GDELT remains a high-value SA-14 event/news-discovery candidate. In 2026 the provider announced migration of the API ecosystem toward GDELT 5 / Spanner. SA-14 will not create a new production adapter against a legacy contract merely to mark the candidate complete. GDELT will be revisited against the current documented public interface once the migration provides a stable provider-specific execution contract.
 
-## Completion gate for the GitHub code-search tranche
+## Remaining SA-14 work after Crossref
 
-GitHub Code Search may be squash-merged only when:
+Crossref completes the first publication-metadata provider, but issue #108 remains open. Remaining work includes:
 
-1. Source Governance, Provider Onboarding, portfolio, runtime registration and the disabled-by-default schedule agree on `github-code-search-metadata` / `github-rest-code-search`;
-2. target and template registries remain fail-closed by default;
-3. deterministic tests cover query scope, secret-hunting rejection, token absence, no-target/no-network behavior, exact-organization filtering, private/non-GitHub rejection, checkpoint validation, provider schema drift, incomplete results and rate-limit classification;
-4. the production adapter obtains non-empty metadata through the real GitHub Code Search endpoint using a controlled non-prospect organization;
-5. every retained live hit maps one-for-one to a raw observation and quarantined projection with zero claims and zero source-code retrieval;
-6. `live_tested` is recorded only after the controlled provider proof;
-7. complete backend/frontend CI and the dedicated live workflow pass on the exact final PR head;
-8. reviews and review threads are clear before squash merge.
+- a patent-discovery provider with a current provider-specific contract and real live proof;
+- a standards/public-specification discovery provider with bounded metadata semantics;
+- a second general web-search provider. Mojeek is the current candidate, but it requires a real API entitlement/key before CIP can legitimately mark it `live_tested`;
+- GDELT once its current GDELT 5 execution contract is stable enough for a new production adapter.
+
+No provider is considered complete merely because it is catalogued or because a synthetic test passes.
+
+## Completion gate for the Crossref tranche
+
+Crossref may be squash-merged only when:
+
+1. Source Governance, portfolio, runtime registration, target registry and disabled-by-default schedule agree on `crossref-publication-metadata` / `crossref-ror-works`;
+2. the checked-in ROR target registry remains empty by default;
+3. provider selection is limited to `DOI,title,type,URL`, and authors/abstracts/references/full-text links cannot enter normalized observation material;
+4. deterministic tests cover ROR normalization, no-target/no-network behavior, safe DOI mapping, invalid checkpoint, schema drift and rate limiting;
+5. the production adapter obtains non-empty metadata from the real Crossref endpoint using a controlled ROR target;
+6. every retained live result maps one-for-one to an observation and quarantined projection with zero claims and zero full-text retrieval;
+7. `live_tested` is recorded only after the controlled provider proof;
+8. complete backend/frontend CI and the dedicated live workflow pass on the exact final PR head;
+9. reviews and review threads are clear before squash merge.

--- a/policies/collection_schedules.search_archives.yml
+++ b/policies/collection_schedules.search_archives.yml
@@ -48,3 +48,15 @@ schedules:
       max_delay_seconds: 7200
       circuit_failure_threshold: 2
       circuit_reset_seconds: 7200
+
+  - source_id: crossref-publication-metadata
+    adapter_id: crossref-ror-works
+    enabled: false
+    interval_seconds: 604800
+    lease_seconds: 180
+    retry:
+      max_attempts: 3
+      base_delay_seconds: 600
+      max_delay_seconds: 7200
+      circuit_failure_threshold: 3
+      circuit_reset_seconds: 7200

--- a/policies/crossref_publication_targets.yml
+++ b/policies/crossref_publication_targets.yml
@@ -1,0 +1,2 @@
+version: 1
+targets: []

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -30,3 +30,17 @@ sources:
       - authorized
       - executable
       - live_tested
+
+  - source_id: crossref-publication-metadata
+    display_name: Crossref ROR-associated publication metadata
+    category: corporate_public_footprint
+    disposition: active
+    activation_wave: SA-14
+    requires_schedule: false
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -44,3 +44,4 @@ sources:
       - adapter_present
       - authorized
       - executable
+      - live_tested

--- a/policies/source_portfolio.search_archives.yml
+++ b/policies/source_portfolio.search_archives.yml
@@ -136,3 +136,39 @@ sources:
       supports_retractions: false
       max_page_size: 20
       cost_per_request: 0
+
+  - source_id: crossref-publication-metadata
+    display_name: Crossref ROR-associated publication metadata
+    canonical_url: https://api.crossref.org/works
+    category: corporate_public_footprint
+    status: executable
+    freshness_max_age_seconds: 604800
+    commercial_use_cases:
+      - organization_research
+      - publication_discovery
+      - public_evidence_map
+    candidate_origin: SA-14
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      target_registry_required: true
+      raw_abstract_storage: false
+      raw_full_text_storage: false
+      author_metadata_materialization: false
+      search_result_is_evidence: false
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: crossref-ror-works
+      adapter_version: "1"
+      provider_schema_version: crossref-ror-works-v1
+      modes: [conditional_refresh, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - public_resource
+        - public_resource_version
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 20
+      cost_per_request: 0

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -152,3 +152,41 @@ sources:
       users, contributors, credentials and private repositories are not retrieved or persisted.
       Search hits are quarantined discovery leads and never directly prove deployment, exposure,
       vulnerability applicability, compromise, commercial need, opportunity or outreach authority.
+
+  - id: crossref-publication-metadata
+    name: Crossref ROR-associated publication metadata
+    base_url: https://api.crossref.org/works
+    status: enabled
+    source_type: search_provider
+    owner: Crossref
+    terms_url: https://www.crossref.org/documentation/retrieve-metadata/rest-api/
+    licence: Open Crossref scholarly metadata; abstracts excluded from CIP materialization
+    allowed_data_categories: [public_result_metadata]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 5
+    retention_days: 180
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_14_SEARCH_ARCHIVES.md#crossref-publication-metadata
+      reviewed_at: "2026-08-11T12:55:00+00:00"
+      expires_at: null
+      approved_hosts: [api.crossref.org]
+      approved_path_prefixes: [/works]
+      approved_purposes: [publication-discovery]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: low
+      maintenance_cost: low
+      expected_stability: high
+    notes: >-
+      Public Crossref metadata queried only by explicitly configured ROR identifiers. CIP selects
+      DOI/title/type/URL and discards authors, abstracts, references and full-text links before
+      observation hashing. A ROR match may represent contributor affiliation or funding metadata;
+      it is therefore quarantined discovery metadata and not proof that the organization authored,
+      owns, deploys, endorses, or commercially needs anything described by the work.

--- a/scripts/live_validate_sa14_crossref.py
+++ b/scripts/live_validate_sa14_crossref.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
+from cip.modules.collection_orchestration.application.crossref_publication_adapter import (
+    CrossrefPublicationAdapter,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+ORG_ID = UUID("74b2a087-10ce-5d99-a90c-5aa1c0fabf6f")
+
+
+def main() -> None:
+    entry = next(
+        item
+        for item in load_source_registry(POLICY_PATH)
+        if item.policy.id == "crossref-publication-metadata"
+    )
+    now = datetime.now(UTC)
+    target = CrossrefPublicationTarget(
+        target_id="goethe-university-live",
+        organization_id=ORG_ID,
+        canonical_name="Goethe University Frankfurt",
+        ror_id="04cvxnb49",
+        enabled=True,
+    )
+    batch = CrossrefPublicationAdapter(
+        entry,
+        (target,),
+        timeout_seconds=30,
+    ).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=180),
+    )
+    observations = len(batch.observations)
+    projections = len(batch.public_footprint_projections)
+    if observations < 1 or projections != observations:
+        raise RuntimeError("Crossref live proof did not preserve ROR-associated metadata")
+    if observations > 20:
+        raise RuntimeError("Crossref live proof exceeded bounded page size")
+    if any(projection.claims for projection in batch.public_footprint_projections):
+        raise RuntimeError("Crossref publication discovery unexpectedly produced claims")
+    if any(
+        projection.resource.retrieval_state.value != "quarantined"
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Crossref results escaped quarantine")
+    if any(
+        not projection.resource.canonical_url.startswith("https://doi.org/")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Crossref live result escaped DOI metadata boundary")
+    if any(
+        "Authors, abstract and full text not retrieved" not in (projection.version.excerpt or "")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Crossref live result lost metadata-only boundary")
+    print(
+        "SA-14 Crossref live validation passed: "
+        f"observations={observations} projections={projections} claims=0 full_text_fetches=0"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/crossref_publications/__init__.py
+++ b/src/cip/adapters/sources/crossref_publications/__init__.py
@@ -1,0 +1,1 @@
+"""Bounded Crossref publication-metadata discovery."""

--- a/src/cip/adapters/sources/crossref_publications/client.py
+++ b/src/cip/adapters/sources/crossref_publications/client.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.crossref_publications.schemas import CrossrefWorksResponse
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_RESULTS = 20
+_USER_AGENT = (
+    "cyber-intelligence-platform/0.24 "
+    "(https://github.com/tobianahillel-afk/cyber-intelligence-platform)"
+)
+
+
+class CrossrefClientError(RuntimeError):
+    def __init__(self, message: str, *, code: str, retryable: bool) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class CrossrefQueryResult:
+    response: CrossrefWorksResponse
+    request_url: str
+
+
+class CrossrefClient:
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def works_for_ror(self, url: str, *, ror_id: str) -> CrossrefQueryResult:
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+                transport=self._transport,
+            ) as client:
+                response = client.get(
+                    url,
+                    headers={
+                        "Accept": "application/json",
+                        "User-Agent": _USER_AGENT,
+                    },
+                    params={
+                        "filter": f"ror-id:{ror_id}",
+                        "rows": str(_MAX_RESULTS),
+                        "select": "DOI,title,type,URL",
+                    },
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise CrossrefClientError(
+                f"Crossref returned HTTP {status}",
+                code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise CrossrefClientError(
+                str(exc) or type(exc).__name__,
+                code="source_transport_error",
+                retryable=True,
+            ) from exc
+
+        content_type = response.headers.get("content-type", "").casefold()
+        if "json" not in content_type:
+            raise CrossrefClientError(
+                "Crossref response is not JSON",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        if len(response.content) > _MAX_RESPONSE_BYTES:
+            raise CrossrefClientError(
+                "Crossref response exceeds size limit",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        try:
+            parsed = CrossrefWorksResponse.model_validate_json(response.content)
+        except ValidationError as exc:
+            raise CrossrefClientError(
+                "Crossref response schema changed",
+                code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        if parsed.status.casefold() != "ok" or parsed.message_type.casefold() != "work-list":
+            raise CrossrefClientError(
+                "Crossref returned an unexpected response envelope",
+                code="source_schema_drift",
+                retryable=False,
+            )
+        return CrossrefQueryResult(response=parsed, request_url=str(response.request.url))

--- a/src/cip/adapters/sources/crossref_publications/registry.py
+++ b/src/cip/adapters/sources/crossref_publications/registry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from uuid import UUID
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+_ROR_PATTERN = re.compile(r"^[0-9a-z]{9}$")
+_ROR_PREFIX = "https://ror.org/"
+
+
+class CrossrefPublicationTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    target_id: str = Field(min_length=1, max_length=200)
+    organization_id: UUID
+    canonical_name: str = Field(min_length=1, max_length=300)
+    ror_id: str = Field(min_length=9, max_length=30)
+    enabled: bool = False
+
+    @field_validator("ror_id")
+    @classmethod
+    def normalize_ror_id(cls, value: str) -> str:
+        normalized = value.strip().casefold()
+        if normalized.startswith(_ROR_PREFIX):
+            normalized = normalized.removeprefix(_ROR_PREFIX)
+        if not _ROR_PATTERN.fullmatch(normalized):
+            raise ValueError("ror_id must be a nine-character ROR identifier")
+        return normalized
+
+
+class CrossrefPublicationTargetFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    targets: list[CrossrefPublicationTarget] = Field(default_factory=list, max_length=500)
+
+
+def load_crossref_publication_targets(
+    path: Path,
+) -> tuple[CrossrefPublicationTarget, ...]:
+    parsed = CrossrefPublicationTargetFile.model_validate(
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+    )
+    targets = tuple(parsed.targets)
+    ids = [target.target_id for target in targets]
+    ror_ids = [target.ror_id for target in targets]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate Crossref publication target_id")
+    if len(ror_ids) != len(set(ror_ids)):
+        raise ValueError("duplicate Crossref publication ROR target")
+    return targets

--- a/src/cip/adapters/sources/crossref_publications/schemas.py
+++ b/src/cip/adapters/sources/crossref_publications/schemas.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CrossrefWork(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, str_strip_whitespace=True)
+
+    doi: str = Field(alias="DOI", min_length=1, max_length=300)
+    title: tuple[str, ...] = Field(default_factory=tuple, max_length=8)
+    type: str = Field(min_length=1, max_length=100)
+    url: str = Field(alias="URL", min_length=1, max_length=2_000)
+
+
+class CrossrefWorksMessage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    items: tuple[CrossrefWork, ...] = Field(default_factory=tuple, max_length=20)
+
+
+class CrossrefWorksResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    status: str = Field(min_length=1, max_length=50)
+    message_type: str = Field(alias="message-type", min_length=1, max_length=100)
+    message: CrossrefWorksMessage

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from cip.adapters.sources.ashby.registry import AshbyBoard
+from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
 from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
 from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
 from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
@@ -72,6 +73,7 @@ class AdapterCompositionInputs:
     developer_ecosystem_targets: tuple[DeveloperEcosystemTarget, ...]
     search_templates: tuple[SearchQueryTemplate, ...]
     github_code_search_templates: tuple[SearchQueryTemplate, ...]
+    crossref_publication_targets: tuple[CrossrefPublicationTarget, ...]
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
     rdap_targets: tuple[RdapTarget, ...]
@@ -133,6 +135,7 @@ def build_runtime_adapters(
         inputs.search_templates,
         inputs.developer_ecosystem_targets,
         inputs.github_code_search_templates,
+        inputs.crossref_publication_targets,
         brave_token_provider=brave_token_provider,
         github_code_search_token_provider=github_code_search_token_provider,
         timeout_seconds=timeout_seconds,

--- a/src/cip/modules/collection_orchestration/application/crossref_publication_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/crossref_publication_adapter.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from hashlib import sha256
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.crossref_publications.client import (
+    CrossrefClient,
+    CrossrefClientError,
+)
+from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
+from cip.adapters.sources.crossref_publications.schemas import CrossrefWork
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.public_footprint.domain.search import SearchResultLead, map_search_result_lead
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_QUERY_TEMPLATE_ID = "crossref-ror-associated-works"
+_QUERY_TEMPLATE_VERSION = 1
+
+
+class CrossrefPublicationAdapter:
+    source_id = "crossref-publication-metadata"
+    adapter_id = "crossref-ror-works"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[CrossrefPublicationTarget, ...],
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Crossref publication adapter requires its source policy")
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled)
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None:
+            return _empty_batch()
+        _authorize(self._entry, collected_at)
+        try:
+            result = CrossrefClient(
+                timeout_seconds=self._timeout_seconds,
+                transport=self._transport,
+            ).works_for_ror(self._entry.policy.base_url, ror_id=target.ror_id)
+        except CrossrefClientError as exc:
+            raise AdapterExecutionError(
+                str(exc), error_code=exc.code, retryable=exc.retryable
+            ) from exc
+        items = tuple(item for item in result.response.message.items if _safe_work(item))
+        observations = tuple(
+            _observation(
+                item,
+                target=target,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+                source_url=result.request_url,
+            )
+            for item in items
+        )
+        projections = tuple(
+            map_search_result_lead(
+                _lead(item, target=target, rank=rank, observed_at=collected_at)
+            )
+            for rank, item in enumerate(items, start=1)
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            public_footprint_projections=projections,
+            checkpoint_payload={"target_index": next_index},
+            not_modified=not items,
+        )
+
+
+def _authorize(entry: SourceRegistryEntry, now: datetime) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=entry.policy.base_url,
+            purpose="publication-discovery",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def _next_target(
+    targets: tuple[CrossrefPublicationTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[CrossrefPublicationTarget | None, int]:
+    if not targets:
+        return None, 0
+    value = 0 if payload is None else payload.get("target_index", 0)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise AdapterExecutionError(
+            "invalid Crossref publication checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(targets)
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _safe_work(item: CrossrefWork) -> bool:
+    if not item.title or not item.title[0].strip():
+        return False
+    if any(character.isspace() for character in item.doi):
+        return False
+    parsed = urlsplit(item.url)
+    return parsed.scheme == "https" and parsed.hostname == "doi.org"
+
+
+def _lead(
+    item: CrossrefWork,
+    *,
+    target: CrossrefPublicationTarget,
+    rank: int,
+    observed_at: datetime,
+) -> SearchResultLead:
+    title = item.title[0].strip()[:1_000]
+    snippet = (
+        f"Crossref metadata for DOI {item.doi}, type {item.type}; matched by ROR "
+        f"{target.ror_id}. Authors, abstract and full text not retrieved."
+    )
+    return SearchResultLead(
+        organization_id=target.organization_id,
+        source_id=CrossrefPublicationAdapter.source_id,
+        source_record_key=_record_key(target, item),
+        target_url=item.url,
+        title=title,
+        snippet=snippet,
+        rank=rank,
+        observed_at=observed_at,
+        query_template_id=_QUERY_TEMPLATE_ID,
+        query_template_version=_QUERY_TEMPLATE_VERSION,
+        candidate_claim=None,
+    )
+
+
+def _observation(
+    item: CrossrefWork,
+    *,
+    target: CrossrefPublicationTarget,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    source_url: str,
+) -> RawObservation:
+    material = (
+        f"{target.ror_id}\n{item.doi}\n{item.title[0].strip()}\n{item.type}\n{item.url}"
+    ).encode()
+    return RawObservation(
+        source_id=CrossrefPublicationAdapter.source_id,
+        adapter_id=CrossrefPublicationAdapter.adapter_id,
+        adapter_version=CrossrefPublicationAdapter.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="crossref-ror-work-metadata",
+        source_url=source_url,
+        payload_hash_sha256=sha256(material).hexdigest(),
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        source_record_key=_record_key(target, item),
+        collected_at=collected_at,
+        retention_until=retention_until,
+        schema_fingerprint="crossref-ror-works:v1",
+    )
+
+
+def _record_key(target: CrossrefPublicationTarget, item: CrossrefWork) -> str:
+    return f"{target.ror_id}:{item.doi.casefold()}"
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"target_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -11,6 +11,9 @@ from time import sleep
 from sqlalchemy.orm import Session, sessionmaker
 
 from cip.adapters.sources.ashby.registry import load_ashby_boards
+from cip.adapters.sources.crossref_publications.registry import (
+    load_crossref_publication_targets,
+)
 from cip.adapters.sources.developer_ecosystem.registry import load_developer_ecosystem_targets
 from cip.adapters.sources.github_code_search.registry import (
     load_github_code_search_templates,
@@ -212,6 +215,9 @@ def _load_adapter_inputs(
         ),
         github_code_search_templates=load_github_code_search_templates(
             settings.github_code_search_template_registry_path
+        ),
+        crossref_publication_targets=load_crossref_publication_targets(
+            settings.crossref_publication_target_registry_path
         ),
         vulnerability_targets=load_vulnerability_query_targets(
             settings.vulnerability_query_target_registry_path

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
 from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.archive_cdx_adapter import (
@@ -12,6 +13,9 @@ from cip.modules.collection_orchestration.application.brave_search_adapter impor
 )
 from cip.modules.collection_orchestration.application.common_crawl_adapter import (
     CommonCrawlIndexAdapter,
+)
+from cip.modules.collection_orchestration.application.crossref_publication_adapter import (
+    CrossrefPublicationAdapter,
 )
 from cip.modules.collection_orchestration.application.github_code_search_adapter import (
     GitHubCodeSearchAdapter,
@@ -28,6 +32,7 @@ def register_search_archive_adapters(
     templates: tuple[SearchQueryTemplate, ...],
     developer_targets: tuple[DeveloperEcosystemTarget, ...],
     github_code_search_templates: tuple[SearchQueryTemplate, ...],
+    crossref_publication_targets: tuple[CrossrefPublicationTarget, ...],
     *,
     brave_token_provider: Callable[[], str | None],
     github_code_search_token_provider: Callable[[], str | None],
@@ -77,6 +82,17 @@ def register_search_archive_adapters(
                 developer_targets,
                 github_code_search_templates,
                 token_provider=github_code_search_token_provider,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    crossref_entry = entries_by_id.get(CrossrefPublicationAdapter.source_id)
+    if crossref_entry is not None:
+        _register(
+            adapters,
+            CrossrefPublicationAdapter(
+                crossref_entry,
+                crossref_publication_targets,
                 timeout_seconds=timeout_seconds,
             ),
         )

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -120,6 +120,9 @@ class Settings(BaseSettings):
     github_code_search_template_registry_path: Path = Path(
         "policies/github_code_search_templates.yml"
     )
+    crossref_publication_target_registry_path: Path = Path(
+        "policies/crossref_publication_targets.yml"
+    )
     vulnerability_query_target_registry_path: Path = Path(
         "policies/vulnerability_query_targets.yml"
     )

--- a/tests/unit/collection_orchestration/test_crossref_publication_adapter.py
+++ b/tests/unit/collection_orchestration/test_crossref_publication_adapter.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.crossref_publications.registry import (
+    CrossrefPublicationTarget,
+    load_crossref_publication_targets,
+)
+from cip.modules.collection_orchestration.application.crossref_publication_adapter import (
+    CrossrefPublicationAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 13, 0, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=180)
+ORG_ID = UUID("74b2a087-10ce-5d99-a90c-5aa1c0fabf6f")
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+TARGET_PATH = Path("policies/crossref_publication_targets.yml")
+
+
+def test_checked_in_crossref_registry_is_empty() -> None:
+    assert load_crossref_publication_targets(TARGET_PATH) == ()
+
+
+def test_crossref_target_normalizes_ror_url() -> None:
+    target = CrossrefPublicationTarget(
+        target_id="goethe",
+        organization_id=ORG_ID,
+        canonical_name="Goethe University Frankfurt",
+        ror_id="https://ror.org/04cvxnb49",
+        enabled=True,
+    )
+    assert target.ror_id == "04cvxnb49"
+
+
+def test_crossref_without_enabled_target_performs_no_network() -> None:
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without enabled target")
+
+    adapter = CrossrefPublicationAdapter(
+        _entry(),
+        (_target(enabled=False),),
+        transport=httpx.MockTransport(fail_network),
+    )
+    batch = _collect(adapter)
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert batch.checkpoint_payload == {"target_index": 0}
+
+
+def test_crossref_maps_only_minimal_safe_doi_metadata() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "status": "ok",
+                "message-type": "work-list",
+                "message": {
+                    "items": [
+                        _work("10.1000/safe", "Useful Research"),
+                        _work("10.1000/offhost", "Off host", url="https://example.com/x"),
+                        _work("10.1000/untitled", ""),
+                    ]
+                },
+            },
+            request=request,
+        )
+
+    adapter = CrossrefPublicationAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.path == "/works"
+    assert request.url.params["filter"] == "ror-id:04cvxnb49"
+    assert request.url.params["rows"] == "20"
+    assert request.url.params["select"] == "DOI,title,type,URL"
+    assert "cyber-intelligence-platform" in request.headers["User-Agent"]
+
+    assert len(batch.observations) == 1
+    assert len(batch.public_footprint_projections) == 1
+    projection = batch.public_footprint_projections[0]
+    assert projection.claims == ()
+    assert projection.resource.canonical_url == "https://doi.org/10.1000/safe"
+    assert projection.resource.retrieval_state.value == "quarantined"
+    excerpt = projection.version.excerpt or ""
+    assert "04cvxnb49" in excerpt
+    assert "Authors, abstract and full text not retrieved" in excerpt
+    assert batch.checkpoint_payload == {"target_index": 0}
+
+
+def test_crossref_rejects_invalid_checkpoint() -> None:
+    adapter = CrossrefPublicationAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter, checkpoint_payload={"target_index": True})
+    assert exc_info.value.error_code == "invalid_checkpoint"
+
+
+def test_crossref_classifies_schema_and_rate_limit_failures() -> None:
+    def malformed(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b"not-json",
+            request=request,
+        )
+
+    malformed_adapter = CrossrefPublicationAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(malformed),
+    )
+    with pytest.raises(AdapterExecutionError) as schema_info:
+        _collect(malformed_adapter)
+    assert schema_info.value.error_code == "source_schema_drift"
+    assert schema_info.value.retryable is False
+
+    def rate_limited(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            headers={"content-type": "application/json"},
+            request=request,
+        )
+
+    rate_adapter = CrossrefPublicationAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(rate_limited),
+    )
+    with pytest.raises(AdapterExecutionError) as rate_info:
+        _collect(rate_adapter)
+    assert rate_info.value.error_code == "http_429"
+    assert rate_info.value.retryable is True
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == "crossref-publication-metadata"
+    )
+
+
+def _target(*, enabled: bool = True) -> CrossrefPublicationTarget:
+    return CrossrefPublicationTarget(
+        target_id="goethe-live",
+        organization_id=ORG_ID,
+        canonical_name="Goethe University Frankfurt",
+        ror_id="04cvxnb49",
+        enabled=enabled,
+    )
+
+
+def _collect(
+    adapter: CrossrefPublicationAdapter,
+    *,
+    checkpoint_payload: dict[str, object] | None = None,
+):
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint_payload,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _work(
+    doi: str,
+    title: str,
+    *,
+    url: str | None = None,
+) -> dict[str, object]:
+    return {
+        "DOI": doi,
+        "title": [title],
+        "type": "journal-article",
+        "URL": url or f"https://doi.org/{doi}",
+        "author": [{"given": "ignored", "family": "ignored"}],
+        "abstract": "ignored and never materialized",
+        "link": [{"URL": "https://publisher.example/fulltext.pdf"}],
+    }


### PR DESCRIPTION
Third implementation tranche for issue #108.

Final Crossref scope:
- real public Crossref `/works` adapter scoped to explicit canonical-organization-bound ROR targets;
- checked-in Crossref target registry remains empty by default;
- bounded `rows=20`, 2 MiB JSON client with identifiable User-Agent, no redirects and typed HTTP/transport/schema failures;
- provider request uses `filter=ror-id:<configured-ror>` and `select=DOI,title,type,URL` only;
- authors, ORCID, abstracts, references, funding structures and full-text links are excluded from the materialized provider schema and observation hashing;
- only non-empty-title HTTPS `doi.org` results are retained;
- ROR association is explicitly treated as ambiguous discovery metadata because Crossref's ROR filter may reflect contributor affiliation or funding metadata; it is not asserted as organizational authorship/ownership/endorsement;
- immutable RawObservation plus existing Lot 12 quarantined SearchResultLead projection, with zero claims/signals/needs/opportunities/outreach;
- Source Governance, portfolio, settings/runtime composition, empty target registry and disabled-by-default weekly schedule are integrated into the shared SA-14 runtime;
- deterministic tests cover target normalization, empty-registry/no-network behavior, bounded request shape, data minimization, safe DOI filtering, invalid checkpoint, schema drift and rate limiting;
- dedicated real-provider live validation uses Goethe University Frankfurt ROR `04cvxnb49` as a controlled research-organization target, not a prospect.

Controlled real-provider proof: `20 observations -> 20 quarantined projections -> 0 claims -> 0 full-text fetches`. `live_tested` was added only after this provider proof; the checked-in schedule intentionally remains disabled and is therefore not claimed as `scheduled`.

Final exact merge candidate: `fbf9a30cc8fe641249136c78af2d756418f4f5b4`.

On this exact SHA:
- SA-14 Crossref live validation: PASS;
- dependency consistency / pip-audit: PASS;
- Ruff: PASS;
- strict Mypy: PASS on 657 source files;
- architecture/release contracts: 36 PASS;
- Alembic upgrade -> downgrade base -> upgrade: PASS;
- pytest: 1368 PASS;
- branch-aware repository coverage: 90.05% (required >=90%);
- frontend audit/typecheck/build: PASS;
- reviews: none; review threads: none.

Issue #108 intentionally remains open after this tranche for patent discovery, standards/public-specification discovery, Mojeek as the current second web-search candidate once a real API entitlement is available, and GDELT once the GDELT 5 execution contract is stable enough for a provider-specific implementation.

Ready to squash-merge only at exact head `fbf9a30cc8fe641249136c78af2d756418f4f5b4`.