### PR TITLE
SA-14: add governed PatentsView patent discovery

### DIFF
--- a/docs/source_activation/SA_14_PATENTSVIEW_PATENTS.md
+++ b/docs/source_activation/SA_14_PATENTSVIEW_PATENTS.md
@@ -1,0 +1,107 @@
+# SA-14 — PatentsView patent discovery
+
+## Objective
+
+This tranche adds a real PatentsView PatentSearch adapter for bounded organization-targeted patent metadata. It extends the existing SA-14 search/archive runtime and does not create a patent-specific persistence subsystem.
+
+Source id: `patentsview-patent-metadata`.
+
+Adapter id: `patentsview-assignee-patents`.
+
+## Targeting
+
+`policies/patentsview_patent_targets.yml` is checked in empty. A target contains:
+
+- a canonical CIP organization UUID;
+- a stable internal target id;
+- a canonical organization name for analyst context;
+- one exact PatentsView `assignee_organization` label;
+- an explicit enabled flag.
+
+The adapter never performs global organization discovery. No enabled target means no provider secret read and no network request.
+
+## Current provider contract
+
+The adapter targets the current PatentsView PatentSearch endpoint:
+
+`GET https://search.patentsview.org/api/v1/patent/`
+
+Provider access requires `X-Api-Key`. Production runtime obtains that key through Provider Onboarding and the existing secret-supplier boundary:
+
+`patentsview-patent-metadata / api_key -> connected_secret_supplier -> PatentsViewPatentAdapter`.
+
+The organization query uses the PatentsView Query Language explicit equality operator:
+
+`{"_eq":{"assignees.assignee_organization":"<configured assignee>"}}`
+
+CIP additionally bounds the request to 20 results and asks only for:
+
+- `patent_id`;
+- `patent_title`;
+- `patent_date`;
+- `patent_type`;
+- `assignees.assignee_organization`.
+
+The client disables redirects and rejects non-JSON, responses larger than 2 MiB, schema drift and inconsistent provider envelopes. HTTP 429 and server failures are classified as retryable; malformed or unsafe responses fail closed.
+
+## Data-minimization and evidence boundary
+
+PatentsView can expose substantially richer patent data. This capability deliberately does not materialize:
+
+- abstracts;
+- patent claims;
+- inventors or other person records;
+- classifications;
+- full text;
+- patent documents or binary files.
+
+A provider response is retained only if:
+
+- the patent id contains no whitespace;
+- the patent date is a valid ISO date;
+- at least one returned assignee organization exactly matches the configured target, case-insensitively.
+
+Each retained item emits one immutable `RawObservation` and one existing Lot 12 quarantined `SEARCH_RESULT` projection. The projection contains no candidate claim. Patent metadata therefore does not automatically prove current technology deployment, security exposure, vulnerability applicability, compromise, cyber need, commercial opportunity or outreach authority.
+
+## Runtime and scheduling
+
+The adapter is registered in the shared collection runtime through `search_archive_registration`. The SA-14 registration surface now uses immutable `SearchArchiveRegistrationInputs` so adding provider-specific registries does not grow the registration function beyond project architecture limits.
+
+The checked-in PatentsView schedule is present but `enabled: false`. Source Activation therefore records the source through `executable`, but intentionally does not record `scheduled` or `live_tested`.
+
+## Live-validation status
+
+No live-provider proof is claimed in this tranche.
+
+The current PatentsView service requires an API key, while provider documentation currently states that new API-key grants are temporarily suspended. CIP does not have a legitimate deployment key available in the checked-in repository or CI. Synthetic tests, mocks and successful normal CI are not substitutes for provider validation.
+
+The terminal state for this PR is therefore:
+
+- real provider-specific adapter: yes;
+- Source Governance authorization: yes;
+- Provider Onboarding path: yes;
+- runtime executable when provisioned: yes;
+- deterministic CI validated: required before merge;
+- checked-in schedule enabled: no;
+- controlled provider `live_tested`: no, outstanding until a legitimate key exists.
+
+When a legitimate PatentsView key becomes available, the source must be live-tested on the exact release-candidate SHA using a controlled non-prospect target. Only a successful production-adapter run with real returned patent metadata can add the `live_tested` stage.
+
+## Deterministic validation
+
+Tests cover:
+
+- empty checked-in target registry;
+- no target -> no secret read and no network;
+- missing API key -> `provider_not_connected` and no network;
+- exact `_eq` assignee query shape and `X-Api-Key` header;
+- 20-result bound and selected-field minimization;
+- exact returned-assignee revalidation;
+- invalid patent ids and dates;
+- invalid checkpoints;
+- schema drift;
+- provider error envelopes;
+- HTTP 429 retry classification;
+- exclusion of abstract, claim and inventor structures from normalized material.
+
+The PR may be squash-merged without a false live badge only if the complete deterministic repository CI is green on the exact final SHA and Source Activation continues to truthfully omit `live_tested`.

--- a/policies/collection_schedules.search_archives.yml
+++ b/policies/collection_schedules.search_archives.yml
@@ -60,3 +60,15 @@ schedules:
       max_delay_seconds: 7200
       circuit_failure_threshold: 3
       circuit_reset_seconds: 7200
