### PR TITLE
SA-14: add governed Mojeek web search discovery

### DIFF
--- a/docs/source_activation/SA_14_MOJEEK_SEARCH.md
+++ b/docs/source_activation/SA_14_MOJEEK_SEARCH.md
@@ -1,0 +1,68 @@
+# SA-14 — Mojeek Web Search metadata discovery
+
+## Status
+
+Source id: `mojeek-web-search-metadata`.
+
+Adapter id: `mojeek-web-search`.
+
+Activation wave: `SA-14`.
+
+The adapter is production-wired but is intentionally not `live_tested` and not scheduled while provider access and durable-storage entitlement remain unprovisioned.
+
+## Provider contract
+
+The selected provider endpoint is `https://api.mojeek.com/search`. The Web Search API requires an API key and supports JSON responses containing result URL, title and query-dependent description/snippet metadata.
+
+Mojeek advertises a limited free trial, but storage rights are plan-specific. CIP therefore treats technical authentication and durable-storage permission as two independent requirements. A working API key does not by itself authorize persistent ingestion.
+
+Checked-in `policies/mojeek_search_entitlement.yml` is fail-closed:
+
+- `durable_storage_authorized: false`;
+- `plan: unprovisioned`;
+- no evidence reference.
+
+Enabling durable storage requires an explicit reviewed evidence reference. Provider Onboarding separately supplies the `api_key` secret through the existing `connected_secret_supplier` boundary.
+
+## Runtime boundary
+
+The adapter reuses the governed public-web targets and approved search-query templates. It executes one enabled target/template pair at a time and requests at most 20 results.
+
+Order of gates before network access:
+
+1. enabled target/template pair exists;
+2. Source Governance authorizes the request;
+3. durable-storage entitlement is explicitly authorized;
+4. a connected Mojeek API key exists;
+5. only then may the HTTP request be sent.
+
+If the storage entitlement is absent, the API-key supplier is not even called.
+
+The runtime composition groups search/archive credential callbacks under immutable `SearchArchiveSecretProviders`, avoiding parameter-count growth as SA-14 gains providers.
+
+## Data minimization
+
+CIP materializes only:
+
+- result URL;
+- result title;
+- query-dependent snippet/description;
+- result rank;
+- organization/query-template provenance.
+
+The adapter does not fetch third-party page bodies, images, scores or other provider fields. Unsafe non-HTTP(S) result URLs are discarded. The API key is never stored in observations or projection metadata.
+
+Each retained item becomes an immutable `RawObservation` plus the existing quarantined Lot 12 `SearchResultLead` projection. Search hits create zero automatic claims, signals, needs, opportunities or outreach authority.
+
+## Live-validation requirement
+
+`live_tested` may be added only after all of the following are true on an exact candidate SHA:
+
+1. a legitimate Mojeek API key has been provisioned;
+2. the reviewed provider entitlement explicitly permits the bounded persistent metadata retained by CIP;
+3. `policies/mojeek_search_entitlement.yml` records that reviewed entitlement evidence;
+4. a controlled GitHub Actions job executes the real production `MojeekSearchAdapter` against the provider;
+5. the job proves bounded observations/projections, zero automatic claims and zero third-party page-body retrieval;
+6. complete deterministic CI passes on the same final SHA.
+
+A skipped live job, a mocked HTTP response, an unreviewed trial key, or a key whose storage rights are insufficient must never be represented as `live_tested`.

--- a/policies/collection_schedules.search_archives.yml
+++ b/policies/collection_schedules.search_archives.yml
@@ -84,3 +84,15 @@ schedules:
       max_delay_seconds: 7200
       circuit_failure_threshold: 3
       circuit_reset_seconds: 7200
+
+  - source_id: mojeek-web-search-metadata
+    adapter_id: mojeek-web-search
+    enabled: false
+    interval_seconds: 86400
+    lease_seconds: 180
+    retry:
+      max_attempts: 2
+      base_delay_seconds: 900
+      max_delay_seconds: 7200
+      circuit_failure_threshold: 2
+      circuit_reset_seconds: 7200

--- a/policies/mojeek_search_entitlement.yml
+++ b/policies/mojeek_search_entitlement.yml
@@ -1,0 +1,5 @@
+version: 1
+entitlement:
+  durable_storage_authorized: false
+  plan: unprovisioned
+  evidence_reference: null

--- a/policies/provider_onboarding.yml
+++ b/policies/provider_onboarding.yml
@@ -96,8 +96,7 @@ providers:
     documentation_url: https://docs.teamtailor.com/
     signup_url: null
     console_url: null
-    required_secret_names:
-      - api_token
+    required_secret_names: [api_token]
     human_actions:
       - sign_in
       - accept_provider_terms
@@ -147,8 +146,7 @@ providers:
     signup_url: https://portail-api.insee.fr/
     console_url: https://portail-api.insee.fr/
     required_secret_names: []
-    human_actions:
-      - enable_source_policy
+    human_actions: [enable_source_policy]
     automatic_onboarding: true
     blocked_reason: null
 
@@ -158,9 +156,7 @@ providers:
     documentation_url: https://data.inpi.fr/content/editorial/Acces_API_Entreprises
     signup_url: https://data.inpi.fr/
     console_url: https://data.inpi.fr/
-    required_secret_names:
-      - username
-      - password
+    required_secret_names: [username, password]
     human_actions:
       - open_official_signup
       - sign_in
@@ -179,12 +175,30 @@ providers:
     documentation_url: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started
     signup_url: https://api-dashboard.search.brave.com/app/keys
     console_url: https://api-dashboard.search.brave.com/
-    required_secret_names:
-      - api_token
+    required_secret_names: [api_token]
     human_actions:
       - open_official_signup
       - sign_in
       - accept_provider_terms
+      - retrieve_technical_credentials
+      - register_secret_reference
+      - enable_source_policy
+    automatic_onboarding: false
+    blocked_reason: null
+
+  - source_id: mojeek-web-search-metadata
+    display_name: Mojeek Web Search API
+    auth_mode: api_key
+    documentation_url: https://www.mojeek.com/support/api/search/
+    signup_url: https://www.mojeek.com/services/search/web-search-api/
+    console_url: null
+    required_secret_names: [api_key]
+    human_actions:
+      - open_official_signup
+      - sign_in
+      - accept_provider_terms
+      - request_provider_access
+      - wait_for_provider_approval
       - retrieve_technical_credentials
       - register_secret_reference
       - enable_source_policy
@@ -197,8 +211,7 @@ providers:
     documentation_url: https://docs.github.com/en/rest/search/search#search-code
     signup_url: https://github.com/settings/tokens
     console_url: https://github.com/settings/tokens
