### PR TITLE
SA15-L02/L03/L04: credentialed search-provider live readiness

### DIFF
--- a/.github/workflows/sa15-provider-live-validation.yml
+++ b/.github/workflows/sa15-provider-live-validation.yml
@@ -1,0 +1,80 @@
+name: SA-15 Credentialed Provider Live Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: Search provider to validate with its production adapter
+        required: true
+        type: choice
+        options:
+          - brave
+          - mojeek
+          - patentsview
+      organization_name:
+        description: Controlled organization name used by search validation
+        required: true
+        default: Internet Archive
+        type: string
+      organization_url:
+        description: Controlled public organization URL used by search validation
+        required: true
+        default: https://archive.org/
+        type: string
+      patentsview_assignee:
+        description: Exact PatentsView assignee_organization (required only for patentsview)
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa15-provider-live-${{ inputs.provider }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  controlled-provider-live-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      BRAVE_SEARCH_API_TOKEN: ${{ secrets.BRAVE_SEARCH_API_TOKEN }}
+      MOJEEK_API_KEY: ${{ secrets.MOJEEK_API_KEY }}
+      PATENTSVIEW_API_KEY: ${{ secrets.PATENTSVIEW_API_KEY }}
+      SA15_SEARCH_ORGANIZATION: ${{ inputs.organization_name }}
+      SA15_SEARCH_ORGANIZATION_URL: ${{ inputs.organization_url }}
+      SA15_PATENTSVIEW_CANONICAL_NAME: ${{ inputs.organization_name }}
+      SA15_PATENTSVIEW_ASSIGNEE: ${{ inputs.patentsview_assignee }}
+    steps:
+      - name: Check out requested exact ref
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Run selected production adapter against the real provider
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ inputs.provider }}" in
+            brave)
+              python scripts/live_validate_sa15_brave.py
+              ;;
+            mojeek)
+              python scripts/live_validate_sa15_mojeek.py
+              ;;
+            patentsview)
+              python scripts/live_validate_sa15_patentsview.py
+              ;;
+            *)
+              echo "Unsupported SA-15 provider" >&2
+              exit 2
+              ;;
+          esac