+
+  - source_id: patentsview-patent-metadata
+    adapter_id: patentsview-assignee-patents
+    enabled: false
+    interval_seconds: 604800
+    lease_seconds: 180
+    retry:
+      max_attempts: 2
+      base_delay_seconds: 1800
+      max_delay_seconds: 14400
+      circuit_failure_threshold: 2
+      circuit_reset_seconds: 14400

--- a/policies/patentsview_patent_targets.yml
+++ b/policies/patentsview_patent_targets.yml
@@ -1,0 +1,2 @@
+version: 1
+targets: []

--- a/policies/provider_onboarding.yml
+++ b/policies/provider_onboarding.yml
@@ -208,6 +208,26 @@ providers:
     automatic_onboarding: false
     blocked_reason: null
 
+  - source_id: patentsview-patent-metadata
+    display_name: PatentsView PatentSearch API
+    auth_mode: api_key
+    documentation_url: https://search.patentsview.org/docs/docs/Search%20API/SearchAPIReference/
+    signup_url: null
+    console_url: null
+    required_secret_names:
+      - api_key
+    human_actions:
+      - open_official_signup
+      - sign_in
+      - accept_provider_terms
+      - request_provider_access
+      - wait_for_provider_approval
+      - retrieve_technical_credentials
+      - register_secret_reference
+      - enable_source_policy
+    automatic_onboarding: false
+    blocked_reason: null
+
   - source_id: internet-archive-cdx
     display_name: Internet Archive CDX
     auth_mode: none

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -45,3 +45,17 @@ sources:
       - authorized
       - executable
       - live_tested
+
+  - source_id: patentsview-patent-metadata
+    display_name: PatentsView assignee patent metadata
+    category: corporate_public_footprint
+    disposition: active
+    activation_wave: SA-14
+    requires_schedule: false
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable

--- a/policies/source_portfolio.search_archives.yml
+++ b/policies/source_portfolio.search_archives.yml
@@ -172,3 +172,41 @@ sources:
       supports_retractions: false
       max_page_size: 20
       cost_per_request: 0
+
+  - source_id: patentsview-patent-metadata
+    display_name: PatentsView assignee patent metadata
+    canonical_url: https://search.patentsview.org/api/v1/patent/
+    category: corporate_public_footprint
+    status: executable
+    freshness_max_age_seconds: 604800
+    commercial_use_cases:
+      - organization_research
+      - patent_discovery
+      - public_evidence_map
+    candidate_origin: SA-14
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      provider_onboarding_required: true
+      target_registry_required: true
+      raw_abstract_storage: false
+      raw_claim_storage: false
+      raw_full_text_storage: false
+      inventor_metadata_materialization: false
+      search_result_is_evidence: false
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: patentsview-assignee-patents
+      adapter_version: "1"
+      provider_schema_version: patentsview-assignee-patents-v1
+      modes: [conditional_refresh, priority_refresh]
+      canonical_output_types:
+        - raw_observation
+        - public_resource
+        - public_resource_version
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 20
+      cost_per_request: 0

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -208,7 +208,7 @@ sources:
     human_review_required: false
     authorization:
       status: approved
-      document_reference: docs/source_activation/SA_14_SEARCH_ARCHIVES.md#patentsview-patent-metadata
+      document_reference: docs/source_activation/SA_14_PATENTSVIEW_PATENTS.md
       reviewed_at: "2026-08-11T13:15:00+00:00"
       expires_at: null
       approved_hosts: [search.patentsview.org]

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -190,3 +190,42 @@ sources:
       observation hashing. A ROR match may represent contributor affiliation or funding metadata;
       it is therefore quarantined discovery metadata and not proof that the organization authored,
       owns, deploys, endorses, or commercially needs anything described by the work.
+
+  - id: patentsview-patent-metadata
+    name: PatentsView assignee patent metadata
+    base_url: https://search.patentsview.org/api/v1/patent/
+    status: enabled
+    source_type: search_provider
+    owner: USPTO PatentsView
+    terms_url: https://patentsview.org/policies
+    licence: PatentsView API data licensed CC BY 4.0
+    allowed_data_categories: [public_result_metadata]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 10
+    retention_days: 365
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_14_SEARCH_ARCHIVES.md#patentsview-patent-metadata
+      reviewed_at: "2026-08-11T13:15:00+00:00"
+      expires_at: null
+      approved_hosts: [search.patentsview.org]
+      approved_path_prefixes: [/api/v1/patent/]
+      approved_purposes: [patent-discovery]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: medium
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: medium
+    notes: >-
+      Real PatentsView PatentSearch adapter scoped to explicit organization-bound assignee labels.
+      Runtime execution additionally requires a connected `api_key`. CIP retains only patent id,
+      title, grant date, type and exact assignee organization; abstracts, claims, inventors,
+      classifications and full text are excluded. Returned assignee identity is revalidated before
+      persistence. Patent presence is quarantined discovery metadata and not evidence of deployment,
+      vulnerability, compromise, cyber need, opportunity or outreach authorization.

--- a/src/cip/adapters/sources/patentsview_patents/__init__.py
+++ b/src/cip/adapters/sources/patentsview_patents/__init__.py
@@ -1,0 +1,1 @@
+"""Bounded PatentsView patent-metadata discovery."""