-    required_secret_names:
-      - api_token
+    required_secret_names: [api_token]
     human_actions:
       - sign_in
       - accept_provider_terms
@@ -214,8 +227,7 @@ providers:
     documentation_url: https://search.patentsview.org/docs/docs/Search%20API/SearchAPIReference/
     signup_url: null
     console_url: null
-    required_secret_names:
-      - api_key
+    required_secret_names: [api_key]
     human_actions:
       - open_official_signup
       - sign_in
@@ -256,8 +268,7 @@ providers:
     documentation_url: https://sslmate.com/help/reference/ct_search_api_v1
     signup_url: https://sslmate.com/account
     console_url: https://sslmate.com/account/api_keys
-    required_secret_names:
-      - api_token
+    required_secret_names: [api_token]
     human_actions:
       - open_official_signup
       - sign_in
@@ -275,8 +286,7 @@ providers:
     signup_url: null
     console_url: null
     required_secret_names: []
-    human_actions:
-      - enable_source_policy
+    human_actions: [enable_source_policy]
     automatic_onboarding: true
     blocked_reason: null
 
@@ -286,8 +296,7 @@ providers:
     documentation_url: https://www.phishtank.com/developer_info.php
     signup_url: https://www.phishtank.com/register.php
     console_url: https://www.phishtank.com/user.php
-    required_secret_names:
-      - api_token
+    required_secret_names: [api_token]
     human_actions:
       - open_official_signup
       - sign_in

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -74,3 +74,17 @@ sources:
       - authorized
       - executable
       - live_tested
+
+  - source_id: mojeek-web-search-metadata
+    display_name: Mojeek Web Search API metadata
+    category: corporate_public_footprint
+    disposition: active
+    activation_wave: SA-14
+    requires_schedule: false
+    stages:
+      - catalogued
+      - reviewed
+      - mapped
+      - adapter_present
+      - authorized
+      - executable

