### PR TITLE
SA15-L01: normalize multi-provider SERP discovery

### DIFF
--- a/src/cip/modules/public_footprint/domain/__init__.py
+++ b/src/cip/modules/public_footprint/domain/__init__.py
@@ -23,6 +23,14 @@ from cip.modules.public_footprint.domain.search import (
     SearchResultLead,
     map_search_result_lead,
 )
+from cip.modules.public_footprint.domain.search_core import (
+    SearchAcquisitionState,
+    SearchDiscoveryCandidate,
+    SearchProviderExecution,
+    SearchProviderHit,
+    SearchQueryPlan,
+    normalize_search_executions,
+)
 from cip.modules.public_footprint.domain.url_identity import (
     CanonicalUrl,
     canonicalize_url,
@@ -46,10 +54,16 @@ __all__ = [
     "PublicResourceVersion",
     "ResourceAccessState",
     "ResourceRetrievalState",
+    "SearchAcquisitionState",
+    "SearchDiscoveryCandidate",
     "SearchLeadClaim",
+    "SearchProviderExecution",
+    "SearchProviderHit",
+    "SearchQueryPlan",
     "SearchQueryTemplate",
     "SearchResultLead",
     "canonicalize_url",
     "map_search_result_lead",
+    "normalize_search_executions",
     "same_origin",
 ]

--- a/src/cip/modules/public_footprint/domain/search_core.py
+++ b/src/cip/modules/public_footprint/domain/search_core.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate, SearchResultLead
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+from cip.shared.kernel.time import require_aware_utc
+
+
+class SearchAcquisitionState(StrEnum):
+    UNROUTED = "unrouted"
+
+
+@dataclass(frozen=True, slots=True)
+class SearchQueryPlan:
+    organization_id: UUID
+    organization_name: str
+    template_id: str
+    template_version: int
+    purpose: str
+    rendered_query: str
+    provider_ids: tuple[str, ...]
+    created_at: datetime
+
+    def __post_init__(self) -> None:
+        organization_name = _required_text(
+            self.organization_name,
+            field_name="organization_name",
+            max_length=300,
+        )
+        template_id = _required_text(
+            self.template_id,
+            field_name="template_id",
+            max_length=100,
+        )
+        purpose = _required_text(self.purpose, field_name="purpose", max_length=200)
+        query = _required_text(
+            self.rendered_query,
+            field_name="rendered_query",
+            max_length=500,
+        )
+        if self.template_version < 1:
+            raise ValueError("search query template version must be positive")
+        providers = _normalized_provider_ids(self.provider_ids)
+        created_at = require_aware_utc(self.created_at, field_name="created_at")
+        object.__setattr__(self, "organization_name", organization_name)
+        object.__setattr__(self, "template_id", template_id)
+        object.__setattr__(self, "purpose", purpose)
+        object.__setattr__(self, "rendered_query", query)
+        object.__setattr__(self, "provider_ids", providers)
+        object.__setattr__(self, "created_at", created_at)
+
+    @classmethod
+    def from_template(
+        cls,
+        *,
+        organization_id: UUID,
+        organization_name: str,
+        template: SearchQueryTemplate,
+        provider_ids: tuple[str, ...],
+        created_at: datetime,
+    ) -> SearchQueryPlan:
+        if not template.enabled:
+            raise ValueError("search query template must be enabled before execution")
+        return cls(
+            organization_id=organization_id,
+            organization_name=organization_name,
+            template_id=template.id,
+            template_version=template.version,
+            purpose=template.purpose,
+            rendered_query=template.render(organization_name),
+            provider_ids=provider_ids,
+            created_at=created_at,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SearchProviderExecution:
+    provider_id: str
+    organization_id: UUID
+    rendered_query: str
+    query_template_id: str
+    query_template_version: int
+    executed_at: datetime
+    results: tuple[SearchResultLead, ...]
+
+    def __post_init__(self) -> None:
+        provider_id = _required_text(
+            self.provider_id,
+            field_name="provider_id",
+            max_length=100,
+        ).casefold()
+        rendered_query = _required_text(
+            self.rendered_query,
+            field_name="rendered_query",
+            max_length=500,
+        )
+        template_id = _required_text(
+            self.query_template_id,
+            field_name="query_template_id",
+            max_length=100,
+        )
+        if self.query_template_version < 1:
+            raise ValueError("search query template version must be positive")
+        executed_at = require_aware_utc(self.executed_at, field_name="executed_at")
+        if any(result.organization_id != self.organization_id for result in self.results):
+            raise ValueError("search execution results must share the organization")
+        if any(result.source_id.casefold() != provider_id for result in self.results):
+            raise ValueError("search execution results must share the provider source id")
+        if any(result.query_template_id != template_id for result in self.results):
+            raise ValueError("search execution results must share the query template id")
+        if any(
+            result.query_template_version != self.query_template_version
+            for result in self.results
+        ):
+            raise ValueError("search execution results must share the query template version")
+        object.__setattr__(self, "provider_id", provider_id)
+        object.__setattr__(self, "rendered_query", rendered_query)
+        object.__setattr__(self, "query_template_id", template_id)
+        object.__setattr__(self, "executed_at", executed_at)
+
+
+@dataclass(frozen=True, slots=True)
+class SearchProviderHit:
+    provider_id: str
+    source_record_key: str
+    rank: int
+    observed_at: datetime
+    title: str
+    snippet: str
+    rendered_query: str
+    query_template_id: str
+    query_template_version: int
+
+    def __post_init__(self) -> None:
+        provider_id = _required_text(
+            self.provider_id,
+            field_name="provider_id",
+            max_length=100,
+        ).casefold()
+        record_key = _required_text(
+            self.source_record_key,
+            field_name="source_record_key",
+            max_length=500,
+        )
+        title = _required_text(self.title, field_name="title", max_length=1_000)
+        snippet = _required_text(self.snippet, field_name="snippet", max_length=1_000)
+        rendered_query = _required_text(
+            self.rendered_query,
+            field_name="rendered_query",
+            max_length=500,
+        )
+        template_id = _required_text(
+            self.query_template_id,
+            field_name="query_template_id",
+            max_length=100,
+        )
+        if not 1 <= self.rank <= 1_000:
+            raise ValueError("search result rank must be between 1 and 1000")
+        if self.query_template_version < 1:
+            raise ValueError("search query template version must be positive")
+        observed_at = require_aware_utc(self.observed_at, field_name="observed_at")
+        object.__setattr__(self, "provider_id", provider_id)
+        object.__setattr__(self, "source_record_key", record_key)
+        object.__setattr__(self, "title", title)
+        object.__setattr__(self, "snippet", snippet)
+        object.__setattr__(self, "rendered_query", rendered_query)
+        object.__setattr__(self, "query_template_id", template_id)
+        object.__setattr__(self, "observed_at", observed_at)
+
+
+@dataclass(frozen=True, slots=True)
+class SearchDiscoveryCandidate:
+    organization_id: UUID
+    target_url: str
+    title: str
+    snippet: str
+    purpose: str
+    provider_hits: tuple[SearchProviderHit, ...]
+    acquisition_state: SearchAcquisitionState = SearchAcquisitionState.UNROUTED
+
+    def __post_init__(self) -> None:
+        target_url = CanonicalUrl(self.target_url).value
+        title = _required_text(self.title, field_name="title", max_length=1_000)
+        snippet = _required_text(self.snippet, field_name="snippet", max_length=1_000)
+        purpose = _required_text(self.purpose, field_name="purpose", max_length=200)
+        if not self.provider_hits:
+            raise ValueError("search discovery candidate requires provider provenance")
+        provider_hits = tuple(sorted(self.provider_hits, key=_hit_sort_key))
+        object.__setattr__(self, "target_url", target_url)
+        object.__setattr__(self, "title", title)
+        object.__setattr__(self, "snippet", snippet)
+        object.__setattr__(self, "purpose", purpose)
+        object.__setattr__(self, "provider_hits", provider_hits)
+
+    @property
+    def provider_count(self) -> int:
+        return len({hit.provider_id for hit in self.provider_hits})
+
+    @property
+    def best_rank(self) -> int:
+        return min(hit.rank for hit in self.provider_hits)
+
+
+def normalize_search_executions(
+    plan: SearchQueryPlan,
+    executions: tuple[SearchProviderExecution, ...],
+) -> tuple[SearchDiscoveryCandidate, ...]:
+    _validate_executions(plan, executions)
+    grouped: dict[str, list[SearchProviderHit]] = {}
+    for execution in executions:
+        for result in execution.results:
+            canonical_url = CanonicalUrl(result.target_url).value
+            grouped.setdefault(canonical_url, []).append(_provider_hit(execution, result))
+    candidates = tuple(
+        _candidate_from_hits(plan, target_url, tuple(hits))
+        for target_url, hits in grouped.items()
+    )
+    return tuple(sorted(candidates, key=_candidate_sort_key))
+
+
+def _validate_executions(
+    plan: SearchQueryPlan,
+    executions: tuple[SearchProviderExecution, ...],
+) -> None:
+    provider_ids = [execution.provider_id for execution in executions]
+    if len(provider_ids) != len(set(provider_ids)):
+        raise ValueError("search plan accepts at most one execution per provider")
+    unknown = set(provider_ids) - set(plan.provider_ids)
+    if unknown:
+        raise ValueError("search execution provider is not part of the query plan")
+    for execution in executions:
+        if execution.organization_id != plan.organization_id:
+            raise ValueError("search execution organization does not match the query plan")
+        if execution.rendered_query != plan.rendered_query:
+            raise ValueError("search execution query does not match the query plan")
+        if execution.query_template_id != plan.template_id:
+            raise ValueError("search execution template does not match the query plan")
+        if execution.query_template_version != plan.template_version:
+            raise ValueError("search execution template version does not match the query plan")
+
+
+def _provider_hit(
+    execution: SearchProviderExecution,
+    result: SearchResultLead,
+) -> SearchProviderHit:
+    return SearchProviderHit(
+        provider_id=execution.provider_id,
+        source_record_key=result.source_record_key,
+        rank=result.rank,
+        observed_at=result.observed_at,
+        title=result.title,
+        snippet=result.snippet,
+        rendered_query=execution.rendered_query,
+        query_template_id=execution.query_template_id,
+        query_template_version=execution.query_template_version,
+    )
+
+
+def _candidate_from_hits(
+    plan: SearchQueryPlan,
+    target_url: str,
+    hits: tuple[SearchProviderHit, ...],
+) -> SearchDiscoveryCandidate:
+    ordered_hits = tuple(sorted(hits, key=_hit_sort_key))
+    representative = ordered_hits[0]
+    return SearchDiscoveryCandidate(
+        organization_id=plan.organization_id,
+        target_url=target_url,
+        title=representative.title,
+        snippet=representative.snippet,
+        purpose=plan.purpose,
+        provider_hits=ordered_hits,
+    )
+
+
+def _hit_sort_key(hit: SearchProviderHit) -> tuple[int, str, str]:
+    return (hit.rank, hit.provider_id, hit.source_record_key)
+
+
+def _candidate_sort_key(candidate: SearchDiscoveryCandidate) -> tuple[int, str]:
+    return (candidate.best_rank, candidate.target_url)
+
+
+def _normalized_provider_ids(values: tuple[str, ...]) -> tuple[str, ...]:
+    providers = tuple(
+        dict.fromkeys(
+            _required_text(value, field_name="provider_id", max_length=100).casefold()
+            for value in values
+        )
+    )
+    if not providers:
+        raise ValueError("search query plan requires at least one provider")
+    if len(providers) != len(values):
+        raise ValueError("search query plan provider ids must be unique")
+    return providers
+
+
+def _required_text(value: str, *, field_name: str, max_length: int) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    if len(normalized) > max_length:
+        raise ValueError(f"{field_name} cannot exceed {max_length} characters")
+    return normalized

--- a/tests/test_search_serp_core.py
+++ b/tests/test_search_serp_core.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+
+from cip.modules.public_footprint.domain import (
+    SearchAcquisitionState,
+    SearchProviderExecution,
+    SearchQueryPlan,
+    SearchQueryTemplate,
+    SearchResultLead,
+    normalize_search_executions,
+)
+
+NOW = datetime(2026, 8, 11, 20, 0, tzinfo=UTC)
+ORGANIZATION_ID = UUID("00000000-0000-0000-0000-000000001501")
+
+
+def test_query_plan_requires_an_enabled_template_and_unique_providers() -> None:
+    disabled = _template(enabled=False)
+
+    with pytest.raises(ValueError, match="enabled"):
+        SearchQueryPlan.from_template(
+            organization_id=ORGANIZATION_ID,
+            organization_name="Example Corp",
+            template=disabled,
+            provider_ids=("brave-web-search",),
+            created_at=NOW,
+        )
+
+    with pytest.raises(ValueError, match="unique"):
+        SearchQueryPlan.from_template(
+            organization_id=ORGANIZATION_ID,
+            organization_name="Example Corp",
+            template=_template(),
+            provider_ids=("brave-web-search", "BRAVE-WEB-SEARCH"),
+            created_at=NOW,
+        )
+
+
+def test_normalization_deduplicates_canonical_url_and_preserves_each_provider_hit() -> None:
+    plan = _plan()
+    brave = SearchProviderExecution(
+        provider_id="brave-web-search",
+        organization_id=ORGANIZATION_ID,
+        rendered_query=plan.rendered_query,
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+        executed_at=NOW,
+        results=(
+            _lead(
+                provider="brave-web-search",
+                key="brave-1",
+                url="https://Example.com:443/security?a=1&b=2#section",
+                rank=2,
+                title="Example security page from Brave",
+            ),
+        ),
+    )
+    mojeek = SearchProviderExecution(
+        provider_id="mojeek-web-search-metadata",
+        organization_id=ORGANIZATION_ID,
+        rendered_query=plan.rendered_query,
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+        executed_at=NOW + timedelta(seconds=1),
+        results=(
+            _lead(
+                provider="mojeek-web-search-metadata",
+                key="mojeek-7",
+                url="https://example.com/security?b=2&a=1",
+                rank=1,
+                title="Example security page from Mojeek",
+            ),
+            _lead(
+                provider="mojeek-web-search-metadata",
+                key="mojeek-8",
+                url="https://example.com/architecture",
+                rank=4,
+                title="Example architecture",
+            ),
+        ),
+    )
+
+    candidates = normalize_search_executions(plan, (brave, mojeek))
+
+    assert len(candidates) == 2
+    shared = candidates[0]
+    assert shared.target_url == "https://example.com/security?a=1&b=2"
+    assert shared.title == "Example security page from Mojeek"
+    assert shared.best_rank == 1
+    assert shared.provider_count == 2
+    assert [hit.provider_id for hit in shared.provider_hits] == [
+        "mojeek-web-search-metadata",
+        "brave-web-search",
+    ]
+    assert {hit.source_record_key for hit in shared.provider_hits} == {
+        "brave-1",
+        "mojeek-7",
+    }
+    assert shared.acquisition_state is SearchAcquisitionState.UNROUTED
+    assert candidates[1].target_url == "https://example.com/architecture"
+
+
+def test_normalization_rejects_execution_outside_plan_or_with_wrong_query() -> None:
+    plan = _plan()
+    outside_provider = SearchProviderExecution(
+        provider_id="unplanned-search",
+        organization_id=ORGANIZATION_ID,
+        rendered_query=plan.rendered_query,
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+        executed_at=NOW,
+        results=(),
+    )
+    wrong_query = SearchProviderExecution(
+        provider_id="brave-web-search",
+        organization_id=ORGANIZATION_ID,
+        rendered_query="different query",
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+        executed_at=NOW,
+        results=(),
+    )
+
+    with pytest.raises(ValueError, match="not part"):
+        normalize_search_executions(plan, (outside_provider,))
+    with pytest.raises(ValueError, match="query does not match"):
+        normalize_search_executions(plan, (wrong_query,))
+
+
+def test_execution_rejects_provider_or_template_mismatch_in_results() -> None:
+    plan = _plan()
+
+    with pytest.raises(ValueError, match="provider source id"):
+        SearchProviderExecution(
+            provider_id="brave-web-search",
+            organization_id=ORGANIZATION_ID,
+            rendered_query=plan.rendered_query,
+            query_template_id=plan.template_id,
+            query_template_version=plan.template_version,
+            executed_at=NOW,
+            results=(
+                _lead(
+                    provider="mojeek-web-search-metadata",
+                    key="wrong-provider",
+                    url="https://example.com/security",
+                    rank=1,
+                    title="Wrong provider",
+                ),
+            ),
+        )
+
+
+def test_duplicate_execution_for_same_provider_is_rejected() -> None:
+    plan = _plan()
+    execution = SearchProviderExecution(
+        provider_id="brave-web-search",
+        organization_id=ORGANIZATION_ID,
+        rendered_query=plan.rendered_query,
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+        executed_at=NOW,
+        results=(),
+    )
+
+    with pytest.raises(ValueError, match="at most one execution"):
+        normalize_search_executions(plan, (execution, execution))
+
+
+def _plan() -> SearchQueryPlan:
+    return SearchQueryPlan.from_template(
+        organization_id=ORGANIZATION_ID,
+        organization_name="Example Corp",
+        template=_template(),
+        provider_ids=("brave-web-search", "mojeek-web-search-metadata"),
+        created_at=NOW,
+    )
+
+
+def _template(*, enabled: bool = True) -> SearchQueryTemplate:
+    return SearchQueryTemplate(
+        id="organization-security-footprint",
+        version=3,
+        query_pattern='"{organization}" security architecture',
+        purpose="corporate-public-footprint",
+        enabled=enabled,
+    )
+
+
+def _lead(
+    *,
+    provider: str,
+    key: str,
+    url: str,
+    rank: int,
+    title: str,
+) -> SearchResultLead:
+    return SearchResultLead(
+        organization_id=ORGANIZATION_ID,
+        source_id=provider,
+        source_record_key=key,
+        target_url=url,
+        title=title,
+        snippet="Search metadata only; original content has not been retrieved.",
+        rank=rank,
+        observed_at=NOW,
+        query_template_id="organization-security-footprint",
+        query_template_version=3,
+    )


### PR DESCRIPTION
Implements SA15-L01 as a provider-neutral layer on top of the existing `public_footprint` search primitives.

Scope:
- `SearchQueryPlan` built only from an enabled, versioned `SearchQueryTemplate`;
- explicit provider set and rendered query captured in the plan;
- `SearchProviderExecution` contract that fails closed on organization/provider/query/template mismatches;
- canonical URL normalization and cross-provider deduplication;
- `SearchDiscoveryCandidate` preserving every provider hit, record key, rank, timestamp, query/template provenance;
- deterministic representative selection and ordering;
- explicit `UNROUTED` acquisition state so SERP metadata cannot silently become Evidence, a CommercialSignal, or an acquired public resource;
- deterministic unit tests for canonicalization, multi-provider provenance, mismatches and duplicate executions.

This PR is draft until exact-head CI is green. SA15-L05 (Internet Archive live/archival acquisition) and SA15-L09 (acquisition routing/consolidation) will build on this core only after L01 passes its own gate.