### PR TITLE
SA15-L06/L07: independent search provider and governed dork library

### DIFF
--- a/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
+++ b/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
@@ -1,0 +1,93 @@
+# SA-15 L06/L07 — Search diversity and governed dork library
+
+## Scope
+
+This increment implements two SA-15 search work items without overstating provider activation:
+
+- **L06** — add a current independent general web-search provider implementation path through Marginalia Search API2;
+- **L07** — replace the three generic search templates with the complete versioned analyst dork/query library required by the SA-15 roadmap.
+
+Search-result metadata remains discovery material. It does not become evidence merely because a provider returned it; downstream retrieval still goes through the governed search-to-acquisition routing path.
+
+## L06 — Marginalia Search API2
+
+### Implemented
+
+- production client targets `https://api2.marginalia-search.com/search`;
+- API key is sent through the provider-documented `API-Key` header;
+- response parsing is bounded and schema validated for `query`, `license`, and result `url` / `title` / `description` fields;
+- redirects are disabled;
+- response body size is bounded;
+- HTTP 429 and 5xx responses are classified retryable;
+- transport failures are classified retryable;
+- schema/content-type failures fail closed;
+- the provider's shared `public` development key is explicitly rejected by the production client;
+- source policy, portfolio state, activation truth, and entitlement prerequisites are represented separately;
+- deterministic tests use `httpx.MockTransport` and never rely on provider network access.
+
+### Current activation truth
+
+`marginalia-web-search-metadata` is **not live tested** and is not production-authorized yet.
+
+Current proven stages:
+
+`catalogued -> reviewed -> mapped -> adapter_present`
+
+Missing prerequisites remain owned work:
+
+1. legitimate commercial API key;
+2. commercial-use entitlement evidence;
+3. Provider Onboarding secret reference;
+4. exact deployment authorization for host/path/purpose;
+5. controlled production-adapter real-endpoint validation;
+6. exact-head CI/live proof before `live_tested` may be added.
+
+The shared development key is not an acceptable substitute for these prerequisites.
+
+## L07 — versioned dork/query library
+
+The registry is upgraded from three generic templates to version-2 coverage for:
+
+- `site:` company/domain research;
+- `filetype:` document discovery;
+- `intitle:` and `inurl:` research patterns;
+- procurement and contracts;
+- cyber products/providers;
+- SOC/SIEM/MDR/XDR/SOAR;
+- IAM/PAM/IGA/Zero Trust;
+- cloud/Kubernetes;
+- AppSec/DevSecOps/SAST/DAST/SCA/SBOM;
+- pentest/red-team/purple-team;
+- GRC/NIS2/DORA/ISO 27001/SOC 2/PCI DSS/HDS;
+- incident/ransomware/breach/regulator signals;
+- recruitment and security-team growth;
+- architecture/migration/transformation;
+- partner/customer/case-study evidence;
+- annual reports, presentations, standards and technical publications;
+- code/package/developer evidence.
+
+Every checked-in template is disabled by default. `build_google_analyst_search_url()` renders an analyst-opened Google search URL locally and performs no network request. Automated Google collection therefore remains unavailable until a legitimate provider/API entitlement and governed execution path are implemented.
+
+## Deterministic gates
+
+Tests enforce:
+
+- exact required template inventory;
+- unique template patterns;
+- template version 2;
+- one `{organization}` placeholder per template;
+- disabled-by-default behavior;
+- explicit `site:`, `filetype:`, `intitle:`, and `inurl:` coverage;
+- representative SA-15 cybersecurity coverage terms;
+- deterministic analyst-link URL rendering;
+- Marginalia commercial entitlement fail-closed behavior;
+- rejection of the shared development key;
+- current API2 host/path/header/query contract;
+- HTTP and schema failure classification.
+
+## Exit state
+
+- **L07:** implementation-complete once the PR exact-head CI is green.
+- **L06:** adapter/governance prerequisite implementation complete, but provider activation remains open until legitimate commercial access exists and the exact production adapter receives controlled real-endpoint live proof.
+
+No `live_tested` stage is added by this increment for Marginalia.

--- a/policies/marginalia_search_entitlement.yml
+++ b/policies/marginalia_search_entitlement.yml
@@ -1,0 +1,9 @@
+version: 1
+entitlement:
+  commercial_use_authorized: false
+  plan: unprovisioned
+  api_key_secret_ref: null
+  evidence_reference: null
+  prerequisite_owner: source-activation
+  target_microlot: SA15-L06
+  acceptance_test: controlled production-adapter search with a legitimate commercial API key

--- a/policies/search_query_templates.yml
+++ b/policies/search_query_templates.yml
@@ -1,164 +1,80 @@
-schema_version: 1
-registry: search_query_templates
-
-defaults:
-  enabled: false
-  purpose: corporate-public-footprint
-  max_age_days: 30
+version: 1
 
 templates:
   - id: q-procurement-contracts
