### PR TITLE
SA15-L05/L09: live Internet Archive CDX and governed SERP routing

### DIFF
--- a/.github/workflows/sa15-live-validation.yml
+++ b/.github/workflows/sa15-live-validation.yml
@@ -1,0 +1,33 @@
+name: SA-15 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa15-live-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-internet-archive-cdx:
+    if: github.event.pull_request.head.ref == 'agent/sa15-l05-l09-cdx-routing'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled Internet Archive CDX production-adapter live validation
+        run: python scripts/live_validate_sa15_cdx.py

--- a/docs/source_activation/SA_15_L05_L09_CDX_ROUTING.md
+++ b/docs/source_activation/SA_15_L05_L09_CDX_ROUTING.md
@@ -1,0 +1,90 @@
+# SA-15 L05/L09 — Internet Archive CDX and governed SERP acquisition routing
+
+## Status
+
+Implemented for SA15-L05 and SA15-L09. Merge is permitted only after the exact final PR head passes both the normal repository CI and the dedicated `SA-15 Live Validation` provider workflow.
+
+A skipped live job is never provider proof.
+
+## SA15-L05 — Internet Archive CDX
+
+### Production path
+
+CIP reuses the production `InternetArchiveCdxAdapter` introduced during SA-02 rather than creating a validation-only provider implementation.
+
+The governed source remains `internet-archive-cdx` at `https://web.archive.org/cdx/search/cdx`. Collection is bounded to CDX index metadata and keeps archived page-body retrieval outside this source path.
+
+The adapter requests only:
+
+- capture timestamp;
+- original URL;
+- MIME type;
+- HTTP status code;
+- digest;
+- archived length.
+
+The result remains a quarantined `ARCHIVE_SNAPSHOT` with zero automatic claims. Historical presence is not treated as current deployment, current vulnerability, current commercial need, or outreach authority.
+
+### Controlled live target
+
+The dedicated SA-15 live workflow executes the real production adapter against an exact first-party Internet Archive URL:
+
+`https://archive.org/about/terms.php`
+
+The exact URL is intentionally narrower than a host/prefix crawl so the provider proof tests the production CDX contract without turning the validation job into bulk archive enumeration.
+
+The live gate requires:
+
+- at least one and at most 50 real CDX observations;
+- one quarantined archive projection per observation;
+- zero claims;
+- zero archived-body retrieval;
+- preserved Wayback capture provenance;
+- a converged single-target checkpoint.
+
+The initial broad root-URL validation attempt was not accepted as proof because the provider request exceeded its original 30-second network window. The validation target was narrowed to the exact first-party URL and the controlled provider run then succeeded. The final merge candidate must repeat that success on its exact final SHA after all activation/documentation changes.
+
+### Activation truth
+
+`internet-archive-cdx` may carry `live_tested` only while an exact-head real-provider run of `scripts/live_validate_sa15_cdx.py` succeeds. The checked-in activation inventory now records this stage and a deterministic regression test prevents entitlement-gated Brave, Mojeek and PatentsView sources from being promoted by association.
+
+## SA15-L09 — acquisition routing and consolidation
+
+### Input boundary
+
+L09 consumes the normalized `SearchDiscoveryCandidate` objects introduced by SA15-L01. Those candidates contain SERP discovery lineage and remain non-evidentiary until the discovered URL is retrieved through an approved acquisition path.
+
+### Automatic public-web route
+
+A candidate may be routed automatically to `PUBLIC_WEB` only when all of the following are true:
+
+1. a checked-in/runtime `PublicWebTarget` belongs to the same canonical organization;
+2. the target authorization is currently executable and not expired;
+3. the candidate URL is same-origin with that target;
+4. the URL falls inside the target crawl-scope path controls and current crawl budget admission rules;
+5. exactly one governed target matches.
+
+Successful routing changes the candidate state to `ROUTED_PUBLIC_WEB` and carries the governed target id. The router chooses an acquisition path; it does not itself fetch the resource or create Evidence.
+
+### Source-review route
+
+If the candidate is off-origin, out of the approved path scope, or has no currently executable organization-bound target, it changes to `REQUIRES_SOURCE_REVIEW`.
+
+That state is intentionally fail-closed: CIP must review/onboard an appropriate source or target before retrieval rather than using a generic unrestricted HTTP fetch.
+
+Ambiguous multiple-target matches fail closed with an error instead of selecting one arbitrarily.
+
+## Invariants retained
+
+- search-result metadata is discovery lineage, not a confirmed company fact;
+- CDX index metadata proves a historical capture record, not the current contents of a page;
+- neither L05 nor L09 creates a CommercialSignal, NeedHypothesis, Opportunity, contact target, or outreach authorization directly;
+- provider/source governance is evaluated before acquisition;
+- external content remains untrusted;
+- no credential, CAPTCHA, MFA, authentication, or access-control bypass is introduced by these microlots.
+
+## Tests and final proof
+
+Deterministic tests cover routing to an executable governed target, off-origin review, path rejection, expired authorization, duplicate-target ambiguity, route ordering, and truthful source-activation stages.
+
+The authoritative final proof is the exact-head GitHub Actions result on PR #123. Any content change after a successful provider/CI run requires both gates to run again before merge.