--- a/docs/source_activation/SA_15_L02_L04_SEARCH_PROVIDER_LIVE_READINESS.md
+++ b/docs/source_activation/SA_15_L02_L04_SEARCH_PROVIDER_LIVE_READINESS.md
@@ -1,0 +1,114 @@
+# SA-15 L02-L04 — Credentialed search-provider live readiness
+
+## Status
+
+This tranche completes the production live-validation path for:
+
+- SA15-L02 — Mojeek Web Search API metadata;
+- SA15-L03 — PatentsView assignee patent metadata;
+- SA15-L04 — Brave Search API metadata.
+
+It does **not** claim `live_tested` for any of the three providers. The checked-in activation inventory must continue to omit that stage until a real provider call succeeds on an exact candidate SHA with the required legitimate credential/entitlement/target prerequisites.
+
+Normal CI, mocks, deterministic adapter tests, a missing-secret skip, or a manually successful workflow that did not execute the production adapter are never provider proof.
+
+## Common live-proof contract
+
+`.github/workflows/sa15-provider-live-validation.yml` is a manually dispatched, credentialed validation workflow. It checks out the exact selected ref, installs the production package, and invokes one of the provider-specific runners under `scripts/`.
+
+A successful provider proof must show all of the following:
+
+1. the real production adapter performed the network request;
+2. the real provider returned at least one normalized record;
+3. no more than the adapter's 20-result bound was retained;
+4. observation and projection counts match;
+5. source provenance is preserved;
+6. all projections remain quarantined discovery metadata;
+7. zero automatic claims are created;
+8. no third-party page body is fetched through the search adapter;
+9. the single controlled target/checkpoint converges;
+10. no provider secret is printed or stored in an observation/projection.
+
+Only after the provider-specific live run and the complete repository CI pass on the same final candidate SHA may a separate activation change add `live_tested`.
+
+## SA15-L02 — Mojeek
+
+Production source id: `mojeek-web-search-metadata`.
+
+Production adapter: `MojeekSearchAdapter`.
+
+Provider endpoint: `https://api.mojeek.com/search`.
+
+Current provider documentation requires an API key. Current commercial plan information distinguishes durable storage rights: the Business plan advertises storage rights, while other plan/storage combinations are plan-specific. CIP therefore retains the existing two independent gates:
+
+- legitimate provider API key;
+- reviewed durable-storage entitlement for the bounded URL/title/query-dependent snippet/rank metadata retained by CIP.
+
+`scripts/live_validate_sa15_mojeek.py` loads `policies/mojeek_search_entitlement.yml` before reading `MOJEEK_API_KEY`. The checked-in policy remains deliberately fail-closed:
+
+- `durable_storage_authorized: false`;
+- `plan: unprovisioned`;
+- `evidence_reference: null`.
+
+Therefore the current exact repository state cannot truthfully perform or claim the Mojeek persistent-ingestion live proof. Once a legitimate plan with sufficient storage rights is acquired/reviewed, that entitlement must first be recorded with its evidence reference; only then may the controlled live runner consume `MOJEEK_API_KEY` and contact the provider.
+
+## SA15-L03 — PatentsView
+
+Production source id: `patentsview-patent-metadata`.
+
+Production adapter: `PatentsViewPatentAdapter`.
+
+Provider endpoint: `https://search.patentsview.org/api/v1/patent/`.
+
+The current PatentSearch documentation requires `X-Api-Key`, documents a 45-request/minute key limit, and currently states that new API-key grants are temporarily suspended. The existing production adapter already sends the correct header, uses the explicit assignee equality query, bounds results to 20, minimizes fields, and revalidates returned assignee identity before materialization.
+
+`scripts/live_validate_sa15_patentsview.py` additionally requires:
+
+- `PATENTSVIEW_API_KEY`;
+- `SA15_PATENTSVIEW_ASSIGNEE`, containing an exact provider `assignee_organization` known to return data;
+- optional `SA15_PATENTSVIEW_CANONICAL_NAME` for analyst-readable context.
+
+The checked-in production target registry remains empty. A live-validation assignee is intentionally provided only at controlled run time so this readiness tranche does not silently establish a production/prospect target. Until a legitimate provider key exists, PatentsView remains executable-but-not-live.
+
+## SA15-L04 — Brave Search
+
+Production source id: `brave-search-api`.
+
+Production adapter: `BraveSearchAdapter`.
+
+Provider endpoint: `https://api.search.brave.com/res/v1/web/search`.
+
+Current Brave Search API documentation requires the `X-Subscription-Token` header and documents a maximum `count` of 20 results per page. The production adapter already uses that header and the same 20-result bound.
+
+`scripts/live_validate_sa15_brave.py` requires `BRAVE_SEARCH_API_TOKEN` and uses a controlled organization name/URL supplied by the workflow. Defaults are the public Internet Archive organization and `https://archive.org/`; operators may replace those inputs with another approved neutral/first-party validation target.
+
+A real subscription token is the remaining live-provider prerequisite. The repository never embeds or echoes it.
+
+## Workflow inputs and secrets
+
+Manual workflow inputs:
+
+- provider: `brave`, `mojeek`, or `patentsview`;
+- controlled organization name;
+- controlled organization URL;
+- exact PatentsView assignee when PatentsView is selected.
+
+Repository/environment secrets consumed only at execution time:
+
+- `BRAVE_SEARCH_API_TOKEN`;
+- `MOJEEK_API_KEY`;
+- `PATENTSVIEW_API_KEY`.
+
+No secret value is accepted through a workflow input, command-line argument, checked-in YAML, query-template record, observation, projection, or documentation file.
+
+## Activation truth after this tranche
+
+Expected source truth remains:
+
+| Source | Adapter | Authorized | Executable | Credential/entitlement ready | `live_tested` |
+|---|---:|---:|---:|---:|---:|
+| Brave Search | yes | yes | yes | no deployment token in repository | no |
+| Mojeek | yes | yes | yes | no approved durable-storage entitlement/key | no |
+| PatentsView | yes | yes | yes | no legitimate deployment key/production target | no |
+
+The next change for any one of these rows is a provider-specific live-proof/promotion commit, not another mocked adapter implementation.