--- a/src/cip/adapters/sources/patentsview_patents/client.py
+++ b/src/cip/adapters/sources/patentsview_patents/client.py
@@ -56,7 +56,7 @@ class PatentsViewClient:
         assignee_organization: str,
     ) -> PatentsViewQueryResult:
         query = dumps(
-            {"assignees.assignee_organization": assignee_organization},
+            {"_eq": {"assignees.assignee_organization": assignee_organization}},
             separators=(",", ":"),
         )
         fields = dumps(_FIELDS, separators=(",", ":"))

--- a/src/cip/adapters/sources/patentsview_patents/client.py
+++ b/src/cip/adapters/sources/patentsview_patents/client.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from json import dumps
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.patentsview_patents.schemas import PatentsViewPatentResponse
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_RESULTS = 20
+_FIELDS = (
+    "patent_id",
+    "patent_title",
+    "patent_date",
+    "patent_type",
+    "assignees.assignee_organization",
+)
+
+
+class PatentsViewClientError(RuntimeError):
+    def __init__(self, message: str, *, code: str, retryable: bool) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class PatentsViewQueryResult:
+    response: PatentsViewPatentResponse
+    request_url: str
+
+
+class PatentsViewClient:
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        token = api_key.strip()
+        if not token:
+            raise ValueError("PatentsView api_key is required")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._api_key = token
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def patents_for_assignee(
+        self,
+        url: str,
+        *,
+        assignee_organization: str,
+    ) -> PatentsViewQueryResult:
+        query = dumps(
+            {"assignees.assignee_organization": assignee_organization},
+            separators=(",", ":"),
+        )
+        fields = dumps(_FIELDS, separators=(",", ":"))
+        options = dumps({"size": _MAX_RESULTS}, separators=(",", ":"))
+        sort = dumps([{"patent_id": "asc"}], separators=(",", ":"))
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+                transport=self._transport,
+            ) as client:
+                response = client.get(
+                    url,
+                    headers={
+                        "Accept": "application/json",
+                        "X-Api-Key": self._api_key,
+                    },
+                    params={"q": query, "f": fields, "o": options, "s": sort},
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise PatentsViewClientError(
+                f"PatentsView returned HTTP {status}",
+                code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise PatentsViewClientError(
+                str(exc) or type(exc).__name__,
+                code="source_transport_error",
+                retryable=True,
+            ) from exc
+
+        if "json" not in response.headers.get("content-type", "").casefold():
+            raise PatentsViewClientError(
+                "PatentsView response is not JSON",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        if len(response.content) > _MAX_RESPONSE_BYTES:
+            raise PatentsViewClientError(
+                "PatentsView response exceeds size limit",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        try:
+            parsed = PatentsViewPatentResponse.model_validate_json(response.content)
+        except ValidationError as exc:
+            raise PatentsViewClientError(
+                "PatentsView response schema changed",
+                code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        if parsed.error or parsed.count != len(parsed.patents):
+            raise PatentsViewClientError(
+                "PatentsView returned an inconsistent response envelope",
+                code="source_schema_drift",
+                retryable=False,
+            )
+        return PatentsViewQueryResult(response=parsed, request_url=str(response.request.url))

--- a/src/cip/adapters/sources/patentsview_patents/registry.py
+++ b/src/cip/adapters/sources/patentsview_patents/registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PatentsViewPatentTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    target_id: str = Field(min_length=1, max_length=200)
+    organization_id: UUID
+    canonical_name: str = Field(min_length=1, max_length=300)
+    assignee_organization: str = Field(min_length=2, max_length=500)
+    enabled: bool = False
+
+
+class PatentsViewPatentTargetFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1, le=1)
+    targets: list[PatentsViewPatentTarget] = Field(default_factory=list, max_length=500)
+
+
+def load_patentsview_patent_targets(path: Path) -> tuple[PatentsViewPatentTarget, ...]:
+    parsed = PatentsViewPatentTargetFile.model_validate(
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+    )
+    targets = tuple(parsed.targets)
+    ids = [target.target_id for target in targets]
+    identities = [target.assignee_organization.casefold() for target in targets]
+    if len(ids) != len(set(ids)):
+        raise ValueError("duplicate PatentsView patent target_id")
+    if len(identities) != len(set(identities)):
+        raise ValueError("duplicate PatentsView assignee target")
+    return targets

--- a/src/cip/adapters/sources/patentsview_patents/schemas.py
+++ b/src/cip/adapters/sources/patentsview_patents/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PatentsViewAssignee(BaseModel):
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    assignee_organization: str | None = Field(default=None, max_length=500)
+
+
+class PatentsViewPatent(BaseModel):
+    model_config = ConfigDict(extra="ignore", str_strip_whitespace=True)
+
+    patent_id: str = Field(min_length=1, max_length=100)
+    patent_title: str = Field(min_length=1, max_length=2_000)
+    patent_date: str = Field(min_length=10, max_length=10)
+    patent_type: str = Field(min_length=1, max_length=100)
+    assignees: tuple[PatentsViewAssignee, ...] = Field(default_factory=tuple, max_length=50)
+
+
+class PatentsViewPatentResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    error: bool
+    count: int = Field(ge=0, le=20)
+    total_hits: int = Field(ge=0)
+    patents: tuple[PatentsViewPatent, ...] = Field(default_factory=tuple, max_length=20)

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -47,6 +47,7 @@ from cip.modules.collection_orchestration.application.reference_adapter import (
     ReferencePortfolioAdapter,
 )
 from cip.modules.collection_orchestration.application.search_archive_registration import (
+    SearchArchiveRegistrationInputs,
     register_search_archive_adapters,
 )
 from cip.modules.collection_orchestration.application.smartrecruiters_adapter import (
@@ -134,12 +135,14 @@ def build_runtime_adapters(
     register_search_archive_adapters(
         adapters,
         entries_by_id,
-        inputs.public_web_targets,
-        inputs.search_templates,
-        inputs.developer_ecosystem_targets,
-        inputs.github_code_search_templates,
-        inputs.crossref_publication_targets,
-        inputs.patentsview_patent_targets,
+        SearchArchiveRegistrationInputs(
+            public_web_targets=inputs.public_web_targets,
+            search_templates=inputs.search_templates,
+            developer_targets=inputs.developer_ecosystem_targets,
+            github_code_search_templates=inputs.github_code_search_templates,
+            crossref_publication_targets=inputs.crossref_publication_targets,
+            patentsview_patent_targets=inputs.patentsview_patent_targets,
+        ),
         brave_token_provider=brave_token_provider,
         github_code_search_token_provider=github_code_search_token_provider,
         patentsview_api_key_provider=patentsview_api_key_provider,

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -12,6 +12,7 @@ from cip.adapters.sources.lever.registry import LeverSite
 from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
 from cip.adapters.sources.passive_infrastructure.rdap_registry import RdapTarget
 from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
+from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.recruitee.registry import RecruiteeCareerSite
 from cip.adapters.sources.smartrecruiters.registry import SmartRecruitersCompany
@@ -74,6 +75,7 @@ class AdapterCompositionInputs:
     search_templates: tuple[SearchQueryTemplate, ...]
     github_code_search_templates: tuple[SearchQueryTemplate, ...]
     crossref_publication_targets: tuple[CrossrefPublicationTarget, ...]
+    patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...]
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
     rdap_targets: tuple[RdapTarget, ...]
@@ -85,6 +87,7 @@ def build_runtime_adapters(
     *,
     brave_token_provider: Callable[[], str | None],
     github_code_search_token_provider: Callable[[], str | None],
+    patentsview_api_key_provider: Callable[[], str | None],
     certspotter_token_provider: Callable[[], str | None],
     phishtank_token_provider: Callable[[], str | None],
     teamtailor_token_provider: Callable[[], str | None],
@@ -136,8 +139,10 @@ def build_runtime_adapters(
         inputs.developer_ecosystem_targets,
         inputs.github_code_search_templates,
         inputs.crossref_publication_targets,
+        inputs.patentsview_patent_targets,
         brave_token_provider=brave_token_provider,
         github_code_search_token_provider=github_code_search_token_provider,
+        patentsview_api_key_provider=patentsview_api_key_provider,
         timeout_seconds=timeout_seconds,
     )
     register_vulnerability_adapters(

--- a/src/cip/modules/collection_orchestration/application/patentsview_patent_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/patentsview_patent_adapter.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import date, datetime
+from hashlib import sha256
+from json import dumps
+from urllib.parse import urlencode
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.patentsview_patents.client import (
+    PatentsViewClient,
+    PatentsViewClientError,
+)
+from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
+from cip.adapters.sources.patentsview_patents.schemas import PatentsViewPatent
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.public_footprint.domain.search import SearchResultLead, map_search_result_lead
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_QUERY_TEMPLATE_ID = "patentsview-assignee-patents"
+_QUERY_TEMPLATE_VERSION = 1
+
+
+class PatentsViewPatentAdapter:
+    source_id = "patentsview-patent-metadata"
+    adapter_id = "patentsview-assignee-patents"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[PatentsViewPatentTarget, ...],
+        *,
+        token_provider: Callable[[], str | None],
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("PatentsView patent adapter requires its source policy")
+        self._entry = entry
+        self._targets = tuple(target for target in targets if target.enabled)
+        self._token_provider = token_provider
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        target, next_index = _next_target(self._targets, checkpoint_payload)
+        if target is None:
+            return _empty_batch()
+        _authorize(self._entry, collected_at)
+        token = self._token_provider()
+        if token is None or not token.strip():
+            raise AdapterExecutionError(
+                "PatentsView provider is not connected",
+                error_code="provider_not_connected",
+                retryable=False,
+            )
+        try:
+            result = PatentsViewClient(
+                token,
+                timeout_seconds=self._timeout_seconds,
+                transport=self._transport,
+            ).patents_for_assignee(
+                self._entry.policy.base_url,
+                assignee_organization=target.assignee_organization,
+            )
+        except PatentsViewClientError as exc:
+            raise AdapterExecutionError(
+                str(exc), error_code=exc.code, retryable=exc.retryable
+            ) from exc
+        items = tuple(
+            item for item in result.response.patents if _belongs_to_target(item, target)
+        )
+        observations = tuple(
+            _observation(
+                item,
+                target=target,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+                source_url=result.request_url,
+            )
+            for item in items
+        )
+        projections = tuple(
+            map_search_result_lead(
+                _lead(
+                    item,
+                    target=target,
+                    rank=rank,
+                    observed_at=collected_at,
+                    base_url=self._entry.policy.base_url,
+                )
+            )
+            for rank, item in enumerate(items, start=1)
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            public_footprint_projections=projections,
+            checkpoint_payload={"target_index": next_index},
+            not_modified=not items,
+        )
+
+
+def _authorize(entry: SourceRegistryEntry, now: datetime) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=entry.policy.base_url,
+            purpose="patent-discovery",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def _next_target(
+    targets: tuple[PatentsViewPatentTarget, ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[PatentsViewPatentTarget | None, int]:
+    if not targets:
+        return None, 0
+    value = 0 if payload is None else payload.get("target_index", 0)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise AdapterExecutionError(
+            "invalid PatentsView patent checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(targets)
+    return targets[index], 0 if index + 1 >= len(targets) else index + 1
+
+
+def _belongs_to_target(item: PatentsViewPatent, target: PatentsViewPatentTarget) -> bool:
+    try:
+        date.fromisoformat(item.patent_date)
+    except ValueError:
+        return False
+    if any(character.isspace() for character in item.patent_id):
+        return False
+    expected = target.assignee_organization.casefold()
+    return any(
+        assignee.assignee_organization is not None
+        and assignee.assignee_organization.casefold() == expected
+        for assignee in item.assignees
+    )
+
+
+def _lead(
+    item: PatentsViewPatent,
+    *,
+    target: PatentsViewPatentTarget,
+    rank: int,
+    observed_at: datetime,
+    base_url: str,
+) -> SearchResultLead:
+    target_url = _patent_locator(base_url, item.patent_id)
+    snippet = (
+        f"PatentsView metadata for US patent {item.patent_id}, granted {item.patent_date}, "
+        f"type {item.patent_type}; matched configured assignee "
+        f"{target.assignee_organization}. Abstract, claims, inventors and full text not retrieved."
+    )
+    return SearchResultLead(
+        organization_id=target.organization_id,
+        source_id=PatentsViewPatentAdapter.source_id,
+        source_record_key=_record_key(target, item),
+        target_url=target_url,
+        title=item.patent_title.strip()[:1_000],
+        snippet=snippet[:1_000],
+        rank=rank,
+        observed_at=observed_at,
+        query_template_id=_QUERY_TEMPLATE_ID,
+        query_template_version=_QUERY_TEMPLATE_VERSION,
+        candidate_claim=None,
+    )
+
+
+def _observation(
+    item: PatentsViewPatent,
+    *,
+    target: PatentsViewPatentTarget,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    source_url: str,
+) -> RawObservation:
+    material = (
+        f"{target.assignee_organization}\n{item.patent_id}\n{item.patent_title.strip()}\n"
+        f"{item.patent_date}\n{item.patent_type}"
+    ).encode()
+    return RawObservation(
+        source_id=PatentsViewPatentAdapter.source_id,
+        adapter_id=PatentsViewPatentAdapter.adapter_id,
+        adapter_version=PatentsViewPatentAdapter.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="patentsview-assignee-patent-metadata",
+        source_url=source_url,
+        payload_hash_sha256=sha256(material).hexdigest(),
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        source_record_key=_record_key(target, item),
+        collected_at=collected_at,
+        retention_until=retention_until,
+        schema_fingerprint="patentsview-assignee-patents:v1",
+    )
+
+
+def _patent_locator(base_url: str, patent_id: str) -> str:
+    query = dumps({"patent_id": patent_id}, separators=(",", ":"))
+    return f"{base_url}?{urlencode({'q': query})}"
+
+
+def _record_key(target: PatentsViewPatentTarget, item: PatentsViewPatent) -> str:
+    return f"{target.target_id}:{item.patent_id}"
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"target_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -24,6 +24,7 @@ from cip.adapters.sources.lever.registry import load_lever_sites
 from cip.adapters.sources.organization_identity.registry import load_organization_identity_targets
 from cip.adapters.sources.passive_infrastructure.rdap_registry import load_rdap_targets
 from cip.adapters.sources.passive_infrastructure.registry import load_passive_infrastructure_targets
+from cip.adapters.sources.patentsview_patents.registry import load_patentsview_patent_targets
 from cip.adapters.sources.public_web.registry import load_public_web_targets
 from cip.adapters.sources.recruitee.registry import load_recruitee_sites
 from cip.adapters.sources.smartrecruiters.registry import load_smartrecruiters_companies
@@ -110,6 +111,11 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
             factory,
             source_id="github-code-search-metadata",
             secret_name="api_token",
+        ),
+        patentsview_api_key_provider=connected_secret_supplier(
+            factory,
+            source_id="patentsview-patent-metadata",
+            secret_name="api_key",
         ),
         certspotter_token_provider=connected_secret_supplier(
             factory,
@@ -218,6 +224,9 @@ def _load_adapter_inputs(
         ),
         crossref_publication_targets=load_crossref_publication_targets(
             settings.crossref_publication_target_registry_path
+        ),
+        patentsview_patent_targets=load_patentsview_patent_targets(
+            settings.patentsview_patent_target_registry_path
         ),
         vulnerability_targets=load_vulnerability_query_targets(
             settings.vulnerability_query_target_registry_path

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
 from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
@@ -29,15 +30,20 @@ from cip.modules.public_footprint.domain.search import SearchQueryTemplate
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
 
+@dataclass(frozen=True, slots=True)
+class SearchArchiveRegistrationInputs:
+    public_web_targets: tuple[PublicWebTarget, ...]
+    search_templates: tuple[SearchQueryTemplate, ...]
+    developer_targets: tuple[DeveloperEcosystemTarget, ...]
+    github_code_search_templates: tuple[SearchQueryTemplate, ...]
+    crossref_publication_targets: tuple[CrossrefPublicationTarget, ...]
+    patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...]
+
+
 def register_search_archive_adapters(
     adapters: dict[tuple[str, str], CollectionAdapter],
     entries_by_id: dict[str, SourceRegistryEntry],
-    targets: tuple[PublicWebTarget, ...],
-    templates: tuple[SearchQueryTemplate, ...],
-    developer_targets: tuple[DeveloperEcosystemTarget, ...],
-    github_code_search_templates: tuple[SearchQueryTemplate, ...],
-    crossref_publication_targets: tuple[CrossrefPublicationTarget, ...],
-    patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...],
+    inputs: SearchArchiveRegistrationInputs,
     *,
     brave_token_provider: Callable[[], str | None],
     github_code_search_token_provider: Callable[[], str | None],
@@ -50,8 +56,8 @@ def register_search_archive_adapters(
             adapters,
             BraveSearchAdapter(
                 brave_entry,
-                targets,
-                templates,
+                inputs.public_web_targets,
+                inputs.search_templates,
                 token_provider=brave_token_provider,
                 timeout_seconds=timeout_seconds,
             ),
@@ -63,7 +69,7 @@ def register_search_archive_adapters(
             adapters,
             InternetArchiveCdxAdapter(
                 archive_entry,
-                targets,
+                inputs.public_web_targets,
                 timeout_seconds=timeout_seconds,
             ),
         )
@@ -74,7 +80,7 @@ def register_search_archive_adapters(
             adapters,
             CommonCrawlIndexAdapter(
                 common_crawl_entry,
-                targets,
+                inputs.public_web_targets,
                 timeout_seconds=timeout_seconds,
             ),
         )
@@ -85,8 +91,8 @@ def register_search_archive_adapters(
             adapters,
             GitHubCodeSearchAdapter(
                 github_code_entry,
-                developer_targets,
-                github_code_search_templates,
+                inputs.developer_targets,
+                inputs.github_code_search_templates,
                 token_provider=github_code_search_token_provider,
                 timeout_seconds=timeout_seconds,
             ),
@@ -98,7 +104,7 @@ def register_search_archive_adapters(
             adapters,
             CrossrefPublicationAdapter(
                 crossref_entry,
-                crossref_publication_targets,
+                inputs.crossref_publication_targets,
                 timeout_seconds=timeout_seconds,
             ),
         )
@@ -109,7 +115,7 @@ def register_search_archive_adapters(
             adapters,
             PatentsViewPatentAdapter(
                 patentsview_entry,
-                patentsview_patent_targets,
+                inputs.patentsview_patent_targets,
                 token_provider=patentsview_api_key_provider,
                 timeout_seconds=timeout_seconds,
             ),

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
 from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
+from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.archive_cdx_adapter import (
     InternetArchiveCdxAdapter,
@@ -20,6 +21,9 @@ from cip.modules.collection_orchestration.application.crossref_publication_adapt
 from cip.modules.collection_orchestration.application.github_code_search_adapter import (
     GitHubCodeSearchAdapter,
 )
+from cip.modules.collection_orchestration.application.patentsview_patent_adapter import (
+    PatentsViewPatentAdapter,
+)
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
 from cip.modules.public_footprint.domain.search import SearchQueryTemplate
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
@@ -33,9 +37,11 @@ def register_search_archive_adapters(
     developer_targets: tuple[DeveloperEcosystemTarget, ...],
     github_code_search_templates: tuple[SearchQueryTemplate, ...],
     crossref_publication_targets: tuple[CrossrefPublicationTarget, ...],
+    patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...],
     *,
     brave_token_provider: Callable[[], str | None],
     github_code_search_token_provider: Callable[[], str | None],
+    patentsview_api_key_provider: Callable[[], str | None],
     timeout_seconds: float,
 ) -> None:
     brave_entry = entries_by_id.get(BraveSearchAdapter.source_id)
@@ -93,6 +99,18 @@ def register_search_archive_adapters(
             CrossrefPublicationAdapter(
                 crossref_entry,
                 crossref_publication_targets,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    patentsview_entry = entries_by_id.get(PatentsViewPatentAdapter.source_id)
+    if patentsview_entry is not None:
+        _register(
+            adapters,
+            PatentsViewPatentAdapter(
+                patentsview_entry,
+                patentsview_patent_targets,
+                token_provider=patentsview_api_key_provider,
                 timeout_seconds=timeout_seconds,
             ),
         )

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -123,6 +123,9 @@ class Settings(BaseSettings):
     crossref_publication_target_registry_path: Path = Path(
         "policies/crossref_publication_targets.yml"
     )
+    patentsview_patent_target_registry_path: Path = Path(
+        "policies/patentsview_patent_targets.yml"
+    )
     vulnerability_query_target_registry_path: Path = Path(
         "policies/vulnerability_query_targets.yml"
     )

--- a/tests/unit/collection_orchestration/test_patentsview_patent_adapter.py
+++ b/tests/unit/collection_orchestration/test_patentsview_patent_adapter.py
@@ -110,7 +110,7 @@ def test_patentsview_maps_only_exact_assignee_minimal_metadata() -> None:
     assert request.url.path == "/api/v1/patent/"
     assert request.headers["X-Api-Key"] == "live-key"
     assert loads(request.url.params["q"]) == {
-        "assignees.assignee_organization": "Example Corporation"
+        "_eq": {"assignees.assignee_organization": "Example Corporation"}
     }
     assert loads(request.url.params["o"]) == {"size": 20}
     fields = loads(request.url.params["f"])

--- a/tests/unit/collection_orchestration/test_patentsview_patent_adapter.py
+++ b/tests/unit/collection_orchestration/test_patentsview_patent_adapter.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from json import loads
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.patentsview_patents.registry import (
+    PatentsViewPatentTarget,
+    load_patentsview_patent_targets,
+)
+from cip.modules.collection_orchestration.application.patentsview_patent_adapter import (
+    PatentsViewPatentAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 13, 30, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
+ORG_ID = UUID("0fe0ab6c-1da4-5af0-9089-a9885ac2f3f3")
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+TARGET_PATH = Path("policies/patentsview_patent_targets.yml")
+
+
+def test_checked_in_patentsview_registry_is_empty() -> None:
+    assert load_patentsview_patent_targets(TARGET_PATH) == ()
+
+
+def test_patentsview_without_enabled_target_performs_no_network_or_secret_read() -> None:
+    secret_reads: list[int] = []
+
+    def token_provider() -> str | None:
+        secret_reads.append(1)
+        return "api-key"
+
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without enabled target")
+
+    adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(enabled=False),),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(fail_network),
+    )
+    batch = _collect(adapter)
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert secret_reads == []
+
+
+def test_patentsview_requires_connected_api_key_before_network() -> None:
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without provider key")
+
+    adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=lambda: None,
+        transport=httpx.MockTransport(fail_network),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "provider_not_connected"
+    assert exc_info.value.retryable is False
+
+
+def test_patentsview_maps_only_exact_assignee_minimal_metadata() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "error": False,
+                "count": 4,
+                "total_hits": 4,
+                "patents": [
+                    _patent("12345678", "Security invention", "Example Corporation"),
+                    _patent("12345679", "Other assignee", "Other Corporation"),
+                    _patent("bad id", "Bad id", "Example Corporation"),
+                    _patent(
+                        "12345680",
+                        "Bad date",
+                        "Example Corporation",
+                        patent_date="2026-99-99",
+                    ),
+                ],
+            },
+            request=request,
+        )
+
+    adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=lambda: "live-key",
+        transport=httpx.MockTransport(handler),
+    )
+    batch = _collect(adapter)
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.path == "/api/v1/patent/"
+    assert request.headers["X-Api-Key"] == "live-key"
+    assert loads(request.url.params["q"]) == {
+        "assignees.assignee_organization": "Example Corporation"
+    }
+    assert loads(request.url.params["o"]) == {"size": 20}
+    fields = loads(request.url.params["f"])
+    assert "patent_abstract" not in fields
+    assert "inventors" not in fields
+    assert "patent_id" in fields
+    assert "assignees.assignee_organization" in fields
+
+    assert len(batch.observations) == 1
+    assert len(batch.public_footprint_projections) == 1
+    projection = batch.public_footprint_projections[0]
+    assert projection.claims == ()
+    assert projection.resource.retrieval_state.value == "quarantined"
+    excerpt = projection.version.excerpt or ""
+    assert "Example Corporation" in excerpt
+    assert "Abstract, claims, inventors and full text not retrieved" in excerpt
+    assert batch.checkpoint_payload == {"target_index": 0}
+
+
+def test_patentsview_rejects_invalid_checkpoint() -> None:
+    adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=lambda: "key",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter, checkpoint_payload={"target_index": True})
+    assert exc_info.value.error_code == "invalid_checkpoint"
+
+
+def test_patentsview_classifies_schema_rate_limit_and_error_envelope() -> None:
+    def malformed(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b"not-json",
+            request=request,
+        )
+
+    malformed_adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=lambda: "key",
+        transport=httpx.MockTransport(malformed),
+    )
+    with pytest.raises(AdapterExecutionError) as schema_info:
+        _collect(malformed_adapter)
+    assert schema_info.value.error_code == "source_schema_drift"
+
+    def rate_limited(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            headers={"content-type": "application/json"},
+            request=request,
+        )
+
+    rate_adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=lambda: "key",
+        transport=httpx.MockTransport(rate_limited),
+    )
+    with pytest.raises(AdapterExecutionError) as rate_info:
+        _collect(rate_adapter)
+    assert rate_info.value.error_code == "http_429"
+    assert rate_info.value.retryable is True
+
+    def provider_error(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"error": True, "count": 0, "total_hits": 0, "patents": []},
+            request=request,
+        )
+
+    error_adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=lambda: "key",
+        transport=httpx.MockTransport(provider_error),
+    )
+    with pytest.raises(AdapterExecutionError) as envelope_info:
+        _collect(error_adapter)
+    assert envelope_info.value.error_code == "source_schema_drift"
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == "patentsview-patent-metadata"
+    )
+
+
+def _target(*, enabled: bool = True) -> PatentsViewPatentTarget:
+    return PatentsViewPatentTarget(
+        target_id="example-patents",
+        organization_id=ORG_ID,
+        canonical_name="Example Corporation",
+        assignee_organization="Example Corporation",
+        enabled=enabled,
+    )
+
+
+def _collect(
+    adapter: PatentsViewPatentAdapter,
+    *,
+    checkpoint_payload: dict[str, object] | None = None,
+):
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint_payload,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _patent(
+    patent_id: str,
+    title: str,
+    assignee: str,
+    *,
+    patent_date: str = "2026-06-01",
+) -> dict[str, object]:
+    return {
+        "patent_id": patent_id,
+        "patent_title": title,
+        "patent_date": patent_date,
+        "patent_type": "utility",
+        "assignees": [{"assignee_organization": assignee}],
+        "patent_abstract": "ignored and never materialized",
+        "inventors": [{"inventor_name_first": "ignored"}],
+        "claims": [{"claim_text": "ignored"}],
+    }

--- a/tests/unit/provider_onboarding/test_provider_registry.py
+++ b/tests/unit/provider_onboarding/test_provider_registry.py
@@ -13,7 +13,7 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     profiles = load_provider_profiles(Path("policies/provider_onboarding.yml"))
     by_source = {profile.source_id: profile for profile in profiles}
 
-    assert len(profiles) == 24
+    assert len(profiles) == 25
     assert by_source["cisa-kev"].initial_state is OnboardingState.CONNECTED
     assert by_source["ashby-job-board"].auth_mode is AuthMode.NONE
     assert by_source["ashby-job-board"].initial_state is OnboardingState.CONNECTED
@@ -33,6 +33,14 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     )
     assert (
         by_source["github-code-search-metadata"].initial_state
+        is OnboardingState.NOT_CONFIGURED
+    )
+    assert by_source["patentsview-patent-metadata"].auth_mode is AuthMode.API_KEY
+    assert by_source["patentsview-patent-metadata"].required_secret_names == (
+        "api_key",
+    )
+    assert (
+        by_source["patentsview-patent-metadata"].initial_state
         is OnboardingState.NOT_CONFIGURED
     )
     assert by_source["internet-archive-cdx"].initial_state is OnboardingState.CONNECTED


### PR DESCRIPTION
Fourth implementation tranche for issue #108.

Final PatentsView scope:
- real PatentsView PatentSearch adapter on the current `/api/v1/patent/` contract;
- explicit canonical-organization-bound assignee target registry, checked in empty by default;
- Provider Onboarding `api_key` supplied through the existing `connected_secret_supplier` runtime boundary;
- bounded GET query using PatentsView Query Language `_eq` on `assignees.assignee_organization`, size 20, selected fields only, no redirects and 2 MiB response limit;
- returned assignee identity is revalidated exactly, with valid patent id/date required before persistence;
- materialized fields limited to patent id/title/date/type and assignee organization; abstracts, claims, inventors, classifications and full text are excluded;
- immutable RawObservation plus existing quarantined Lot 12 SearchResultLead projection; zero automatic claims/signals/needs/opportunities/outreach;
- Source Governance, portfolio, Provider Onboarding, settings/runtime composition and disabled-by-default schedule wired into shared SA-14 runtime;
- architecture refactor introduces immutable `SearchArchiveRegistrationInputs`, keeping `register_search_archive_adapters()` within project parameter-count limits while making future SA-14 providers composable;
- deterministic tests cover empty target/no network, missing provider key/no network, exact query/header shape, data minimization, exact-assignee filtering, bad dates/ids, invalid checkpoint, schema drift, provider error and 429 classification;
- dedicated documentation records the current provider entitlement limitation and the exact future live-validation requirement.

Truthful activation state:
- adapter_present: yes;
- authorized: yes;
- executable when provisioned: yes;
- checked-in schedule enabled: no;
- `scheduled`: intentionally absent;
- real provider `live_tested`: intentionally absent.

PatentsView currently requires `X-Api-Key`, and no legitimate provider key is available in this repository/CI. The SA-14 live workflow is therefore expected to skip this branch; that skip is not a provider validation. The adapter must receive a future exact-SHA controlled live run with a legitimate provider key before `live_tested` can be added.

Final exact merge candidate: `ea257ceb2921a3a4ffcb8ab3cf1d5f90798ad562`.

On this exact SHA:
- CI #1810: PASS;
- dependency consistency / pip-audit: PASS;
- Ruff: PASS;
- strict Mypy: PASS;
- architecture/release contracts: PASS;
- reversible Alembic migrations: PASS;
- complete pytest + branch-aware coverage gate: PASS;
- frontend audit/typecheck/build: PASS;
- reviews: none; review threads: none;
- SA-14 live workflow: skipped by design because no legitimate PatentsView API key is available.

Issue #108 remains open after this tranche. Next work is standards/public-specification discovery, with W3C public API as the current no-auth provider candidate, followed by remaining second-search/GDELT entitlement-dependent work.

Ready to squash-merge only at exact head `ea257ceb2921a3a4ffcb8ab3cf1d5f90798ad562`.