--- a/policies/source_activation.yml
+++ b/policies/source_activation.yml
@@ -540,7 +540,7 @@ sources:
     category: public_archive
     disposition: active
     activation_wave: SA-02
-    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable, scheduled]
+    stages: [catalogued, reviewed, mapped, adapter_present, authorized, executable, scheduled, live_tested]
 
   - source_id: sherlock-local
     display_name: Sherlock username OSINT tool

--- a/scripts/live_validate_sa15_cdx.py
+++ b/scripts/live_validate_sa15_cdx.py
@@ -16,6 +16,7 @@ from cip.modules.source_governance.infrastructure.registry import load_source_re
 
 POLICY_PATH = Path("policies/sources.search_archives.yml")
 ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+_TARGET_URL = "https://archive.org/about/terms.php"
 
 
 def main() -> None:
@@ -29,21 +30,21 @@ def main() -> None:
         id="sa15-internet-archive-first-party",
         organization_id=ORG_ID,
         canonical_name="Internet Archive",
-        base_url="https://archive.org/",
+        base_url=_TARGET_URL,
         sitemap_urls=("https://archive.org/sitemap.xml",),
         feed_urls=(),
         discover_security_txt=False,
-        allowed_path_prefixes=("/",),
+        allowed_path_prefixes=("/about",),
         enabled=True,
         authorization_reference="sa15-controlled-internet-archive-first-party-target",
         authorization_reviewed_at=now,
-        terms_url="https://archive.org/about/terms.php",
+        terms_url=_TARGET_URL,
         max_pages=50,
         max_total_bytes=2_000_000,
         max_resource_bytes=1_000_000,
         max_redirects=0,
     )