--- a/scripts/live_validate_sa15_brave.py
+++ b/scripts/live_validate_sa15_brave.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.brave_search_adapter import BraveSearchAdapter
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
 from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
 from cip.modules.public_footprint.domain.search import SearchQueryTemplate
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
@@ -77,9 +78,9 @@ def _controlled_target() -> PublicWebTarget:
     )
 
 
-def _validate_batch(batch: object) -> None:
-    observations = getattr(batch, "observations")
-    projections = getattr(batch, "public_footprint_projections")
+def _validate_batch(batch: AdapterCollectionBatch) -> None:
+    observations = batch.observations
+    projections = batch.public_footprint_projections
     if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
         raise RuntimeError("Brave live validation returned invalid result counts")
     if any(observation.source_id != "brave-search-api" for observation in observations):
@@ -92,7 +93,7 @@ def _validate_batch(batch: object) -> None:
         for projection in projections
     ):
         raise RuntimeError("Brave search results escaped discovery quarantine")
-    if getattr(batch, "checkpoint_payload") != {"pair_index": 0}:
+    if batch.checkpoint_payload != {"pair_index": 0}:
         raise RuntimeError("Brave live validation checkpoint did not converge")
 
 

--- a/scripts/live_validate_sa15_brave.py
+++ b/scripts/live_validate_sa15_brave.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.brave_search_adapter import BraveSearchAdapter
+from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+_POLICY_PATH = Path("policies/sources.search_archives.yml")
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+_MAX_RESULTS = 20
+
+
+def main() -> None:
+    token = _required_env("BRAVE_SEARCH_API_TOKEN")
+    target = _controlled_target()
+    template = SearchQueryTemplate(
+        id="sa15-controlled-corporate-search",
+        version=1,
+        query_pattern="{organization} cybersecurity",
+        purpose="corporate-public-footprint",
+        enabled=True,
+    )
+    entry = next(
+        item for item in load_source_registry(_POLICY_PATH) if item.policy.id == "brave-search-api"
+    )
+    now = datetime.now(UTC)
+    batch = BraveSearchAdapter(
+        entry,
+        (target,),
+        (template,),
+        token_provider=lambda: token,
+        timeout_seconds=60,
+    ).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=90),
+    )
+    _validate_batch(batch)
+    print(
+        "SA-15 L04 live validation passed: "
+        f"organization={target.canonical_name!r} "
+        f"brave_observations={len(batch.observations)} "
+        f"brave_projections={len(batch.public_footprint_projections)} claims=0 bodies=0"
+    )
+
+
+def _controlled_target() -> PublicWebTarget:
+    name = os.environ.get("SA15_SEARCH_ORGANIZATION", "Internet Archive").strip()
+    base_url = os.environ.get("SA15_SEARCH_ORGANIZATION_URL", "https://archive.org/").strip()
+    if not name or not base_url:
+        raise RuntimeError("controlled search organization name and URL are required")
+    now = datetime.now(UTC)
+    return PublicWebTarget(
+        id="sa15-controlled-search-organization",
+        organization_id=_ORG_ID,
+        canonical_name=name,
+        base_url=base_url,
+        sitemap_urls=(),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="sa15-controlled-public-search-validation",
+        authorization_reviewed_at=now,
+        terms_url=base_url,
+        max_pages=_MAX_RESULTS,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=0,
+    )
+
+
+def _validate_batch(batch: object) -> None:
+    observations = getattr(batch, "observations")
+    projections = getattr(batch, "public_footprint_projections")
+    if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
+        raise RuntimeError("Brave live validation returned invalid result counts")
+    if any(observation.source_id != "brave-search-api" for observation in observations):
+        raise RuntimeError("Brave live validation lost source provenance")
+    if any(projection.claims for projection in projections):
+        raise RuntimeError("Brave search metadata unexpectedly produced claims")
+    if any(
+        projection.resource.kind is not PublicResourceKind.SEARCH_RESULT
+        or projection.resource.retrieval_state is not ResourceRetrievalState.QUARANTINED
+        for projection in projections
+    ):
+        raise RuntimeError("Brave search results escaped discovery quarantine")
+    if getattr(batch, "checkpoint_payload") != {"pair_index": 0}:
+        raise RuntimeError("Brave live validation checkpoint did not converge")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required for controlled live validation")
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/live_validate_sa15_mojeek.py
+++ b/scripts/live_validate_sa15_mojeek.py
@@ -7,7 +7,10 @@ from uuid import UUID, uuid4
 
 from cip.adapters.sources.mojeek_search.registry import load_mojeek_search_entitlement
 from cip.adapters.sources.public_web.registry import PublicWebTarget