-    query: '"{organization}" (tender OR RFP OR procurement OR contract OR marché OR appel d offres) cybersecurity'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 7
-    version: 2
+    query_pattern: '"{organization}" (tender OR RFP OR procurement OR contract OR marché OR "appel d offres") cybersecurity'
 
   - id: q-products-providers
-    query: '"{organization}" (cybersecurity OR security) (product OR platform OR provider OR vendor OR supplier)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 14
-    version: 2
+    query_pattern: '"{organization}" (cybersecurity OR security) (product OR platform OR provider OR vendor OR supplier)'
 
   - id: q-soc-siem-mdr-xdr-soar
-    query: '"{organization}" (SOC OR SIEM OR MDR OR XDR OR SOAR) (security OR cybersecurity)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 14
-    version: 2
+    query_pattern: '"{organization}" (SOC OR SIEM OR MDR OR XDR OR SOAR) (security OR cybersecurity)'
 
   - id: q-iam-pam-iga-zero-trust
-    query: '"{organization}" (IAM OR PAM OR IGA OR "Zero Trust" OR ZeroTrust)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 14
-    version: 2
+    query_pattern: '"{organization}" (IAM OR PAM OR IGA OR "Zero Trust" OR ZeroTrust)'
 
   - id: q-cloud-kubernetes
-    query: '"{organization}" (cloud OR AWS OR Azure OR GCP OR Kubernetes OR K8s) security'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 14
-    version: 2
+    query_pattern: '"{organization}" (cloud OR AWS OR Azure OR GCP OR Kubernetes OR K8s) security'
 
   - id: q-appsec-devsecops-sast-dast-sca-sbom
-    query: '"{organization}" (AppSec OR DevSecOps OR SAST OR DAST OR SCA OR SBOM OR "software supply chain")'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 14
-    version: 2
+    query_pattern: '"{organization}" (AppSec OR DevSecOps OR SAST OR DAST OR SCA OR SBOM OR "software supply chain")'
 
   - id: q-pentest-red-purple
-    query: '"{organization}" (pentest OR penetration testing OR red-team OR "red team" OR purple-team OR "purple team")'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 14
-    version: 2
+    query_pattern: '"{organization}" (pentest OR "penetration testing" OR red-team OR "red team" OR purple-team OR "purple team")'
 
   - id: q-grc-compliance
-    query: '"{organization}" (GRC OR NIS2 OR DORA OR ISO27001 OR "ISO 27001" OR SOC2 OR "SOC 2" OR "PCI DSS" OR HDS)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 30
-    version: 2
+    query_pattern: '"{organization}" (GRC OR NIS2 OR DORA OR ISO27001 OR "ISO 27001" OR SOC2 OR "SOC 2" OR "PCI DSS" OR HDS)'
 
   - id: q-incidents-ransomware-regulator
-    query: '"{organization}" (incident OR breach OR ransomware OR cyberattack OR regulator OR notification)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 7
-    version: 2
+    query_pattern: '"{organization}" (incident OR breach OR ransomware OR cyberattack OR regulator OR notification)'
 
   - id: q-hiring-team-growth
-    query: '"{organization}" (cybersecurity OR security) (jobs OR careers OR hiring OR recruitment OR analyst OR engineer OR CISO)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 7
-    version: 2
+    query_pattern: '"{organization}" (cybersecurity OR security) (jobs OR careers OR hiring OR recruitment OR analyst OR engineer OR CISO)'
 
   - id: q-architecture-migration-transformation
-    query: '"{organization}" (architecture OR migration OR transformation OR modernization OR modernisation) (cloud OR security OR infrastructure)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 30
-    version: 2
+    query_pattern: '"{organization}" (architecture OR migration OR transformation OR modernization OR modernisation) (cloud OR security OR infrastructure)'
 
   - id: q-partners-customers-case-studies
-    query: '"{organization}" (partner OR partnership OR customer OR client OR "case study" OR "success story") cybersecurity'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 30
-    version: 2
+    query_pattern: '"{organization}" (partner OR partnership OR customer OR client OR "case study" OR "success story") cybersecurity'
 
   - id: q-reports-presentations-standards-publications
-    query: '"{organization}" ("annual report" OR presentation OR standard OR specification OR "technical publication" OR whitepaper) (security OR cybersecurity OR technology)'
-    provider: google
-    endpoint: "https://www.google.com/search"
-    license_tag: manual-link
-    robots_status: not-automated
-    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    version: 2
     enabled: false
     purpose: corporate-public-footprint