--- a/policies/source_portfolio.search_archives.yml
+++ b/policies/source_portfolio.search_archives.yml
@@ -24,10 +24,7 @@ sources:
       adapter_version: "1"
       provider_schema_version: brave-search-web-v1
       modes: [conditional_refresh, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
@@ -40,9 +37,7 @@ sources:
     category: corporate_public_footprint
     status: executable
     freshness_max_age_seconds: 604800
-    commercial_use_cases:
-      - public_evidence_map
-      - change_history
+    commercial_use_cases: [public_evidence_map, change_history]
     candidate_origin: SA-02
     monthly_cost_limit: 0
     metadata:
@@ -56,10 +51,7 @@ sources:
       adapter_version: "1"
       provider_schema_version: cdx-json-v1
       modes: [incremental_cursor, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
@@ -72,10 +64,7 @@ sources:
     category: corporate_public_footprint
     status: executable
     freshness_max_age_seconds: 604800
-    commercial_use_cases:
-      - public_evidence_map
-      - change_history
-      - historical_public_discovery
+    commercial_use_cases: [public_evidence_map, change_history, historical_public_discovery]
     candidate_origin: SA-14
     monthly_cost_limit: 0
     metadata:
@@ -90,10 +79,7 @@ sources:
       adapter_version: "1"
       provider_schema_version: common-crawl-cdxj-v1
       modes: [incremental_cursor, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
@@ -106,10 +92,7 @@ sources:
     category: corporate_public_footprint
     status: executable
     freshness_max_age_seconds: 86400
-    commercial_use_cases:
-      - public_evidence_map
-      - organization_research
-      - public_engineering_context
+    commercial_use_cases: [public_evidence_map, organization_research, public_engineering_context]
     candidate_origin: SA-14
     monthly_cost_limit: 0
     metadata:
@@ -127,10 +110,7 @@ sources:
       adapter_version: "1"
       provider_schema_version: github-code-search-v1
       modes: [conditional_refresh, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
@@ -143,10 +123,7 @@ sources:
     category: corporate_public_footprint
     status: executable
     freshness_max_age_seconds: 604800
-    commercial_use_cases:
-      - organization_research
-      - publication_discovery
-      - public_evidence_map
+    commercial_use_cases: [organization_research, publication_discovery, public_evidence_map]
     candidate_origin: SA-14
     monthly_cost_limit: 0
     metadata:
@@ -163,10 +140,7 @@ sources:
       adapter_version: "1"
       provider_schema_version: crossref-ror-works-v1
       modes: [conditional_refresh, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
@@ -179,10 +153,7 @@ sources:
     category: corporate_public_footprint
     status: executable
     freshness_max_age_seconds: 604800
-    commercial_use_cases:
-      - organization_research
-      - patent_discovery
-      - public_evidence_map
+    commercial_use_cases: [organization_research, patent_discovery, public_evidence_map]
     candidate_origin: SA-14
     monthly_cost_limit: 0
     metadata:
@@ -201,10 +172,7 @@ sources:
       adapter_version: "1"
       provider_schema_version: patentsview-assignee-patents-v1
       modes: [conditional_refresh, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false
@@ -217,10 +185,7 @@ sources:
     category: corporate_public_footprint
     status: executable
     freshness_max_age_seconds: 604800
-    commercial_use_cases:
-      - organization_research
-      - standards_discovery
-      - public_evidence_map
+    commercial_use_cases: [organization_research, standards_discovery, public_evidence_map]
     candidate_origin: SA-14
     monthly_cost_limit: 0
     metadata:
@@ -237,10 +202,38 @@ sources:
       adapter_version: "1"
       provider_schema_version: w3c-affiliation-specifications-v1
       modes: [conditional_refresh, priority_refresh]
-      canonical_output_types:
-        - raw_observation
-        - public_resource
-        - public_resource_version
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 20
+      cost_per_request: 0
+
+  - source_id: mojeek-web-search-metadata
+    display_name: Mojeek Web Search API metadata
+    canonical_url: https://api.mojeek.com/search
+    category: corporate_public_footprint
+    status: executable
+    freshness_max_age_seconds: 86400
+    commercial_use_cases: [public_evidence_map, organization_research]
+    candidate_origin: SA-14
+    monthly_cost_limit: 0
+    metadata:
+      executable: true
+      authorization_status: approved
+      provider_onboarding_required: true
+      durable_storage_entitlement_required: true
+      query_registry_required: true
+      raw_response_storage: false
+      third_party_page_body_storage: false
+      search_result_is_evidence: false
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: mojeek-web-search
+      adapter_version: "1"
+      provider_schema_version: mojeek-web-search-v1
+      modes: [conditional_refresh, priority_refresh]
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
       supports_corrections: true
       supports_tombstones: false
       supports_retractions: false

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -271,3 +271,42 @@ sources:
       specification versions and specification bodies are never retrieved by this adapter. Group
       participation is quarantined discovery metadata, not proof of authorship, ownership,
       deployment, cyber need, commercial opportunity or outreach authorization.
+
+  - id: mojeek-web-search-metadata
+    name: Mojeek Web Search API metadata
+    base_url: https://api.mojeek.com/search
+    status: enabled
+    source_type: search_provider
+    owner: Mojeek Limited
+    terms_url: https://www.mojeek.com/services/search/web-search-api/
+    licence: Mojeek Web Search API customer agreement and plan-specific storage rights
+    allowed_data_categories: [public_result_metadata]
+    prohibited_data_categories: *prohibited
+    rate_limit_per_minute: 5
+    retention_days: 90
+    attribution_required: true
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: approved
+      document_reference: docs/source_activation/SA_14_MOJEEK_SEARCH.md
+      reviewed_at: "2026-08-11T15:25:00+00:00"
+      expires_at: null
+      approved_hosts: [api.mojeek.com]
+      approved_path_prefixes: [/search]
+      approved_purposes: [corporate-public-footprint]
+      automated_collection_allowed: true
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: medium
+      maintenance_cost: medium
+      expected_stability: medium
+    notes: >-
+      Provider execution is fail-closed until both a connected API key and explicit durable-storage
+      entitlement evidence are configured. CIP retains only bounded URL/title/query-dependent
+      snippet/rank metadata and never fetches third-party page bodies through this adapter. Trial or
+      plan credentials without durable storage rights must not be used for persistent collection.
+      Search hits remain quarantined discovery leads and never directly prove deployment, exposure,
+      vulnerability, compromise, need, opportunity, or outreach authorization.

--- a/src/cip/adapters/sources/mojeek_search/registry.py
+++ b/src/cip/adapters/sources/mojeek_search/registry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class _MojeekEntitlementModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    durable_storage_authorized: bool = False
+    plan: str = Field(default="unprovisioned", min_length=1, max_length=100)
+    evidence_reference: str | None = Field(default=None, max_length=1_000)
+
+
+class _MojeekRegistryModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1)
+    entitlement: _MojeekEntitlementModel
+
+
+@dataclass(frozen=True, slots=True)
+class MojeekSearchEntitlement:
+    durable_storage_authorized: bool
+    plan: str
+    evidence_reference: str | None
+
+    def __post_init__(self) -> None:
+        normalized_plan = self.plan.strip()
+        if not normalized_plan:
+            raise ValueError("Mojeek plan is required")
+        evidence = None if self.evidence_reference is None else self.evidence_reference.strip()
+        if self.durable_storage_authorized and not evidence:
+            raise ValueError(
+                "durable Mojeek storage authorization requires an evidence reference"
+            )
+        object.__setattr__(self, "plan", normalized_plan)
+        object.__setattr__(self, "evidence_reference", evidence or None)
+
+
+def load_mojeek_search_entitlement(path: Path) -> MojeekSearchEntitlement:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    parsed = _MojeekRegistryModel.model_validate(payload)
+    item = parsed.entitlement
+    return MojeekSearchEntitlement(
+        durable_storage_authorized=item.durable_storage_authorized,
+        plan=item.plan,
+        evidence_reference=item.evidence_reference,
+    )

--- a/src/cip/adapters/sources/mojeek_search/schemas.py
+++ b/src/cip/adapters/sources/mojeek_search/schemas.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MojeekWebResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    url: str = Field(min_length=1, max_length=4_096)
+    title: str = Field(min_length=1, max_length=1_000)
+    desc: str = Field(default="No snippet supplied", max_length=4_000)
+
+
+class MojeekResponseBody(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    status: str = Field(min_length=1, max_length=200)
+    results: list[MojeekWebResult] = Field(default_factory=list, max_length=20)
+
+
+class MojeekSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    response: MojeekResponseBody

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -9,6 +9,7 @@ from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystem
 from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
 from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
 from cip.adapters.sources.lever.registry import LeverSite
+from cip.adapters.sources.mojeek_search.registry import MojeekSearchEntitlement
 from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
 from cip.adapters.sources.passive_infrastructure.rdap_registry import RdapTarget
 from cip.adapters.sources.passive_infrastructure.registry import PassiveInfrastructureTarget
@@ -49,6 +50,7 @@ from cip.modules.collection_orchestration.application.reference_adapter import (
 )
 from cip.modules.collection_orchestration.application.search_archive_registration import (
     SearchArchiveRegistrationInputs,
+    SearchArchiveSecretProviders,
     register_search_archive_adapters,
 )
 from cip.modules.collection_orchestration.application.smartrecruiters_adapter import (
@@ -79,21 +81,25 @@ class AdapterCompositionInputs:
     crossref_publication_targets: tuple[CrossrefPublicationTarget, ...]
     patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...]
     w3c_affiliation_targets: tuple[W3cAffiliationTarget, ...]
+    mojeek_entitlement: MojeekSearchEntitlement
     vulnerability_targets: tuple[VulnerabilityQueryTarget, ...]
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
     rdap_targets: tuple[RdapTarget, ...]
     sec_incident_targets: tuple[SecIncidentTarget, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class RuntimeSecretProviders:
+    search_archives: SearchArchiveSecretProviders
+    certspotter_token_provider: Callable[[], str | None]
+    phishtank_token_provider: Callable[[], str | None]
+    teamtailor_token_provider: Callable[[], str | None]
+
+
 def build_runtime_adapters(
     inputs: AdapterCompositionInputs,
+    secrets: RuntimeSecretProviders,
     *,
-    brave_token_provider: Callable[[], str | None],
-    github_code_search_token_provider: Callable[[], str | None],
-    patentsview_api_key_provider: Callable[[], str | None],
-    certspotter_token_provider: Callable[[], str | None],
-    phishtank_token_provider: Callable[[], str | None],
-    teamtailor_token_provider: Callable[[], str | None],
     sec_user_agent: str | None,
     phishtank_user_agent: str | None,
     timeout_seconds: float,
@@ -108,7 +114,7 @@ def build_runtime_adapters(
         inputs.ashby_boards,
         inputs.recruitee_sites,
         inputs.teamtailor_accounts,
-        teamtailor_token_provider=teamtailor_token_provider,
+        teamtailor_token_provider=secrets.teamtailor_token_provider,
         timeout_seconds=timeout_seconds,
     )
     register_procurement_funding_adapters(
@@ -145,10 +151,9 @@ def build_runtime_adapters(
             crossref_publication_targets=inputs.crossref_publication_targets,
             patentsview_patent_targets=inputs.patentsview_patent_targets,
             w3c_affiliation_targets=inputs.w3c_affiliation_targets,
+            mojeek_entitlement=inputs.mojeek_entitlement,
         ),
-        brave_token_provider=brave_token_provider,
-        github_code_search_token_provider=github_code_search_token_provider,
-        patentsview_api_key_provider=patentsview_api_key_provider,
+        secrets.search_archives,
         timeout_seconds=timeout_seconds,
     )
     register_vulnerability_adapters(
@@ -162,14 +167,14 @@ def build_runtime_adapters(
         entries_by_id,
         inputs.passive_infrastructure_targets,
         inputs.rdap_targets,
-        certspotter_token_provider=certspotter_token_provider,
+        certspotter_token_provider=secrets.certspotter_token_provider,
         timeout_seconds=timeout_seconds,
     )
     register_intelligence_adapters(
         adapters,
         entries_by_id,
         inputs.sec_incident_targets,
-        phishtank_token_provider=phishtank_token_provider,
+        phishtank_token_provider=secrets.phishtank_token_provider,
         sec_user_agent=sec_user_agent,
         phishtank_user_agent=phishtank_user_agent,
         timeout_seconds=timeout_seconds,

--- a/src/cip/modules/collection_orchestration/application/mojeek_search_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/mojeek_search_adapter.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from hashlib import sha256
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.mojeek_search.registry import MojeekSearchEntitlement
+from cip.adapters.sources.mojeek_search.schemas import MojeekSearchResponse, MojeekWebResult
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.public_footprint.domain.search import (
+    SearchQueryTemplate,
+    SearchResultLead,
+    map_search_result_lead,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_RESULTS = 20
+
+
+class MojeekSearchAdapter:
+    source_id = "mojeek-web-search-metadata"
+    adapter_id = "mojeek-web-search"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[PublicWebTarget, ...],
+        templates: tuple[SearchQueryTemplate, ...],
+        entitlement: MojeekSearchEntitlement,
+        *,
+        token_provider: Callable[[], str | None],
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Mojeek adapter requires mojeek-web-search-metadata policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._pairs = tuple(
+            (target, template)
+            for target in targets
+            if target.enabled
+            for template in templates
+            if template.enabled
+        )
+        self._entitlement = entitlement
+        self._token_provider = token_provider
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        pair, next_index = _next_pair(self._pairs, checkpoint_payload)
+        if pair is None:
+            return _empty_batch()
+        target, template = pair
+        query = template.render(target.canonical_name)
+        target_url = self._entry.policy.base_url
+        _authorize(self._entry, target_url, template.purpose, collected_at)
+        if not self._entitlement.durable_storage_authorized:
+            raise AdapterExecutionError(
+                "Mojeek durable result storage entitlement is not authorized",
+                error_code="provider_storage_entitlement_missing",
+                retryable=False,
+            )
+        api_key = self._token_provider()
+        if api_key is None or not api_key.strip():
+            raise AdapterExecutionError(
+                "Mojeek provider secret is unavailable",
+                error_code="provider_not_connected",
+                retryable=False,
+            )
+        response = _request(
+            target_url,
+            query=query,
+            api_key=api_key.strip(),
+            timeout_seconds=self._timeout_seconds,
+            transport=self._transport,
+        )
+        try:
+            parsed = MojeekSearchResponse.model_validate_json(response)
+        except ValidationError as exc:
+            raise AdapterExecutionError(
+                "Mojeek response schema changed",
+                error_code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        if parsed.response.status.casefold() != "ok":
+            raise AdapterExecutionError(
+                "Mojeek provider returned a non-OK response status",
+                error_code="provider_response_error",
+                retryable=False,
+            )
+        results = tuple(
+            result for result in parsed.response.results[:_MAX_RESULTS] if _safe_result(result)
+        )
+        observations = tuple(
+            _observation(
+                result,
+                target=target,
+                template=template,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+                source_url=target_url,
+            )
+            for result in results
+        )
+        projections = tuple(
+            map_search_result_lead(
+                SearchResultLead(
+                    organization_id=target.organization_id,
+                    source_id=self.source_id,
+                    source_record_key=_record_key(query, result.url),
+                    target_url=result.url,
+                    title=result.title,
+                    snippet=result.desc[:1_000],
+                    rank=rank,
+                    observed_at=collected_at,
+                    query_template_id=template.id,
+                    query_template_version=template.version,
+                )
+            )
+            for rank, result in enumerate(results, start=1)
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            public_footprint_projections=projections,
+            checkpoint_payload={"pair_index": next_index},
+            not_modified=not results,
+        )
+
+
+def _authorize(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    purpose: str,
+    now: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=target_url,
+            purpose=purpose,
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def _request(
+    target_url: str,
+    *,
+    query: str,
+    api_key: str,
+    timeout_seconds: float,
+    transport: httpx.BaseTransport | None,
+) -> bytes:
+    try:
+        with httpx.Client(
+            timeout=timeout_seconds,
+            follow_redirects=False,
+            transport=transport,
+        ) as client:
+            response = client.get(
+                target_url,
+                headers={"Accept": "application/json"},
+                params={
+                    "api_key": api_key,
+                    "q": query,
+                    "t": _MAX_RESULTS,
+                    "fmt": "json",
+                },
+            )
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        raise AdapterExecutionError(
+            f"Mojeek Search returned HTTP {status}",
+            error_code=f"http_{status}",
+            retryable=status == 429 or status >= 500,
+        ) from exc
+    except (httpx.TimeoutException, httpx.TransportError) as exc:
+        raise AdapterExecutionError(
+            str(exc) or type(exc).__name__,
+            error_code="source_transport_error",
+            retryable=True,
+        ) from exc
+    if "json" not in response.headers.get("content-type", "").casefold():
+        raise AdapterExecutionError(
+            "Mojeek Search response is not JSON",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    if len(response.content) > _MAX_RESPONSE_BYTES:
+        raise AdapterExecutionError(
+            "Mojeek Search response exceeds size limit",
+            error_code="unsafe_source_response",
+            retryable=False,
+        )
+    return response.content
+
+
+def _safe_result(result: MojeekWebResult) -> bool:
+    parsed = urlsplit(result.url)
+    return parsed.scheme in {"http", "https"} and parsed.hostname is not None
+
+
+def _observation(
+    result: MojeekWebResult,
+    *,
+    target: PublicWebTarget,
+    template: SearchQueryTemplate,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    source_url: str,
+) -> RawObservation:
+    payload = result.model_dump_json(exclude_none=True).encode("utf-8")
+    query = template.render(target.canonical_name)
+    return RawObservation(
+        source_id=MojeekSearchAdapter.source_id,
+        adapter_id=MojeekSearchAdapter.adapter_id,
+        adapter_version=MojeekSearchAdapter.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="mojeek-search-result",
+        source_url=source_url,
+        payload_hash_sha256=sha256(payload).hexdigest(),
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        source_record_key=_record_key(query, result.url),
+        collected_at=collected_at,
+        retention_until=retention_until,
+        schema_fingerprint="mojeek-web-search:v1",
+    )
+
+
+def _record_key(query: str, result_url: str) -> str:
+    return sha256(f"{query}\0{result_url}".encode()).hexdigest()
+
+
+def _next_pair(
+    pairs: tuple[tuple[PublicWebTarget, SearchQueryTemplate], ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[tuple[PublicWebTarget, SearchQueryTemplate] | None, int]:
+    if not pairs:
+        return None, 0
+    value = 0 if payload is None else payload.get("pair_index", 0)
+    if not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            "invalid Mojeek Search checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(pairs)
+    return pairs[index], 0 if index + 1 >= len(pairs) else index + 1
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"pair_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/mojeek_search_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/mojeek_search_adapter.py
@@ -280,7 +280,7 @@ def _next_pair(
     if not pairs:
         return None, 0
     value = 0 if payload is None else payload.get("pair_index", 0)
-    if not isinstance(value, int) or value < 0:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise AdapterExecutionError(
             "invalid Mojeek Search checkpoint",
             error_code="invalid_checkpoint",

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -34,17 +34,13 @@ from cip.adapters.sources.vulnerability_catalogs.registry import load_vulnerabil
 from cip.adapters.sources.w3c_standards.registry import load_w3c_affiliation_targets
 from cip.modules.collection_orchestration.application.adapter_composition import (
     AdapterCompositionInputs,
-    RuntimeSecretProviders,
     build_runtime_adapters,
 )
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
-from cip.modules.collection_orchestration.application.provider_secret_supplier import (
-    connected_secret_supplier,
+from cip.modules.collection_orchestration.application.runtime_secret_providers import (
+    build_runtime_secret_providers,
 )
 from cip.modules.collection_orchestration.application.scheduler import schedule_due_jobs
-from cip.modules.collection_orchestration.application.search_archive_registration import (
-    SearchArchiveSecretProviders,
-)
 from cip.modules.collection_orchestration.application.worker import (
     WorkerOutcome,
     WorkerStatus,
@@ -108,45 +104,7 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         sync_source_portfolio(session, portfolio, now=synchronized_at)
     adapters = build_runtime_adapters(
         adapter_inputs,
-        RuntimeSecretProviders(
-            search_archives=SearchArchiveSecretProviders(
-                brave_token_provider=connected_secret_supplier(
-                    factory,
-                    source_id="brave-search-api",
-                    secret_name="api_token",
-                ),
-                github_code_search_token_provider=connected_secret_supplier(
-                    factory,
-                    source_id="github-code-search-metadata",
-                    secret_name="api_token",
-                ),
-                patentsview_api_key_provider=connected_secret_supplier(
-                    factory,
-                    source_id="patentsview-patent-metadata",
-                    secret_name="api_key",
-                ),
-                mojeek_api_key_provider=connected_secret_supplier(
-                    factory,
-                    source_id="mojeek-web-search-metadata",
-                    secret_name="api_key",
-                ),
-            ),
-            certspotter_token_provider=connected_secret_supplier(
-                factory,
-                source_id="certspotter-ct",
-                secret_name="api_token",
-            ),
-            phishtank_token_provider=connected_secret_supplier(
-                factory,
-                source_id="phishtank-verified-online",
-                secret_name="api_token",
-            ),
-            teamtailor_token_provider=connected_secret_supplier(
-                factory,
-                source_id="teamtailor-public-jobs",
-                secret_name="api_token",
-            ),
-        ),
+        build_runtime_secret_providers(factory),
         sec_user_agent=settings.sec_edgar_user_agent,
         phishtank_user_agent=settings.phishtank_user_agent,
         timeout_seconds=settings.source_http_timeout_seconds,

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -21,6 +21,7 @@ from cip.adapters.sources.github_code_search.registry import (
 from cip.adapters.sources.greenhouse.registry import load_greenhouse_boards
 from cip.adapters.sources.incident_catalogs.sec_registry import load_sec_incident_targets
 from cip.adapters.sources.lever.registry import load_lever_sites
+from cip.adapters.sources.mojeek_search.registry import load_mojeek_search_entitlement
 from cip.adapters.sources.organization_identity.registry import load_organization_identity_targets
 from cip.adapters.sources.passive_infrastructure.rdap_registry import load_rdap_targets
 from cip.adapters.sources.passive_infrastructure.registry import load_passive_infrastructure_targets
@@ -33,6 +34,7 @@ from cip.adapters.sources.vulnerability_catalogs.registry import load_vulnerabil
 from cip.adapters.sources.w3c_standards.registry import load_w3c_affiliation_targets
 from cip.modules.collection_orchestration.application.adapter_composition import (
     AdapterCompositionInputs,
+    RuntimeSecretProviders,
     build_runtime_adapters,
 )
 from cip.modules.collection_orchestration.application.ports import CollectionAdapter
@@ -40,6 +42,9 @@ from cip.modules.collection_orchestration.application.provider_secret_supplier i
     connected_secret_supplier,
 )
 from cip.modules.collection_orchestration.application.scheduler import schedule_due_jobs
+from cip.modules.collection_orchestration.application.search_archive_registration import (
+    SearchArchiveSecretProviders,
+)
 from cip.modules.collection_orchestration.application.worker import (
     WorkerOutcome,
     WorkerStatus,
@@ -103,35 +108,44 @@ def build_collection_runtime(settings: Settings) -> CollectionRuntime:
         sync_source_portfolio(session, portfolio, now=synchronized_at)
     adapters = build_runtime_adapters(
         adapter_inputs,
-        brave_token_provider=connected_secret_supplier(
-            factory,
-            source_id="brave-search-api",
-            secret_name="api_token",
-        ),
-        github_code_search_token_provider=connected_secret_supplier(
-            factory,
-            source_id="github-code-search-metadata",
-            secret_name="api_token",
-        ),
-        patentsview_api_key_provider=connected_secret_supplier(
-            factory,
-            source_id="patentsview-patent-metadata",
-            secret_name="api_key",
-        ),
-        certspotter_token_provider=connected_secret_supplier(
-            factory,
-            source_id="certspotter-ct",
-            secret_name="api_token",
-        ),
-        phishtank_token_provider=connected_secret_supplier(
-            factory,
-            source_id="phishtank-verified-online",
-            secret_name="api_token",
-        ),
-        teamtailor_token_provider=connected_secret_supplier(
-            factory,
-            source_id="teamtailor-public-jobs",
-            secret_name="api_token",
+        RuntimeSecretProviders(
+            search_archives=SearchArchiveSecretProviders(
+                brave_token_provider=connected_secret_supplier(
+                    factory,
+                    source_id="brave-search-api",
+                    secret_name="api_token",
+                ),
+                github_code_search_token_provider=connected_secret_supplier(
+                    factory,
+                    source_id="github-code-search-metadata",
+                    secret_name="api_token",
+                ),
+                patentsview_api_key_provider=connected_secret_supplier(
+                    factory,
+                    source_id="patentsview-patent-metadata",
+                    secret_name="api_key",
+                ),
+                mojeek_api_key_provider=connected_secret_supplier(
+                    factory,
+                    source_id="mojeek-web-search-metadata",
+                    secret_name="api_key",
+                ),
+            ),
+            certspotter_token_provider=connected_secret_supplier(
+                factory,
+                source_id="certspotter-ct",
+                secret_name="api_token",
+            ),
+            phishtank_token_provider=connected_secret_supplier(
+                factory,
+                source_id="phishtank-verified-online",
+                secret_name="api_token",
+            ),
+            teamtailor_token_provider=connected_secret_supplier(
+                factory,
+                source_id="teamtailor-public-jobs",
+                secret_name="api_token",
+            ),
         ),
         sec_user_agent=settings.sec_edgar_user_agent,
         phishtank_user_agent=settings.phishtank_user_agent,
@@ -231,6 +245,9 @@ def _load_adapter_inputs(
         ),
         w3c_affiliation_targets=load_w3c_affiliation_targets(
             settings.w3c_affiliation_target_registry_path
+        ),
+        mojeek_entitlement=load_mojeek_search_entitlement(
+            settings.mojeek_search_entitlement_registry_path
         ),
         vulnerability_targets=load_vulnerability_query_targets(
             settings.vulnerability_query_target_registry_path

--- a/src/cip/modules/collection_orchestration/application/runtime_secret_providers.py
+++ b/src/cip/modules/collection_orchestration/application/runtime_secret_providers.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from cip.modules.collection_orchestration.application.adapter_composition import (
+    RuntimeSecretProviders,
+)
+from cip.modules.collection_orchestration.application.provider_secret_supplier import (
+    connected_secret_supplier,
+)
+from cip.modules.collection_orchestration.application.search_archive_registration import (
+    SearchArchiveSecretProviders,
+)
+
+
+def build_runtime_secret_providers(
+    factory: sessionmaker[Session],
+) -> RuntimeSecretProviders:
+    return RuntimeSecretProviders(
+        search_archives=SearchArchiveSecretProviders(
+            brave_token_provider=connected_secret_supplier(
+                factory,
+                source_id="brave-search-api",
+                secret_name="api_token",
+            ),
+            github_code_search_token_provider=connected_secret_supplier(
+                factory,
+                source_id="github-code-search-metadata",
+                secret_name="api_token",
+            ),
+            patentsview_api_key_provider=connected_secret_supplier(
+                factory,
+                source_id="patentsview-patent-metadata",
+                secret_name="api_key",
+            ),
+            mojeek_api_key_provider=connected_secret_supplier(
+                factory,
+                source_id="mojeek-web-search-metadata",
+                secret_name="api_key",
+            ),
+        ),
+        certspotter_token_provider=connected_secret_supplier(
+            factory,
+            source_id="certspotter-ct",
+            secret_name="api_token",
+        ),
+        phishtank_token_provider=connected_secret_supplier(
+            factory,
+            source_id="phishtank-verified-online",
+            secret_name="api_token",
+        ),
+        teamtailor_token_provider=connected_secret_supplier(
+            factory,
+            source_id="teamtailor-public-jobs",
+            secret_name="api_token",
+        ),
+    )

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
 from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
+from cip.adapters.sources.mojeek_search.registry import MojeekSearchEntitlement
 from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.w3c_standards.registry import W3cAffiliationTarget
@@ -22,6 +23,9 @@ from cip.modules.collection_orchestration.application.crossref_publication_adapt
 )
 from cip.modules.collection_orchestration.application.github_code_search_adapter import (
     GitHubCodeSearchAdapter,
+)
+from cip.modules.collection_orchestration.application.mojeek_search_adapter import (
+    MojeekSearchAdapter,
 )
 from cip.modules.collection_orchestration.application.patentsview_patent_adapter import (
     PatentsViewPatentAdapter,
@@ -41,16 +45,23 @@ class SearchArchiveRegistrationInputs:
     crossref_publication_targets: tuple[CrossrefPublicationTarget, ...]
     patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...]
     w3c_affiliation_targets: tuple[W3cAffiliationTarget, ...]
+    mojeek_entitlement: MojeekSearchEntitlement
+
+
+@dataclass(frozen=True, slots=True)
+class SearchArchiveSecretProviders:
+    brave_token_provider: Callable[[], str | None]
+    github_code_search_token_provider: Callable[[], str | None]
+    patentsview_api_key_provider: Callable[[], str | None]
+    mojeek_api_key_provider: Callable[[], str | None]
 
 
 def register_search_archive_adapters(
     adapters: dict[tuple[str, str], CollectionAdapter],
     entries_by_id: dict[str, SourceRegistryEntry],
     inputs: SearchArchiveRegistrationInputs,
+    secrets: SearchArchiveSecretProviders,
     *,
-    brave_token_provider: Callable[[], str | None],
-    github_code_search_token_provider: Callable[[], str | None],
-    patentsview_api_key_provider: Callable[[], str | None],
     timeout_seconds: float,
 ) -> None:
     brave_entry = entries_by_id.get(BraveSearchAdapter.source_id)
@@ -61,7 +72,21 @@ def register_search_archive_adapters(
                 brave_entry,
                 inputs.public_web_targets,
                 inputs.search_templates,
-                token_provider=brave_token_provider,
+                token_provider=secrets.brave_token_provider,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    mojeek_entry = entries_by_id.get(MojeekSearchAdapter.source_id)
+    if mojeek_entry is not None:
+        _register(
+            adapters,
+            MojeekSearchAdapter(
+                mojeek_entry,
+                inputs.public_web_targets,
+                inputs.search_templates,
+                inputs.mojeek_entitlement,
+                token_provider=secrets.mojeek_api_key_provider,
                 timeout_seconds=timeout_seconds,
             ),
         )
@@ -96,7 +121,7 @@ def register_search_archive_adapters(
                 github_code_entry,
                 inputs.developer_targets,
                 inputs.github_code_search_templates,
-                token_provider=github_code_search_token_provider,
+                token_provider=secrets.github_code_search_token_provider,
                 timeout_seconds=timeout_seconds,
             ),
         )
@@ -119,7 +144,7 @@ def register_search_archive_adapters(
             PatentsViewPatentAdapter(
                 patentsview_entry,
                 inputs.patentsview_patent_targets,
-                token_provider=patentsview_api_key_provider,
+                token_provider=secrets.patentsview_api_key_provider,
                 timeout_seconds=timeout_seconds,
             ),
         )

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -129,6 +129,9 @@ class Settings(BaseSettings):
     w3c_affiliation_target_registry_path: Path = Path(
         "policies/w3c_affiliation_targets.yml"
     )
+    mojeek_search_entitlement_registry_path: Path = Path(
+        "policies/mojeek_search_entitlement.yml"
+    )
     vulnerability_query_target_registry_path: Path = Path(
         "policies/vulnerability_query_targets.yml"
     )

--- a/tests/unit/collection_orchestration/test_mojeek_search_adapter.py
+++ b/tests/unit/collection_orchestration/test_mojeek_search_adapter.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.mojeek_search.registry import (
+    MojeekSearchEntitlement,
+    load_mojeek_search_entitlement,
+)
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.mojeek_search_adapter import (
+    MojeekSearchAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 11, 15, 25, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=90)
+ORG_ID = UUID("74b2a087-10ce-5d99-a90c-5aa1c0fabf6f")
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+ENTITLEMENT_PATH = Path("policies/mojeek_search_entitlement.yml")
+
+
+def test_checked_in_mojeek_entitlement_is_fail_closed() -> None:
+    entitlement = load_mojeek_search_entitlement(ENTITLEMENT_PATH)
+    assert entitlement.durable_storage_authorized is False
+    assert entitlement.plan == "unprovisioned"
+    assert entitlement.evidence_reference is None
+
+
+def test_mojeek_empty_target_uses_no_entitlement_secret_or_network() -> None:
+    token_calls = 0
+
+    def token_provider() -> str:
+        nonlocal token_calls
+        token_calls += 1
+        return "secret"
+
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without enabled target")
+
+    batch = _collect(
+        MojeekSearchAdapter(
+            _entry(),
+            (_target(enabled=False),),
+            (_template(),),
+            _entitlement(authorized=False),
+            token_provider=token_provider,
+            transport=httpx.MockTransport(fail_network),
+        )
+    )
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert token_calls == 0
+
+
+def test_mojeek_missing_storage_entitlement_stops_before_secret_and_network() -> None:
+    token_calls = 0
+
+    def token_provider() -> str:
+        nonlocal token_calls
+        token_calls += 1
+        return "secret"
+
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        raise AssertionError("network must not be used without storage entitlement")
+
+    adapter = MojeekSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        _entitlement(authorized=False),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(fail_network),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "provider_storage_entitlement_missing"
+    assert exc_info.value.retryable is False
+    assert token_calls == 0
+
+
+def test_mojeek_missing_secret_stops_before_network() -> None:
+    adapter = MojeekSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        _entitlement(),
+        token_provider=lambda: None,
+        transport=httpx.MockTransport(
+            lambda _request: (_ for _ in ()).throw(
+                AssertionError("network must not be used without provider secret")
+            )
+        ),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "provider_not_connected"
+    assert exc_info.value.retryable is False
+
+
+def test_mojeek_maps_bounded_safe_result_metadata_only() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "response": {
+                    "status": "OK",
+                    "head": {"ignored": True},
+                    "results": [
+                        {
+                            "url": "https://example.com/security",
+                            "title": "Example security",
+                            "desc": "Public search snippet",
+                            "score": 999,
+                            "image": {"url": "https://images.example/image.jpg"},
+                        },
+                        {
+                            "url": "javascript:alert(1)",
+                            "title": "Unsafe",
+                            "desc": "discard me",
+                        },
+                    ],
+                }
+            },
+            request=request,
+        )
+
+    batch = _collect(
+        MojeekSearchAdapter(
+            _entry(),
+            (_target(),),
+            (_template(),),
+            _entitlement(),
+            token_provider=lambda: "provider-key",
+            transport=httpx.MockTransport(handler),
+        )
+    )
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.path == "/search"
+    assert request.url.params["api_key"] == "provider-key"
+    assert request.url.params["q"] == '"Example Corp" security'
+    assert request.url.params["t"] == "20"
+    assert request.url.params["fmt"] == "json"
+    assert len(batch.observations) == 1
+    assert len(batch.public_footprint_projections) == 1
+    projection = batch.public_footprint_projections[0]
+    assert projection.claims == ()
+    assert projection.resource.canonical_url == "https://example.com/security"
+    assert projection.resource.retrieval_state.value == "quarantined"
+    assert projection.version.excerpt == "Public search snippet"
+    assert "provider-key" not in batch.observations[0].source_url
+
+
+def test_mojeek_checkpoint_schema_drift_provider_status_and_429_fail_closed() -> None:
+    adapter = MojeekSearchAdapter(
+        _entry(),
+        (_target(),),
+        (_template(),),
+        _entitlement(),
+        token_provider=lambda: "key",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+    )
+    with pytest.raises(AdapterExecutionError) as checkpoint_info:
+        _collect(adapter, checkpoint_payload={"pair_index": True})
+    assert checkpoint_info.value.error_code == "invalid_checkpoint"
+
+    def malformed(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=b"not-json",
+            request=request,
+        )
+
+    with pytest.raises(AdapterExecutionError) as schema_info:
+        _collect(
+            MojeekSearchAdapter(
+                _entry(),
+                (_target(),),
+                (_template(),),
+                _entitlement(),
+                token_provider=lambda: "key",
+                transport=httpx.MockTransport(malformed),
+            )
+        )
+    assert schema_info.value.error_code == "source_schema_drift"
+
+    def provider_error(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"response": {"status": "ERROR: Daily Limit Reached", "results": []}},
+            request=request,
+        )
+
+    with pytest.raises(AdapterExecutionError) as provider_info:
+        _collect(
+            MojeekSearchAdapter(
+                _entry(),
+                (_target(),),
+                (_template(),),
+                _entitlement(),
+                token_provider=lambda: "key",
+                transport=httpx.MockTransport(provider_error),
+            )
+        )
+    assert provider_info.value.error_code == "provider_response_error"
+
+    def rate_limited(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(429, request=request)
+
+    with pytest.raises(AdapterExecutionError) as rate_info:
+        _collect(
+            MojeekSearchAdapter(
+                _entry(),
+                (_target(),),
+                (_template(),),
+                _entitlement(),
+                token_provider=lambda: "key",
+                transport=httpx.MockTransport(rate_limited),
+            )
+        )
+    assert rate_info.value.error_code == "http_429"
+    assert rate_info.value.retryable is True
+
+
+def test_mojeek_authorized_entitlement_requires_evidence() -> None:
+    with pytest.raises(ValueError, match="evidence reference"):
+        MojeekSearchEntitlement(
+            durable_storage_authorized=True,
+            plan="business",
+            evidence_reference=None,
+        )
+
+
+def _entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == "mojeek-web-search-metadata"
+    )
+
+
+def _target(*, enabled: bool = True) -> PublicWebTarget:
+    return PublicWebTarget(
+        id="example-corp",
+        organization_id=ORG_ID,
+        canonical_name="Example Corp",
+        base_url="https://example.com/",
+        sitemap_urls=("https://example.com/sitemap.xml",),
+        allowed_path_prefixes=("/",),
+        enabled=enabled,
+        authorization_reference="controlled-test-target",
+        authorization_reviewed_at=NOW,
+    )
+
+
+def _template() -> SearchQueryTemplate:
+    return SearchQueryTemplate(
+        id="security-context",
+        version=1,
+        query_pattern='"{organization}" security',
+        purpose="corporate-public-footprint",
+        enabled=True,
+    )
+
+
+def _entitlement(*, authorized: bool = True) -> MojeekSearchEntitlement:
+    return MojeekSearchEntitlement(
+        durable_storage_authorized=authorized,
+        plan="business" if authorized else "unprovisioned",
+        evidence_reference="controlled-test-entitlement" if authorized else None,
+    )
+
+
+def _collect(
+    adapter: MojeekSearchAdapter,
+    *,
+    checkpoint_payload: dict[str, object] | None = None,
+):
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint_payload,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )

--- a/tests/unit/provider_onboarding/test_provider_registry.py
+++ b/tests/unit/provider_onboarding/test_provider_registry.py
@@ -13,7 +13,7 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     profiles = load_provider_profiles(Path("policies/provider_onboarding.yml"))
     by_source = {profile.source_id: profile for profile in profiles}
 
-    assert len(profiles) == 25
+    assert len(profiles) == 26
     assert by_source["cisa-kev"].initial_state is OnboardingState.CONNECTED
     assert by_source["ashby-job-board"].auth_mode is AuthMode.NONE
     assert by_source["ashby-job-board"].initial_state is OnboardingState.CONNECTED
@@ -41,6 +41,13 @@ def test_repository_provider_catalog_has_safe_defaults() -> None:
     )
     assert (
         by_source["patentsview-patent-metadata"].initial_state
+        is OnboardingState.NOT_CONFIGURED
+    )
+    assert by_source["mojeek-web-search-metadata"].auth_mode is AuthMode.API_KEY
+    assert by_source["mojeek-web-search-metadata"].required_secret_names == ("api_key",)
+    assert by_source["mojeek-web-search-metadata"].automatic_onboarding is False
+    assert (
+        by_source["mojeek-web-search-metadata"].initial_state
         is OnboardingState.NOT_CONFIGURED
     )
     assert by_source["internet-archive-cdx"].initial_state is OnboardingState.CONNECTED


### PR DESCRIPTION
Sixth implementation tranche for issue #108.

Implemented scope:
- real Mojeek Web Search API adapter for `https://api.mojeek.com/search`;
- bounded JSON result mapping: URL/title/query-dependent snippet/rank only, max 20, no redirects, 2 MiB response bound;
- existing explicit public-web organization targets + governed search-query templates reused;
- Provider Onboarding `api_key` secret through the existing `connected_secret_supplier` boundary;
- separate fail-closed Mojeek storage-entitlement registry because a working credential is not equivalent to durable-storage permission;
- checked-in entitlement defaults to `durable_storage_authorized: false` and cannot be enabled without evidence reference;
- adapter gate order ensures missing durable-storage authorization stops before secret retrieval and before network;
- third-party page bodies, images and provider score fields are never materialized;
- unsafe non-HTTP(S) result URLs are discarded;
- immutable RawObservation + quarantined Lot 12 SearchResultLead projection, zero automatic claims/signals/needs/opportunities/outreach;
- runtime composition refactored to immutable `SearchArchiveSecretProviders` / `RuntimeSecretProviders`; secret construction is isolated in `runtime_secret_providers.py`, keeping runtime modules within hard architecture limits;
- Source Governance, portfolio, Provider Onboarding, disabled-by-default schedule and Source Activation wired;
- Source Activation intentionally stops at `executable`: no `live_tested`, no `scheduled`;
- deterministic tests cover no target/no secret/no entitlement network suppression, exact request shape, minimization, unsafe URL filtering, checkpoint/schema/provider-status/429 handling and entitlement evidence validation;
- provider catalogue contract updated to include Mojeek with safe NOT_CONFIGURED defaults.

External dependency remains explicit:
- legitimate Mojeek API key required;
- reviewed durable-storage entitlement required;
- a trial credential without durable-storage rights MUST NOT be used to claim `live_tested`;
- no live provider validation was run or claimed in this PR.

Final exact merge candidate: `47c9efeabe1206bfb8c008b85d05ac86e5409da7`.

Validation on this exact SHA:
- frontend dependency audit/typecheck/production build: PASS;
- Python dependency consistency and pip-audit: PASS, no known vulnerabilities;
- Ruff: PASS;
- strict Mypy: PASS on 672 source files;
- architecture/release contracts: 36 PASS;
- reversible Alembic `upgrade -> downgrade base -> upgrade`: PASS;
- complete pytest: 1385 PASS;
- branch-aware coverage: 90.04% (required threshold unchanged at 90%);
- reviews: none;
- review threads: none;
- SA-14 live workflow: intentionally skipped; this is not live proof.

Issue #108 remains open. Follow-up work remains: exact Mojeek live proof once legitimate API/storage entitlements exist, PatentsView live proof once legitimate key issuance is available, and GDELT only against a verified current GDELT 5 contract.