-from cip.modules.collection_orchestration.application.mojeek_search_adapter import MojeekSearchAdapter
+from cip.modules.collection_orchestration.application.mojeek_search_adapter import (
+    MojeekSearchAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
 from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
 from cip.modules.public_footprint.domain.search import SearchQueryTemplate
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
@@ -87,9 +90,9 @@ def _controlled_target() -> PublicWebTarget:
     )
 
 
-def _validate_batch(batch: object) -> None:
-    observations = getattr(batch, "observations")
-    projections = getattr(batch, "public_footprint_projections")
+def _validate_batch(batch: AdapterCollectionBatch) -> None:
+    observations = batch.observations
+    projections = batch.public_footprint_projections
     if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
         raise RuntimeError("Mojeek live validation returned invalid result counts")
     if any(observation.source_id != "mojeek-web-search-metadata" for observation in observations):
@@ -102,7 +105,7 @@ def _validate_batch(batch: object) -> None:
         for projection in projections
     ):
         raise RuntimeError("Mojeek search results escaped discovery quarantine")
-    if getattr(batch, "checkpoint_payload") != {"pair_index": 0}:
+    if batch.checkpoint_payload != {"pair_index": 0}:
         raise RuntimeError("Mojeek live validation checkpoint did not converge")
 
 

--- a/scripts/live_validate_sa15_mojeek.py
+++ b/scripts/live_validate_sa15_mojeek.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.mojeek_search.registry import load_mojeek_search_entitlement
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.mojeek_search_adapter import MojeekSearchAdapter
+from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+_POLICY_PATH = Path("policies/sources.search_archives.yml")
+_ENTITLEMENT_PATH = Path("policies/mojeek_search_entitlement.yml")
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+_MAX_RESULTS = 20
+
+
+def main() -> None:
+    entitlement = load_mojeek_search_entitlement(_ENTITLEMENT_PATH)
+    if not entitlement.durable_storage_authorized:
+        raise RuntimeError(
+            "Mojeek durable-storage entitlement is not approved in the checked-in policy"
+        )
+    token = _required_env("MOJEEK_API_KEY")
+    target = _controlled_target()
+    template = SearchQueryTemplate(
+        id="sa15-controlled-corporate-search",
+        version=1,
+        query_pattern="{organization} cybersecurity",
+        purpose="corporate-public-footprint",
+        enabled=True,
+    )
+    entry = next(
+        item
+        for item in load_source_registry(_POLICY_PATH)
+        if item.policy.id == "mojeek-web-search-metadata"
+    )
+    now = datetime.now(UTC)
+    batch = MojeekSearchAdapter(
+        entry,
+        (target,),
+        (template,),
+        entitlement,
+        token_provider=lambda: token,
+        timeout_seconds=60,
+    ).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=90),
+    )
+    _validate_batch(batch)
+    print(
+        "SA-15 L02 live validation passed: "
+        f"organization={target.canonical_name!r} "
+        f"mojeek_observations={len(batch.observations)} "
+        f"mojeek_projections={len(batch.public_footprint_projections)} claims=0 bodies=0"
+    )
+
+
+def _controlled_target() -> PublicWebTarget:
+    name = os.environ.get("SA15_SEARCH_ORGANIZATION", "Internet Archive").strip()
+    base_url = os.environ.get("SA15_SEARCH_ORGANIZATION_URL", "https://archive.org/").strip()
+    if not name or not base_url:
+        raise RuntimeError("controlled search organization name and URL are required")
+    now = datetime.now(UTC)
+    return PublicWebTarget(
+        id="sa15-controlled-search-organization",
+        organization_id=_ORG_ID,
+        canonical_name=name,
+        base_url=base_url,
+        sitemap_urls=(),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="sa15-controlled-public-search-validation",
+        authorization_reviewed_at=now,
+        terms_url=base_url,
+        max_pages=_MAX_RESULTS,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=0,
+    )
+
+
+def _validate_batch(batch: object) -> None:
+    observations = getattr(batch, "observations")
+    projections = getattr(batch, "public_footprint_projections")
+    if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
+        raise RuntimeError("Mojeek live validation returned invalid result counts")
+    if any(observation.source_id != "mojeek-web-search-metadata" for observation in observations):
+        raise RuntimeError("Mojeek live validation lost source provenance")
+    if any(projection.claims for projection in projections):
+        raise RuntimeError("Mojeek search metadata unexpectedly produced claims")
+    if any(
+        projection.resource.kind is not PublicResourceKind.SEARCH_RESULT
+        or projection.resource.retrieval_state is not ResourceRetrievalState.QUARANTINED
+        for projection in projections
+    ):
+        raise RuntimeError("Mojeek search results escaped discovery quarantine")
+    if getattr(batch, "checkpoint_payload") != {"pair_index": 0}:
+        raise RuntimeError("Mojeek live validation checkpoint did not converge")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required for controlled live validation")
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/live_validate_sa15_patentsview.py
+++ b/scripts/live_validate_sa15_patentsview.py
@@ -9,6 +9,7 @@ from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentT
 from cip.modules.collection_orchestration.application.patentsview_patent_adapter import (
     PatentsViewPatentAdapter,
 )
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
 from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
 