-    max_age_days: 90
-    version: 2
+    query_pattern: '"{organization}" ("annual report" OR presentation OR standard OR specification OR "technical publication" OR whitepaper) (security OR cybersecurity OR technology)'

--- a/policies/search_query_templates.yml
+++ b/policies/search_query_templates.yml
@@ -1,6 +1,24 @@
 version: 1
 
 templates:
+  - id: q-site-company-research
+    version: 2
+    enabled: false
+    purpose: corporate-public-footprint-domain
+    query_pattern: 'site:{organization} (security OR cybersecurity OR technology OR architecture)'
+
+  - id: q-filetype-documents
+    version: 2
+    enabled: false
+    purpose: corporate-public-footprint
+    query_pattern: '"{organization}" (filetype:pdf OR filetype:pptx OR filetype:docx) (security OR cybersecurity OR technology)'
+
+  - id: q-intitle-inurl-research
+    version: 2
+    enabled: false
+    purpose: corporate-public-footprint
+    query_pattern: '"{organization}" (intitle:security OR intitle:cybersecurity OR inurl:security OR inurl:cyber)'
+
   - id: q-procurement-contracts
     version: 2
     enabled: false
@@ -78,3 +96,9 @@ templates:
     enabled: false
     purpose: corporate-public-footprint
     query_pattern: '"{organization}" ("annual report" OR presentation OR standard OR specification OR "technical publication" OR whitepaper) (security OR cybersecurity OR technology)'
+
+  - id: q-code-package-developer-evidence
+    version: 2
+    enabled: false
+    purpose: corporate-public-footprint
+    query_pattern: '"{organization}" (GitHub OR GitLab OR repository OR package OR npm OR PyPI OR Maven OR NuGet OR crates.io OR SBOM)'

--- a/policies/search_query_templates.yml
+++ b/policies/search_query_templates.yml
@@ -1,20 +1,164 @@
-version: 1
+schema_version: 1
+registry: search_query_templates
+
+defaults:
+  enabled: false
+  purpose: corporate-public-footprint
+  max_age_days: 30
 
 templates:
-  - id: organization-security-footprint
-    version: 1
+  - id: q-procurement-contracts
+    query: '"{organization}" (tender OR RFP OR procurement OR contract OR marché OR appel d offres) cybersecurity'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
     enabled: false
     purpose: corporate-public-footprint
-    query_pattern: '"{organization}" cybersecurity architecture'
+    max_age_days: 7
+    version: 2
 
-  - id: organization-technology-footprint
-    version: 1
+  - id: q-products-providers
+    query: '"{organization}" (cybersecurity OR security) (product OR platform OR provider OR vendor OR supplier)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
     enabled: false
     purpose: corporate-public-footprint
-    query_pattern: '"{organization}" technology platform cloud'
+    max_age_days: 14
+    version: 2
 
-  - id: organization-public-change
-    version: 1
+  - id: q-soc-siem-mdr-xdr-soar
+    query: '"{organization}" (SOC OR SIEM OR MDR OR XDR OR SOAR) (security OR cybersecurity)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
     enabled: false
     purpose: corporate-public-footprint
-    query_pattern: '"{organization}" transformation acquisition partnership'
+    max_age_days: 14
+    version: 2
+
+  - id: q-iam-pam-iga-zero-trust
+    query: '"{organization}" (IAM OR PAM OR IGA OR "Zero Trust" OR ZeroTrust)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 14
+    version: 2
+
+  - id: q-cloud-kubernetes
+    query: '"{organization}" (cloud OR AWS OR Azure OR GCP OR Kubernetes OR K8s) security'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 14
+    version: 2
+
+  - id: q-appsec-devsecops-sast-dast-sca-sbom
+    query: '"{organization}" (AppSec OR DevSecOps OR SAST OR DAST OR SCA OR SBOM OR "software supply chain")'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 14
+    version: 2
+
+  - id: q-pentest-red-purple
+    query: '"{organization}" (pentest OR penetration testing OR red-team OR "red team" OR purple-team OR "purple team")'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 14
+    version: 2
+
+  - id: q-grc-compliance
+    query: '"{organization}" (GRC OR NIS2 OR DORA OR ISO27001 OR "ISO 27001" OR SOC2 OR "SOC 2" OR "PCI DSS" OR HDS)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 30
+    version: 2
+
+  - id: q-incidents-ransomware-regulator
+    query: '"{organization}" (incident OR breach OR ransomware OR cyberattack OR regulator OR notification)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 7
+    version: 2
+
+  - id: q-hiring-team-growth
+    query: '"{organization}" (cybersecurity OR security) (jobs OR careers OR hiring OR recruitment OR analyst OR engineer OR CISO)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 7
+    version: 2
+
+  - id: q-architecture-migration-transformation
+    query: '"{organization}" (architecture OR migration OR transformation OR modernization OR modernisation) (cloud OR security OR infrastructure)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 30
+    version: 2
+
+  - id: q-partners-customers-case-studies
+    query: '"{organization}" (partner OR partnership OR customer OR client OR "case study" OR "success story") cybersecurity'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 30
+    version: 2
+
+  - id: q-reports-presentations-standards-publications
+    query: '"{organization}" ("annual report" OR presentation OR standard OR specification OR "technical publication" OR whitepaper) (security OR cybersecurity OR technology)'
+    provider: google
+    endpoint: "https://www.google.com/search"
+    license_tag: manual-link
+    robots_status: not-automated
+    allowed_stored_fields: [url, title, snippet, fetched_at, query_id, metadata]
+    enabled: false
+    purpose: corporate-public-footprint
+    max_age_days: 90
+    version: 2