-    batch = InternetArchiveCdxAdapter(entry, (target,), timeout_seconds=30).collect(
+    batch = InternetArchiveCdxAdapter(entry, (target,), timeout_seconds=90).collect(
         collection_job_id=uuid4(),
         checkpoint_payload=None,
         collected_at=now,
@@ -76,6 +77,7 @@ def main() -> None:
         raise RuntimeError("Internet Archive CDX checkpoint did not converge for one target")
     print(
         "SA-15 L05 live validation passed: "
+        f"target={_TARGET_URL} "
         f"internet_archive_cdx_observations={observations} "
         f"internet_archive_cdx_projections={projections} claims=0 bodies=0"
     )

--- a/scripts/live_validate_sa15_cdx.py
+++ b/scripts/live_validate_sa15_cdx.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.archive_cdx_adapter import (
+    InternetArchiveCdxAdapter,
+)
+from cip.modules.public_footprint.domain.models import (
+    PublicResourceKind,
+    ResourceRetrievalState,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+
+
+def main() -> None:
+    entry = next(
+        item
+        for item in load_source_registry(POLICY_PATH)
+        if item.policy.id == "internet-archive-cdx"
+    )
+    now = datetime.now(UTC)
+    target = PublicWebTarget(
+        id="sa15-internet-archive-first-party",
+        organization_id=ORG_ID,
+        canonical_name="Internet Archive",
+        base_url="https://archive.org/",
+        sitemap_urls=("https://archive.org/sitemap.xml",),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="sa15-controlled-internet-archive-first-party-target",
+        authorization_reviewed_at=now,
+        terms_url="https://archive.org/about/terms.php",
+        max_pages=50,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=0,
+    )
+    batch = InternetArchiveCdxAdapter(entry, (target,), timeout_seconds=30).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=365),
+    )
+    observations = len(batch.observations)
+    projections = len(batch.public_footprint_projections)
+    if not 1 <= observations <= 50 or projections != observations:
+        raise RuntimeError("Internet Archive CDX live validation returned invalid capture counts")
+    if any(projection.claims for projection in batch.public_footprint_projections):
+        raise RuntimeError("Internet Archive CDX metadata unexpectedly produced claims")
+    if any(
+        projection.resource.kind is not PublicResourceKind.ARCHIVE_SNAPSHOT
+        or projection.resource.retrieval_state is not ResourceRetrievalState.QUARANTINED
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Internet Archive CDX captures escaped archive quarantine")
+    if any(
+        projection.resource.source_id != "internet-archive-cdx"
+        or not projection.resource.source_url.startswith("https://web.archive.org/web/")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Internet Archive CDX provenance was not preserved")
+    if any(
+        "Historical archive index metadata" not in (projection.version.excerpt or "")
+        for projection in batch.public_footprint_projections
+    ):
+        raise RuntimeError("Internet Archive CDX lost the metadata-only evidence boundary")
+    if batch.checkpoint_payload != {"target_index": 0}:
+        raise RuntimeError("Internet Archive CDX checkpoint did not converge for one target")
+    print(
+        "SA-15 L05 live validation passed: "
+        f"internet_archive_cdx_observations={observations} "
+        f"internet_archive_cdx_projections={projections} claims=0 bodies=0"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/modules/collection_orchestration/application/search_acquisition_router.py
+++ b/src/cip/modules/collection_orchestration/application/search_acquisition_router.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from enum import StrEnum
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.public_footprint.domain.scope import CrawlUsage
+from cip.modules.public_footprint.domain.search_core import (
+    SearchAcquisitionState,
+    SearchDiscoveryCandidate,
+)
+from cip.modules.public_footprint.domain.url_identity import same_origin
+from cip.shared.kernel.time import require_aware_utc
+
+
+class SearchAcquisitionRouteKind(StrEnum):
+    PUBLIC_WEB = "public_web"
+    SOURCE_REVIEW = "source_review"
+
+
+@dataclass(frozen=True, slots=True)
+class SearchAcquisitionRoute:
+    candidate: SearchDiscoveryCandidate
+    route_kind: SearchAcquisitionRouteKind
+    requested_url: str
+    public_web_target_id: str | None
+    reason: str
+
+    def __post_init__(self) -> None:
+        reason = self.reason.strip()
+        if not reason:
+            raise ValueError("search acquisition route requires a reason")
+        if self.route_kind is SearchAcquisitionRouteKind.PUBLIC_WEB:
+            if not self.public_web_target_id:
+                raise ValueError("public-web route requires a governed target id")
+            if self.candidate.acquisition_state is not SearchAcquisitionState.ROUTED_PUBLIC_WEB:
+                raise ValueError("public-web route requires routed candidate state")
+        elif self.public_web_target_id is not None:
+            raise ValueError("source-review route cannot carry a public-web target id")
+        object.__setattr__(self, "reason", reason)
+
+    @property
+    def automatic(self) -> bool:
+        return self.route_kind is SearchAcquisitionRouteKind.PUBLIC_WEB
+
+
+def route_search_discovery_candidates(
+    candidates: tuple[SearchDiscoveryCandidate, ...],
+    targets: tuple[PublicWebTarget, ...],
+    *,
+    routed_at: datetime,
+) -> tuple[SearchAcquisitionRoute, ...]:
+    now = require_aware_utc(routed_at, field_name="routed_at")
+    routes = tuple(_route_candidate(candidate, targets, now=now) for candidate in candidates)
+    return tuple(sorted(routes, key=_route_sort_key))
+
+
+def _route_candidate(
+    candidate: SearchDiscoveryCandidate,
+    targets: tuple[PublicWebTarget, ...],
+    *,
+    now: datetime,
+) -> SearchAcquisitionRoute:
+    matching = tuple(
+        target
+        for target in targets
+        if target.organization_id == candidate.organization_id
+        and target.executable_at(now)
+        and same_origin(candidate.target_url, target.base_url)
+        and target.crawl_scope.evaluate_target(
+            candidate.target_url,
+            depth=0,
+            redirects=0,
+            usage=CrawlUsage(),
+        ).allowed
+    )
+    if len(matching) > 1:
+        raise ValueError("search candidate matches multiple governed public-web targets")
+    if matching:
+        target = matching[0]
+        routed = replace(
+            candidate,
+            acquisition_state=SearchAcquisitionState.ROUTED_PUBLIC_WEB,
+        )
+        return SearchAcquisitionRoute(
+            candidate=routed,
+            route_kind=SearchAcquisitionRouteKind.PUBLIC_WEB,
+            requested_url=routed.target_url,
+            public_web_target_id=target.id,
+            reason="candidate URL is inside an executable governed public-web target",
+        )
+    review_candidate = replace(
+        candidate,
+        acquisition_state=SearchAcquisitionState.REQUIRES_SOURCE_REVIEW,
+    )
+    return SearchAcquisitionRoute(
+        candidate=review_candidate,
+        route_kind=SearchAcquisitionRouteKind.SOURCE_REVIEW,
+        requested_url=review_candidate.target_url,
+        public_web_target_id=None,
+        reason=(
+            "candidate URL is not inside an executable governed public-web target; "
+            "provider/source review is required before retrieval"
+        ),
+    )
+
+
+def _route_sort_key(route: SearchAcquisitionRoute) -> tuple[int, str]:
+    priority = 0 if route.route_kind is SearchAcquisitionRouteKind.PUBLIC_WEB else 1
+    return (priority, route.requested_url)

--- a/src/cip/modules/public_footprint/domain/search_core.py
+++ b/src/cip/modules/public_footprint/domain/search_core.py
@@ -12,6 +12,8 @@ from cip.shared.kernel.time import require_aware_utc
 
 class SearchAcquisitionState(StrEnum):
     UNROUTED = "unrouted"
+    ROUTED_PUBLIC_WEB = "routed_public_web"
+    REQUIRES_SOURCE_REVIEW = "requires_source_review"
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/collection_orchestration/test_search_acquisition_router.py
+++ b/tests/unit/collection_orchestration/test_search_acquisition_router.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.search_acquisition_router import (
+    SearchAcquisitionRouteKind,
+    route_search_discovery_candidates,
+)
+from cip.modules.public_footprint.domain.search_core import (
+    SearchAcquisitionState,
+    SearchDiscoveryCandidate,
+    SearchProviderHit,
+)
+
+NOW = datetime(2026, 8, 12, 0, 45, tzinfo=UTC)
+ORGANIZATION_ID = UUID("00000000-0000-0000-0000-000000001509")
+
+
+def test_same_origin_candidate_routes_to_executable_governed_public_web_target() -> None:
+    routes = route_search_discovery_candidates(
+        (_candidate("https://example.com/security/report"),),
+        (_target(),),
+        routed_at=NOW,
+    )
+
+    route = routes[0]
+    assert route.route_kind is SearchAcquisitionRouteKind.PUBLIC_WEB
+    assert route.public_web_target_id == "example-company"
+    assert route.automatic is True
+    assert route.requested_url == "https://example.com/security/report"
+    assert route.candidate.acquisition_state is SearchAcquisitionState.ROUTED_PUBLIC_WEB
+
+
+def test_off_origin_candidate_requires_source_review_instead_of_generic_fetch() -> None:
+    route = route_search_discovery_candidates(
+        (_candidate("https://third-party.example/research"),),
+        (_target(),),
+        routed_at=NOW,
+    )[0]
+
+    assert route.route_kind is SearchAcquisitionRouteKind.SOURCE_REVIEW
+    assert route.public_web_target_id is None
+    assert route.automatic is False
+    assert route.candidate.acquisition_state is SearchAcquisitionState.REQUIRES_SOURCE_REVIEW
+
+
+def test_same_origin_candidate_outside_allowed_path_requires_source_review() -> None:
+    target = _target(allowed_path_prefixes=("/security",))
+    route = route_search_discovery_candidates(
+        (_candidate("https://example.com/careers"),),
+        (target,),
+        routed_at=NOW,
+    )[0]
+
+    assert route.route_kind is SearchAcquisitionRouteKind.SOURCE_REVIEW
+    assert route.candidate.acquisition_state is SearchAcquisitionState.REQUIRES_SOURCE_REVIEW
+
+
+def test_expired_target_cannot_receive_automatic_search_acquisition() -> None:
+    target = _target(authorization_expires_at=NOW - timedelta(seconds=1))
+    route = route_search_discovery_candidates(
+        (_candidate("https://example.com/security"),),
+        (target,),
+        routed_at=NOW,
+    )[0]
+
+    assert route.route_kind is SearchAcquisitionRouteKind.SOURCE_REVIEW
+
+
+def test_router_fails_closed_when_candidate_matches_multiple_governed_targets() -> None:
+    first = _target(target_id="one")
+    second = _target(target_id="two")
+
+    with pytest.raises(ValueError, match="multiple governed"):
+        route_search_discovery_candidates(
+            (_candidate("https://example.com/security"),),
+            (first, second),
+            routed_at=NOW,
+        )
+
+
+def test_automatic_routes_sort_before_source_review_routes() -> None:
+    routes = route_search_discovery_candidates(
+        (
+            _candidate("https://third-party.example/research"),
+            _candidate("https://example.com/security"),
+        ),
+        (_target(),),
+        routed_at=NOW,
+    )
+
+    assert [route.route_kind for route in routes] == [
+        SearchAcquisitionRouteKind.PUBLIC_WEB,
+        SearchAcquisitionRouteKind.SOURCE_REVIEW,
+    ]
+
+
+def _candidate(url: str) -> SearchDiscoveryCandidate:
+    return SearchDiscoveryCandidate(
+        organization_id=ORGANIZATION_ID,
+        target_url=url,
+        title="Search discovery",
+        snippet="Provider metadata only",
+        purpose="corporate-public-footprint",
+        provider_hits=(
+            SearchProviderHit(
+                provider_id="brave-search-api",
+                source_record_key=f"record:{url}",
+                rank=1,
+                observed_at=NOW,
+                title="Search discovery",
+                snippet="Provider metadata only",
+                rendered_query='"Example Corp" cybersecurity',
+                query_template_id="security",
+                query_template_version=1,
+            ),
+        ),
+    )
+
+
+def _target(
+    *,
+    target_id: str = "example-company",
+    allowed_path_prefixes: tuple[str, ...] = ("/",),
+    authorization_expires_at: datetime | None = None,
+) -> PublicWebTarget:
+    return PublicWebTarget(
+        id=target_id,
+        organization_id=ORGANIZATION_ID,
+        canonical_name="Example Corp",
+        base_url="https://example.com/",
+        sitemap_urls=("https://example.com/sitemap.xml",),
+        allowed_path_prefixes=allowed_path_prefixes,
+        enabled=True,
+        authorization_reference="sa15-router-test",
+        authorization_reviewed_at=NOW - timedelta(days=1),
+        authorization_expires_at=authorization_expires_at,
+    )

--- a/tests/unit/source_activation/test_sa15_search_activation.py
+++ b/tests/unit/source_activation/test_sa15_search_activation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from cip.modules.source_activation.domain.models import ActivationStage
+from cip.modules.source_activation.infrastructure import load_activation_inventory
+from cip.shared.config.settings import Settings
+
+
+def test_sa15_promotes_only_search_provider_with_real_live_proof() -> None:
+    records = {
+        record.source_id: record
+        for record in load_activation_inventory(Settings().source_activation_path)
+    }
+
+    internet_archive = records["internet-archive-cdx"]
+    assert ActivationStage.LIVE_TESTED in internet_archive.stages
+    assert internet_archive.is_fully_integrated is True
+
+    for source_id in (
+        "brave-search-api",
+        "mojeek-web-search-metadata",
+        "patentsview-patent-metadata",
+    ):
+        assert ActivationStage.LIVE_TESTED not in records[source_id].stages


### PR DESCRIPTION
Implements the next two SA-15 microlots after merged L01.

## SA15-L05 — Internet Archive CDX live validation
- reuses the existing production `InternetArchiveCdxAdapter` and governed `internet-archive-cdx` source policy;
- adds a controlled live-validation script against the neutral first-party Internet Archive target;
- requires 1..50 real CDX captures, one quarantined archive projection per observation, zero claims, zero archived-body retrieval and preserved Wayback provenance;
- adds a dedicated SA-15 pull-request live workflow; a skipped job is never live proof.

## SA15-L09 — governed acquisition routing/consolidation
- turns L01 `SearchDiscoveryCandidate` objects into explicit acquisition routes;
- same-organization, same-origin candidates inside an executable `PublicWebTarget` and its crawl scope route to `PUBLIC_WEB`;
- off-origin, out-of-scope or expired-target candidates fail closed to `SOURCE_REVIEW` and are never generically fetched;
- adds explicit `ROUTED_PUBLIC_WEB` and `REQUIRES_SOURCE_REVIEW` states;
- deterministic tests cover automatic routing, off-origin review, path controls, authorization expiry, duplicate governed matches and ordering.

This PR remains draft until exact-head normal CI is green and the real Internet Archive CDX production-adapter live job succeeds. Only after that proof will `live_tested` be promoted truthfully.