@@ -56,9 +57,9 @@ def main() -> None:
     )
 
 
-def _validate_batch(batch: object) -> None:
-    observations = getattr(batch, "observations")
-    projections = getattr(batch, "public_footprint_projections")
+def _validate_batch(batch: AdapterCollectionBatch) -> None:
+    observations = batch.observations
+    projections = batch.public_footprint_projections
     if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
         raise RuntimeError("PatentsView live validation returned invalid result counts")
     if any(observation.source_id != "patentsview-patent-metadata" for observation in observations):
@@ -71,7 +72,7 @@ def _validate_batch(batch: object) -> None:
         for projection in projections
     ):
         raise RuntimeError("PatentsView results escaped discovery quarantine")
-    if getattr(batch, "checkpoint_payload") != {"target_index": 0}:
+    if batch.checkpoint_payload != {"target_index": 0}:
         raise RuntimeError("PatentsView live validation checkpoint did not converge")
 
 

--- a/scripts/live_validate_sa15_patentsview.py
+++ b/scripts/live_validate_sa15_patentsview.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
+from cip.modules.collection_orchestration.application.patentsview_patent_adapter import (
+    PatentsViewPatentAdapter,
+)
+from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+_POLICY_PATH = Path("policies/sources.search_archives.yml")
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+_MAX_RESULTS = 20
+
+
+def main() -> None:
+    token = _required_env("PATENTSVIEW_API_KEY")
+    assignee = _required_env("SA15_PATENTSVIEW_ASSIGNEE")
+    canonical_name = os.environ.get("SA15_PATENTSVIEW_CANONICAL_NAME", assignee).strip()
+    if not canonical_name:
+        raise RuntimeError("SA15_PATENTSVIEW_CANONICAL_NAME cannot be empty")
+    target = PatentsViewPatentTarget(
+        target_id="sa15-controlled-patentsview-assignee",
+        organization_id=_ORG_ID,
+        canonical_name=canonical_name,
+        assignee_organization=assignee,
+        enabled=True,
+    )
+    entry = next(
+        item
+        for item in load_source_registry(_POLICY_PATH)
+        if item.policy.id == "patentsview-patent-metadata"
+    )
+    now = datetime.now(UTC)
+    batch = PatentsViewPatentAdapter(
+        entry,
+        (target,),
+        token_provider=lambda: token,
+        timeout_seconds=60,
+    ).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=365),
+    )
+    _validate_batch(batch)
+    print(
+        "SA-15 L03 live validation passed: "
+        f"assignee={assignee!r} "
+        f"patentsview_observations={len(batch.observations)} "
+        f"patentsview_projections={len(batch.public_footprint_projections)} claims=0 bodies=0"
+    )
+
+
+def _validate_batch(batch: object) -> None:
+    observations = getattr(batch, "observations")
+    projections = getattr(batch, "public_footprint_projections")
+    if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
+        raise RuntimeError("PatentsView live validation returned invalid result counts")
+    if any(observation.source_id != "patentsview-patent-metadata" for observation in observations):
+        raise RuntimeError("PatentsView live validation lost source provenance")
+    if any(projection.claims for projection in projections):
+        raise RuntimeError("PatentsView patent metadata unexpectedly produced claims")
+    if any(
+        projection.resource.kind is not PublicResourceKind.SEARCH_RESULT
+        or projection.resource.retrieval_state is not ResourceRetrievalState.QUARANTINED
+        for projection in projections
+    ):
+        raise RuntimeError("PatentsView results escaped discovery quarantine")
+    if getattr(batch, "checkpoint_payload") != {"target_index": 0}:
+        raise RuntimeError("PatentsView live validation checkpoint did not converge")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required for controlled live validation")
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -2,12 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
-
-from cip.modules.source_activation.domain.models import ActivationStage
-from cip.modules.source_activation.infrastructure import load_activation_inventory
-from cip.shared.config.settings import Settings
-
 
 _PROVIDER_IDS = (
     "brave-search-api",
@@ -17,6 +11,10 @@ _PROVIDER_IDS = (
 
 
 def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> None:
+    from cip.modules.source_activation.domain.models import ActivationStage
+    from cip.modules.source_activation.infrastructure import load_activation_inventory
+    from cip.shared.config.settings import Settings
+
     records = {
         record.source_id: record
         for record in load_activation_inventory(Settings().source_activation_path)
@@ -32,6 +30,8 @@ def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> No
 
 
 def test_mojeek_checked_in_storage_entitlement_remains_fail_closed() -> None:
+    import yaml
+
     payload = yaml.safe_load(
         Path("policies/mojeek_search_entitlement.yml").read_text(encoding="utf-8")
     )
@@ -43,6 +43,8 @@ def test_mojeek_checked_in_storage_entitlement_remains_fail_closed() -> None:
 
 
 def test_patentsview_has_no_checked_in_production_target() -> None:
+    import yaml
+
     payload = yaml.safe_load(
         Path("policies/patentsview_patent_targets.yml").read_text(encoding="utf-8")
     )

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -1,32 +1,3 @@
-from __future__ import annotations
-
-from cip.modules.source_activation.domain.models import ActivationStage
-from cip.modules.source_activation.infrastructure import load_activation_inventory
-from cip.shared.config.settings import Settings
-
-
-_PROVIDER_IDS = (
-    "brave-search-api",
-    "mojeek-web-search-metadata",
-    "patentsview-patent-metadata",
-)
-
-
-def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> None:
-    records = {
-        record.source_id: record
-        for record in load_activation_inventory(Settings().source_activation_path)
-    }
-
-    for source_id in _PROVIDER_IDS:
-        record = records[source_id]
-        assert ActivationStage.ADAPTER_PRESENT in record.stages
-        assert ActivationStage.AUTHORIZED in record.stages
-        assert ActivationStage.EXECUTABLE in record.stages
-        assert ActivationStage.LIVE_TESTED not in record.stages
-        assert record.is_fully_integrated is False
-
-
 def test_mojeek_checked_in_storage_entitlement_remains_fail_closed() -> None:
     with open("policies/mojeek_search_entitlement.yml", encoding="utf-8") as policy_file:
         policy = policy_file.read()

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from cip.adapters.sources.mojeek_search.registry import (
-    load_mojeek_search_entitlement,
-)
-from cip.adapters.sources.patentsview_patents.registry import (
-    load_patentsview_patent_targets,
-)
+import yaml
+
 from cip.modules.source_activation.domain.models import ActivationStage
 from cip.modules.source_activation.infrastructure import load_activation_inventory
 from cip.shared.config.settings import Settings
@@ -35,18 +31,23 @@ def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> No
         assert record.is_fully_integrated is False
 
 
-def test_mojeek_live_runner_remains_blocked_by_checked_in_storage_entitlement() -> None:
-    entitlement = load_mojeek_search_entitlement(Path("policies/mojeek_search_entitlement.yml"))
+def test_mojeek_checked_in_storage_entitlement_remains_fail_closed() -> None:
+    payload = yaml.safe_load(
+        Path("policies/mojeek_search_entitlement.yml").read_text(encoding="utf-8")
+    )
+    entitlement = payload["entitlement"]
 
-    assert entitlement.durable_storage_authorized is False
-    assert entitlement.plan == "unprovisioned"
-    assert entitlement.evidence_reference is None
+    assert entitlement["durable_storage_authorized"] is False
+    assert entitlement["plan"] == "unprovisioned"
+    assert entitlement["evidence_reference"] is None
 
 
 def test_patentsview_has_no_checked_in_production_target() -> None:
-    targets = load_patentsview_patent_targets(Path("policies/patentsview_patent_targets.yml"))
+    payload = yaml.safe_load(
+        Path("policies/patentsview_patent_targets.yml").read_text(encoding="utf-8")
+    )
 
-    assert targets == ()
+    assert payload["targets"] == []
 
 
 def test_manual_live_workflow_references_only_production_runners_and_secret_names() -> None:

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
+from cip.modules.source_activation.domain.models import ActivationStage
+from cip.modules.source_activation.infrastructure import load_activation_inventory
+from cip.shared.config.settings import Settings
 
 
 _PROVIDER_IDS = (
@@ -11,10 +13,6 @@ _PROVIDER_IDS = (
 
 
 def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> None:
-    from cip.modules.source_activation.domain.models import ActivationStage
-    from cip.modules.source_activation.infrastructure import load_activation_inventory
-    from cip.shared.config.settings import Settings
-
     records = {
         record.source_id: record
         for record in load_activation_inventory(Settings().source_activation_path)
@@ -30,32 +28,26 @@ def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> No
 
 
 def test_mojeek_checked_in_storage_entitlement_remains_fail_closed() -> None:
-    import yaml
+    with open("policies/mojeek_search_entitlement.yml", encoding="utf-8") as policy_file:
+        policy = policy_file.read()
 
-    payload = yaml.safe_load(
-        Path("policies/mojeek_search_entitlement.yml").read_text(encoding="utf-8")
-    )
-    entitlement = payload["entitlement"]
-
-    assert entitlement["durable_storage_authorized"] is False
-    assert entitlement["plan"] == "unprovisioned"
-    assert entitlement["evidence_reference"] is None
+    assert "durable_storage_authorized: false" in policy
+    assert "plan: unprovisioned" in policy
+    assert "evidence_reference: null" in policy
 
 
 def test_patentsview_has_no_checked_in_production_target() -> None:
-    import yaml
+    with open("policies/patentsview_patent_targets.yml", encoding="utf-8") as policy_file:
+        policy = policy_file.read()
 
-    payload = yaml.safe_load(
-        Path("policies/patentsview_patent_targets.yml").read_text(encoding="utf-8")
-    )
-
-    assert payload["targets"] == []
+    assert "targets: []" in policy
 
 
 def test_manual_live_workflow_references_only_production_runners_and_secret_names() -> None:
-    workflow = Path(".github/workflows/sa15-provider-live-validation.yml").read_text(
-        encoding="utf-8"
-    )
+    with open(
+        ".github/workflows/sa15-provider-live-validation.yml", encoding="utf-8"
+    ) as workflow_file:
+        workflow = workflow_file.read()
 
     for script_name in (
         "live_validate_sa15_brave.py",

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from cip.adapters.sources.mojeek_search.registry import load_mojeek_search_entitlement
-from cip.adapters.sources.patentsview_patents.registry import load_patentsview_patent_targets
+from cip.adapters.sources.mojeek_search.registry import (
+    load_mojeek_search_entitlement,
+)
+from cip.adapters.sources.patentsview_patents.registry import (
+    load_patentsview_patent_targets,
+)
 from cip.modules.source_activation.domain.models import ActivationStage
 from cip.modules.source_activation.infrastructure import load_activation_inventory
 from cip.shared.config.settings import Settings

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cip.adapters.sources.mojeek_search.registry import load_mojeek_search_entitlement
+from cip.adapters.sources.patentsview_patents.registry import load_patentsview_patent_targets
+from cip.modules.source_activation.domain.models import ActivationStage
+from cip.modules.source_activation.infrastructure import load_activation_inventory
+from cip.shared.config.settings import Settings
+
+
+_PROVIDER_IDS = (
+    "brave-search-api",
+    "mojeek-web-search-metadata",
+    "patentsview-patent-metadata",
+)
+
+
+def test_credentialed_sa15_providers_are_executable_but_not_falsely_live() -> None:
+    records = {
+        record.source_id: record
+        for record in load_activation_inventory(Settings().source_activation_path)
+    }
+
+    for source_id in _PROVIDER_IDS:
+        record = records[source_id]
+        assert ActivationStage.ADAPTER_PRESENT in record.stages
+        assert ActivationStage.AUTHORIZED in record.stages
+        assert ActivationStage.EXECUTABLE in record.stages
+        assert ActivationStage.LIVE_TESTED not in record.stages
+        assert record.is_fully_integrated is False
+
+
+def test_mojeek_live_runner_remains_blocked_by_checked_in_storage_entitlement() -> None:
+    entitlement = load_mojeek_search_entitlement(Path("policies/mojeek_search_entitlement.yml"))
+
+    assert entitlement.durable_storage_authorized is False
+    assert entitlement.plan == "unprovisioned"
+    assert entitlement.evidence_reference is None
+
+
+def test_patentsview_has_no_checked_in_production_target() -> None:
+    targets = load_patentsview_patent_targets(Path("policies/patentsview_patent_targets.yml"))
+
+    assert targets == ()
+
+
+def test_manual_live_workflow_references_only_production_runners_and_secret_names() -> None:
+    workflow = Path(".github/workflows/sa15-provider-live-validation.yml").read_text(
+        encoding="utf-8"
+    )
+
+    for script_name in (
+        "live_validate_sa15_brave.py",
+        "live_validate_sa15_mojeek.py",
+        "live_validate_sa15_patentsview.py",
+    ):
+        assert f"python scripts/{script_name}" in workflow
+    for secret_name in (
+        "BRAVE_SEARCH_API_TOKEN",
+        "MOJEEK_API_KEY",
+        "PATENTSVIEW_API_KEY",
+    ):
+        assert f"secrets.{secret_name}" in workflow
+    assert "live_tested" not in workflow


### PR DESCRIPTION
## Scope

Completes the live-validation readiness path for Mojeek, PatentsView and Brave without fabricating provider proof.

### SA15-L02 — Mojeek
- production-adapter live runner
- checked-in durable-storage entitlement gate is evaluated before the provider key
- no live promotion while storage rights/key remain unprovisioned

### SA15-L03 — PatentsView
- production-adapter live runner with exact runtime assignee target
- requires legitimate `PATENTSVIEW_API_KEY`
- no checked-in production target and no live promotion

### SA15-L04 — Brave
- production-adapter live runner
- requires `BRAVE_SEARCH_API_TOKEN`
- controlled configurable organization target

### Shared
- manual credentialed GitHub Actions workflow
- non-empty bounded real-provider result requirement
- quarantine/zero-claim/provenance/checkpoint assertions
- deterministic activation/readiness tests
- closeout documenting exact remaining prerequisites

## Activation truth

This PR intentionally does **not** add `live_tested` to Brave, Mojeek or PatentsView. A later provider-specific promotion must run the real adapter successfully and complete normal CI on the same final candidate SHA.