--- a/policies/source_activation.search_providers_sa15.yml
+++ b/policies/source_activation.search_providers_sa15.yml
@@ -1,0 +1,17 @@
+version: 1
+
+sources:
+  - source_id: marginalia-web-search-metadata
+    display_name: Marginalia Search API metadata
+    category: corporate_public_footprint
+    disposition: blocked
+    activation_wave: SA15-L06
+    requires_schedule: false
+    reason: >-
+      Production adapter and response contract are present, but a legitimate commercial API key,
+      commercial-use entitlement evidence, Provider Onboarding secret reference and exact
+      authorization record are not present. The shared public development key is not an acceptable
+      production credential or live-test proof. Recheck when those prerequisites are provisioned;
+      acceptance requires the production adapter to execute a controlled real-endpoint search and
+      then pass exact-head CI/live validation before adding live_tested.
+    stages: [catalogued, reviewed, mapped, adapter_present]

--- a/policies/source_portfolio.search_providers_sa15.yml
+++ b/policies/source_portfolio.search_providers_sa15.yml
@@ -1,0 +1,36 @@
+version: 1
+
+sources:
+  - source_id: marginalia-web-search-metadata
+    display_name: Marginalia Search API metadata
+    canonical_url: https://api2.marginalia-search.com/search
+    category: corporate_public_footprint
+    status: candidate
+    freshness_max_age_seconds: 86400
+    commercial_use_cases: [public_evidence_map, organization_research]
+    candidate_origin: SA15-L06
+    monthly_cost_limit: 0
+    metadata:
+      executable: false
+      authorization_status: missing
+      runtime_adapter_present: true
+      provider_onboarding_required: true
+      commercial_use_entitlement_required: true
+      api_key_secret_required: true
+      query_registry_required: true
+      public_development_key_forbidden: true
+      raw_response_storage: false
+      third_party_page_body_storage: false
+      search_result_is_evidence: false
+      automatic_opportunity: forbidden
+    adapter:
+      adapter_id: marginalia-web-search
+      adapter_version: "1"
+      provider_schema_version: marginalia-api2-search-v1
+      modes: [conditional_refresh, priority_refresh]
+      canonical_output_types: [raw_observation, public_resource, public_resource_version]
+      supports_corrections: true
+      supports_tombstones: false
+      supports_retractions: false
+      max_page_size: 20
+      cost_per_request: 0

--- a/policies/sources.search_providers_sa15.yml
+++ b/policies/sources.search_providers_sa15.yml
@@ -1,0 +1,48 @@
+version: 1
+reviewed_at: 2026-08-12
+
+sources:
+  - id: marginalia-web-search-metadata
+    name: Marginalia Search API metadata
+    base_url: https://api2.marginalia-search.com/search
+    status: draft
+    source_type: search_provider
+    owner: Marginalia Search
+    terms_url: https://about.marginalia-search.com/article/api/
+    licence: Commercial API key and provider commercial-use terms required
+    allowed_data_categories: [public_result_metadata]
+    prohibited_data_categories:
+      - credential
+      - victim_file
+      - private_communication
+      - private_personal_data
+      - restricted_content
+    rate_limit_per_minute: null
+    retention_days: 90
+    attribution_required: false
+    raw_content_storage: false
+    human_review_required: false
+    authorization:
+      status: missing
+      document_reference: null
+      reviewed_at: null
+      expires_at: null
+      approved_hosts: []
+      approved_path_prefixes: []
+      approved_purposes: []
+      automated_collection_allowed: false
+      raw_storage_allowed: false
+    economics:
+      commercial_value: high
+      monthly_cost: 0
+      implementation_cost: low
+      maintenance_cost: low
+      expected_stability: medium
+    notes: >-
+      SA15-L06 production adapter is present for the current API2 contract. Execution remains
+      fail-closed until a legitimate commercial API key, commercial-use entitlement evidence,
+      exact approved host/path/purpose and Provider Onboarding secret reference are configured.
+      The provider's shared `public` development key is explicitly rejected by the production
+      client and must never be used as production or live-tested evidence. Search results remain
+      discovery metadata only; third-party page bodies are acquired separately through governed
+      public-web targets.

--- a/src/cip/adapters/sources/marginalia_search/__init__.py
+++ b/src/cip/adapters/sources/marginalia_search/__init__.py
@@ -1,0 +1,4 @@
+from cip.adapters.sources.marginalia_search.client import MarginaliaSearchClient
+from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
+
+__all__ = ["MarginaliaSearchClient", "MarginaliaSearchEntitlement"]

--- a/src/cip/adapters/sources/marginalia_search/client.py
+++ b/src/cip/adapters/sources/marginalia_search/client.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+from pydantic import ValidationError
+
+from cip.adapters.sources.marginalia_search.schemas import MarginaliaSearchResponse
+
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_RESULTS = 20
+_API_URL = "https://api2.marginalia-search.com/search"
+_USER_AGENT = (
+    "cyber-intelligence-platform/0.24 "
+    "(https://github.com/tobianahillel-afk/cyber-intelligence-platform)"
+)
+
+
+class MarginaliaSearchClientError(RuntimeError):
+    def __init__(self, message: str, *, code: str, retryable: bool) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class MarginaliaQueryResult:
+    response: MarginaliaSearchResponse
+    request_url: str
+
+
+class MarginaliaSearchClient:
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def search(self, *, query: str, api_key: str) -> MarginaliaQueryResult:
+        normalized_query = query.strip()
+        normalized_key = api_key.strip()
+        if not normalized_query:
+            raise ValueError("query must be non-empty")
+        if not normalized_key:
+            raise ValueError("api_key must be non-empty")
+        if normalized_key.casefold() == "public":
+            raise PermissionError(
+                "Marginalia public development key is not accepted for production collection"
+            )
+
+        try:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+                transport=self._transport,
+            ) as client:
+                response = client.get(
+                    _API_URL,
+                    headers={
+                        "Accept": "application/json",
+                        "API-Key": normalized_key,
+                        "User-Agent": _USER_AGENT,
+                    },
+                    params={
+                        "query": normalized_query,
+                        "count": str(_MAX_RESULTS),
+                        "dc": "3",
+                        "nsfw": "1",
+                    },
+                )
+                response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise MarginaliaSearchClientError(
+                f"Marginalia returned HTTP {status}",
+                code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise MarginaliaSearchClientError(
+                str(exc) or type(exc).__name__,
+                code="source_transport_error",
+                retryable=True,
+            ) from exc
+
+        content_type = response.headers.get("content-type", "").casefold()
+        if "json" not in content_type:
+            raise MarginaliaSearchClientError(
+                "Marginalia response is not JSON",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        if len(response.content) > _MAX_RESPONSE_BYTES:
+            raise MarginaliaSearchClientError(
+                "Marginalia response exceeds size limit",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        try:
+            parsed = MarginaliaSearchResponse.model_validate_json(response.content)
+        except ValidationError as exc:
+            raise MarginaliaSearchClientError(
+                "Marginalia response schema changed",
+                code="source_schema_drift",
+                retryable=False,
+            ) from exc
+        return MarginaliaQueryResult(
+            response=parsed,
+            request_url=str(response.request.url),
+        )

--- a/src/cip/adapters/sources/marginalia_search/registry.py
+++ b/src/cip/adapters/sources/marginalia_search/registry.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+MARGINALIA_API_HOST = "api2.marginalia-search.com"
+
+
+@dataclass(frozen=True, slots=True)
+class MarginaliaSearchEntitlement:
+    api_host: str = MARGINALIA_API_HOST
+    commercial_use_rights: bool = False
+    api_key_secret_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        host = self.api_host.strip().casefold()
+        if host != MARGINALIA_API_HOST:
+            raise ValueError("Marginalia API host is not approved")
+        object.__setattr__(self, "api_host", host)
+
+        if self.api_key_secret_ref is not None:
+            secret_ref = self.api_key_secret_ref.strip()
+            if not secret_ref:
+                raise ValueError("api_key_secret_ref must be non-empty when provided")
+            object.__setattr__(self, "api_key_secret_ref", secret_ref)
+
+    def assert_live_collection_ready(self) -> None:
+        if not self.commercial_use_rights:
+            raise PermissionError(
+                "Marginalia production collection requires commercial-use rights"
+            )
+        if self.api_key_secret_ref is None:
+            raise PermissionError(
+                "Marginalia production collection requires an API-key secret ref"
+            )

--- a/src/cip/adapters/sources/marginalia_search/schemas.py
+++ b/src/cip/adapters/sources/marginalia_search/schemas.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MarginaliaSearchResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    url: str = Field(min_length=1, max_length=4_096)
+    title: str = Field(default="Untitled result", max_length=1_000)
+    description: str = Field(default="", max_length=4_000)
+
+
+class MarginaliaSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    query: str = Field(min_length=1, max_length=2_000)
+    license: str = Field(default="", max_length=500)
+    results: list[MarginaliaSearchResult] = Field(default_factory=list, max_length=100)

--- a/src/cip/modules/public_footprint/infrastructure/manual_search.py
+++ b/src/cip/modules/public_footprint/infrastructure/manual_search.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from cip.modules.public_footprint.domain import SearchQueryTemplate
+
+_GOOGLE_SEARCH_URL = "https://www.google.com/search"
+
+
+def build_google_analyst_search_url(
+    template: SearchQueryTemplate,
+    organization: str,
+) -> str:
+    """Build an analyst-opened Google search URL without performing network I/O."""
+    query = template.render(organization)
+    return f"{_GOOGLE_SEARCH_URL}?{urlencode({'q': query})}"

--- a/tests/test_search_query_registry.py
+++ b/tests/test_search_query_registry.py
@@ -12,10 +12,14 @@ from cip.modules.public_footprint.infrastructure.search_registry import (
 def test_repository_search_query_templates_are_versioned_and_disabled() -> None:
     templates = load_search_query_templates(Path("policies/search_query_templates.yml"))
 
-    assert len(templates) == 3
+    assert templates
+    assert all(template.version >= 1 for template in templates)
     assert all(not template.enabled for template in templates)
-    assert len({(template.id, template.version) for template in templates}) == 3
-    assert templates[0].render("Example Corp").startswith('"Example Corp"')
+    assert len({(template.id, template.version) for template in templates}) == len(templates)
+    for template in templates:
+        rendered = template.render("Example Corp")
+        assert "{organization}" not in rendered
+        assert "Example Corp" in rendered
 
 
 def test_search_query_registry_rejects_duplicate_versions(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_marginalia_search.py
+++ b/tests/unit/adapters/test_marginalia_search.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from cip.adapters.sources.marginalia_search.client import (
+    MarginaliaSearchClient,
+    MarginaliaSearchClientError,
+)
+from cip.adapters.sources.marginalia_search.registry import (
+    MARGINALIA_API_HOST,
+    MarginaliaSearchEntitlement,
+)
+
+
+def test_marginalia_entitlement_fails_closed_without_commercial_rights() -> None:
+    entitlement = MarginaliaSearchEntitlement(api_key_secret_ref="secret://marginalia")
+
+    with pytest.raises(PermissionError, match="commercial-use rights"):
+        entitlement.assert_live_collection_ready()
+
+
+def test_marginalia_entitlement_requires_secret_ref() -> None:
+    entitlement = MarginaliaSearchEntitlement(commercial_use_rights=True)
+
+    with pytest.raises(PermissionError, match="API-key secret ref"):
+        entitlement.assert_live_collection_ready()
+
+
+def test_marginalia_entitlement_accepts_only_current_api_host() -> None:
+    with pytest.raises(ValueError, match="not approved"):
+        MarginaliaSearchEntitlement(api_host="api.marginalia.nu")
+
+    entitlement = MarginaliaSearchEntitlement(
+        api_host=MARGINALIA_API_HOST,
+        commercial_use_rights=True,
+        api_key_secret_ref="secret://marginalia/commercial",
+    )
+    entitlement.assert_live_collection_ready()
+
+
+def test_marginalia_client_rejects_shared_public_development_key() -> None:
+    client = MarginaliaSearchClient()
+
+    with pytest.raises(PermissionError, match="public development key"):
+        client.search(query="cyber security", api_key="public")
+
+
+def test_marginalia_client_uses_current_api2_contract() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == MARGINALIA_API_HOST
+        assert request.url.path == "/search"
+        assert request.headers["API-Key"] == "commercial-test-key"
+        assert request.url.params["query"] == "example cybersecurity"
+        assert request.url.params["count"] == "20"
+        assert request.url.params["dc"] == "3"
+        assert request.url.params["nsfw"] == "1"
+        body = {
+            "query": "example cybersecurity",
+            "license": "commercial",
+            "results": [
+                {
+                    "url": "https://example.com/security",
+                    "title": "Security",
+                    "description": "Public result metadata",
+                }
+            ],
+        }
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=json.dumps(body).encode(),
+        )
+
+    client = MarginaliaSearchClient(transport=httpx.MockTransport(handler))
+    result = client.search(
+        query="example cybersecurity",
+        api_key="commercial-test-key",
+    )
+
+    assert result.response.query == "example cybersecurity"
+    assert result.response.results[0].url == "https://example.com/security"
+    assert result.request_url.startswith("https://api2.marginalia-search.com/search?")
+
+
+def test_marginalia_client_classifies_http_and_schema_failures() -> None:
+    throttled = MarginaliaSearchClient(
+        transport=httpx.MockTransport(lambda _: httpx.Response(429))
+    )
+    with pytest.raises(MarginaliaSearchClientError) as http_error:
+        throttled.search(query="example", api_key="commercial-test-key")
+    assert http_error.value.code == "http_429"
+    assert http_error.value.retryable is True
+
+    drifted = MarginaliaSearchClient(
+        transport=httpx.MockTransport(
+            lambda _: httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                content=b'{"unexpected": true}',
+            )
+        )
+    )
+    with pytest.raises(MarginaliaSearchClientError) as schema_error:
+        drifted.search(query="example", api_key="commercial-test-key")
+    assert schema_error.value.code == "source_schema_drift"
+    assert schema_error.value.retryable is False

--- a/tests/unit/source_activation/test_sa15_search_query_library.py
+++ b/tests/unit/source_activation/test_sa15_search_query_library.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.modules.public_footprint.infrastructure.search_registry import (
+    load_search_query_templates,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = ROOT / "policies" / "search_query_templates.yml"
+
+EXPECTED_TEMPLATE_IDS = {
+    "q-procurement-contracts",
+    "q-products-providers",
+    "q-soc-siem-mdr-xdr-soar",
+    "q-iam-pam-iga-zero-trust",
+    "q-cloud-kubernetes",
+    "q-appsec-devsecops-sast-dast-sca-sbom",
+    "q-pentest-red-purple",
+    "q-grc-compliance",
+    "q-incidents-ransomware-regulator",
+    "q-hiring-team-growth",
+    "q-architecture-migration-transformation",
+    "q-partners-customers-case-studies",
+    "q-reports-presentations-standards-publications",
+}
+
+
+def test_sa15_dork_library_covers_every_required_family() -> None:
+    registry = load_search_query_templates(REGISTRY_PATH)
+    templates = registry.all()
+
+    assert {template.query_id for template in templates} == EXPECTED_TEMPLATE_IDS
+    assert len(templates) == len(EXPECTED_TEMPLATE_IDS)
+    assert len({template.query for template in templates}) == len(templates)
+
+
+def test_sa15_dork_library_is_versioned_and_manual_only() -> None:
+    registry = load_search_query_templates(REGISTRY_PATH)
+
+    for template in registry.all():
+        assert template.version == 2
+        assert template.source == "google"
+        assert template.endpoint == "https://www.google.com/search"
+        assert template.license_tag == "manual-link"
+        assert template.robots_status == "not-automated"
+        assert template.enabled is False
+        assert "{organization}" in template.query
+        assert template.allowed_stored_fields == (
+            "url",
+            "title",
+            "snippet",
+            "fetched_at",
+            "query_id",
+            "metadata",
+        )

--- a/tests/unit/source_activation/test_sa15_search_query_library.py
+++ b/tests/unit/source_activation/test_sa15_search_query_library.py
@@ -6,7 +6,7 @@ from cip.modules.public_footprint.infrastructure.search_registry import (
     load_search_query_templates,
 )
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 REGISTRY_PATH = ROOT / "policies" / "search_query_templates.yml"
 
 EXPECTED_TEMPLATE_IDS = {
@@ -27,30 +27,21 @@ EXPECTED_TEMPLATE_IDS = {
 
 
 def test_sa15_dork_library_covers_every_required_family() -> None:
-    registry = load_search_query_templates(REGISTRY_PATH)
-    templates = registry.all()
+    templates = load_search_query_templates(REGISTRY_PATH)
 
-    assert {template.query_id for template in templates} == EXPECTED_TEMPLATE_IDS
+    assert {template.id for template in templates} == EXPECTED_TEMPLATE_IDS
     assert len(templates) == len(EXPECTED_TEMPLATE_IDS)
-    assert len({template.query for template in templates}) == len(templates)
+    assert len({template.query_pattern for template in templates}) == len(templates)
 
 
-def test_sa15_dork_library_is_versioned_and_manual_only() -> None:
-    registry = load_search_query_templates(REGISTRY_PATH)
+def test_sa15_dork_library_is_versioned_and_disabled_by_default() -> None:
+    templates = load_search_query_templates(REGISTRY_PATH)
 
-    for template in registry.all():
+    for template in templates:
         assert template.version == 2
-        assert template.source == "google"
-        assert template.endpoint == "https://www.google.com/search"
-        assert template.license_tag == "manual-link"
-        assert template.robots_status == "not-automated"
+        assert template.purpose == "corporate-public-footprint"
         assert template.enabled is False
-        assert "{organization}" in template.query
-        assert template.allowed_stored_fields == (
-            "url",
-            "title",
-            "snippet",
-            "fetched_at",
-            "query_id",
-            "metadata",
-        )
+        assert template.query_pattern.count("{organization}") == 1
+        rendered = template.render("Example Corp")
+        assert "{organization}" not in rendered
+        assert "Example Corp" in rendered

--- a/tests/unit/source_activation/test_sa15_search_query_library.py
+++ b/tests/unit/source_activation/test_sa15_search_query_library.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
+from cip.modules.public_footprint.infrastructure.manual_search import (
+    build_google_analyst_search_url,
+)
 from cip.modules.public_footprint.infrastructure.search_registry import (
     load_search_query_templates,
 )
@@ -10,6 +14,9 @@ ROOT = Path(__file__).resolve().parents[3]
 REGISTRY_PATH = ROOT / "policies" / "search_query_templates.yml"
 
 EXPECTED_TEMPLATE_IDS = {
+    "q-site-company-research",
+    "q-filetype-documents",
+    "q-intitle-inurl-research",
     "q-procurement-contracts",
     "q-products-providers",
     "q-soc-siem-mdr-xdr-soar",
@@ -23,6 +30,7 @@ EXPECTED_TEMPLATE_IDS = {
     "q-architecture-migration-transformation",
     "q-partners-customers-case-studies",
     "q-reports-presentations-standards-publications",
+    "q-code-package-developer-evidence",
 }
 
 
@@ -33,15 +41,36 @@ def test_sa15_dork_library_covers_every_required_family() -> None:
     assert len(templates) == len(EXPECTED_TEMPLATE_IDS)
     assert len({template.query_pattern for template in templates}) == len(templates)
 
+    combined = " ".join(template.query_pattern for template in templates).casefold()
+    for operator in ("site:", "filetype:", "intitle:", "inurl:"):
+        assert operator in combined
+    for term in ("procurement", "siem", "zero trust", "kubernetes", "sbom"):
+        assert term in combined
+
 
 def test_sa15_dork_library_is_versioned_and_disabled_by_default() -> None:
     templates = load_search_query_templates(REGISTRY_PATH)
 
     for template in templates:
         assert template.version == 2
-        assert template.purpose == "corporate-public-footprint"
+        assert template.purpose.startswith("corporate-public-footprint")
         assert template.enabled is False
         assert template.query_pattern.count("{organization}") == 1
         rendered = template.render("Example Corp")
         assert "{organization}" not in rendered
         assert "Example Corp" in rendered
+
+
+def test_sa15_google_route_builds_manual_link_without_network_io() -> None:
+    templates = load_search_query_templates(REGISTRY_PATH)
+    template = next(item for item in templates if item.id == "q-filetype-documents")
+
+    url = build_google_analyst_search_url(template, "Example Corp")
+    parsed = urlparse(url)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "www.google.com"
+    assert parsed.path == "/search"
+    query = parse_qs(parsed.query)["q"][0]
+    assert "Example Corp" in query
+    assert "filetype:pdf" in query


### PR DESCRIPTION
## Scope

- **SA15-L06:** implement the current Marginalia API2 search client with bounded response parsing and fail-closed commercial entitlement gates.
- Reject Marginalia's shared `public` development key for production collection.
- Track the missing commercial key/use-rights/onboarding authorization as an explicit activation prerequisite; do **not** mark the provider `live_tested`.
- **SA15-L07:** replace the three generic templates with 17 version-2 templates covering every required SA-15 business family plus explicit `site:`, `filetype:`, `intitle:`, `inurl:` and code/package/developer evidence coverage.
- Add `build_google_analyst_search_url()` as a deterministic analyst route that only renders an HTTPS Google search URL and performs no network I/O. Checked-in Google templates remain disabled by default.
- Add deterministic unit/contract tests for the Marginalia client, entitlement gates, dork completeness, operator coverage, uniqueness, versioning, disabled-by-default behavior and analyst-link rendering.
- Record exact L06/L07 activation truth in `docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md`.

## Activation truth

Marginalia is currently proven only through `catalogued -> reviewed -> mapped -> adapter_present`. Authorization, executable production state and `live_tested` remain absent until a legitimate commercial API key, commercial-use entitlement, Provider Onboarding secret reference and exact deployment authorization are provisioned and the production adapter passes a controlled real-endpoint exact-head validation.

L07 is implementation-complete when this PR's exact-head CI is green. Search metadata remains discovery-only and routes through governed acquisition before evidence promotion.

## External contract

The Marginalia provider contract was verified against the provider's current official API documentation: API2 at `api2.marginalia-search.com`, `API-Key` request header, JSON response containing `query`, `license`, and result `url`/`title`/`description`; commercial use requires a commercial key.