### PR TITLE
SA16-L01: automatic governed company crawl target

### DIFF
--- a/.github/workflows/sa16-l01-live-validation.yml
+++ b/.github/workflows/sa16-l01-live-validation.yml
@@ -1,0 +1,33 @@
+name: SA-16 L01 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa16-l01-live-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-automatic-public-web-target:
+    if: github.event.pull_request.head.ref == 'agent/sa16-l01-auto-crawl-target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled automatic company-target production live validation
+        run: python scripts/live_validate_sa16_l01.py

--- a/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
+++ b/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
@@ -2,15 +2,20 @@
 
 ## Status
 
-`IN_PROGRESS` until both the repository CI and the dedicated real-network live workflow pass on the exact final candidate SHA.
+`LIVE_TESTED` on the implementation candidate and awaiting the mandatory exact-head revalidation of this proof/documentation commit before merge.
 
-This increment must not be called complete, `live_tested`, or fully integrated before that proof exists.
+The first real production-path proof succeeded on implementation head `1fed10fe0fdcc1959b06cc6bd57b1678dcc03d51`:
+
+- SA-16 L01 Live Validation run `31588271537`: **PASS**;
+- normal CI run `31588271512` / CI #1921: **PASS**.
+
+Because recording this proof changes the PR head, repository rules require both gates to pass again on the new final SHA. Until that second pass completes, the PR remains draft and must not be merged.
 
 ## Objective
 
 Remove the developer-edited-YAML dependency between a resolved organization website and the first governed public-web collection.
 
-The intended runtime chain is:
+The implemented runtime chain is:
 
 ```text
 Organization.website_url
@@ -79,7 +84,7 @@ It intentionally does not guess that `/sitemap.xml` exists. Automatic robots/sit
 
 ## Deterministic validation
 
-Unit coverage must prove:
+Unit coverage proves:
 
 - a canonical website is mandatory;
 - target identity is deterministic;
@@ -107,6 +112,22 @@ Organization(Python Software Foundation, https://www.python.org/)
 -> non-empty RawObservation / PublicResource projection
 ```
 
+### First successful proof
+
+On implementation head `1fed10fe0fdcc1959b06cc6bd57b1678dcc03d51`, the dedicated real-network workflow reported:
+
+```text
+SA-16 L01 live validation passed:
+organization='Python Software Foundation'
+target=public-web-15712d0d905450b48a26e25d9ea1f509
+source=automatic-public-company-web
+observations=1
+projections=1
+homepage=https://www.python.org/
+```
+
+The live gate therefore proved that the production client and production collector can consume a target generated from a real organization website, fetch real public data, retain exact source provenance and stay inside the approved origin.
+
 The live gate fails unless:
 
 1. the generated homepage is checkpointed;
@@ -117,7 +138,7 @@ The live gate fails unless:
 
 ## Completion rule
 
-L01 becomes `IMPLEMENTED_VALIDATED` / `live_tested` only after:
+L01 is merge-valid only after:
 
 1. deterministic tests pass;
 2. Ruff passes;
@@ -128,6 +149,6 @@ L01 becomes `IMPLEMENTED_VALIDATED` / `live_tested` only after:
 7. frontend quality remains green;
 8. the SA-16 L01 real-network workflow passes using the production client and collector;
 9. the live proof is recorded in this document;
-10. the documentation/live-state commit is itself revalidated by both normal CI and the live workflow on the exact final SHA.
+10. this documentation/live-state commit itself passes both normal CI and the live workflow on the exact final SHA.
 
 A skipped live job, mocked HTTP response, documentation-only claim, or earlier SHA does not satisfy this gate.

--- a/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
+++ b/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
@@ -1,0 +1,133 @@
+# SA-16 L01 — Automatic governed company crawl target
+
+## Status
+
+`IN_PROGRESS` until both the repository CI and the dedicated real-network live workflow pass on the exact final candidate SHA.
+
+This increment must not be called complete, `live_tested`, or fully integrated before that proof exists.
+
+## Objective
+
+Remove the developer-edited-YAML dependency between a resolved organization website and the first governed public-web collection.
+
+The intended runtime chain is:
+
+```text
+Organization.website_url
+-> AutomaticPublicWebPolicy
+-> deterministic PublicWebTarget
+-> exact generated SourcePolicy / SourceAuthorization
+-> PublicWebClient
+-> collect_public_web_target
+-> RawObservation + PublicResource provenance
+```
+
+L01 does not implement recursive link traversal, sitemap-index recursion, generalized browser rendering, or incremental recrawl. Those remain subsequent SA-16 increments.
+
+## Architecture decisions
+
+### Reuse the canonical public-web target
+
+`PublicWebTarget` remains the single target definition. L01 extends it with:
+
+- `seed_urls` for explicit first-party entry pages such as the canonical homepage;
+- `source_id` so a unique organization target identity is not confused with the governed acquisition-source identity.
+
+Existing checked-in targets remain backward compatible: when `source_id` is omitted, it defaults to the existing target `id`.
+
+### Generated governance, not per-company source YAML
+
+The previous collector required `SourceRegistryEntry.policy.id == PublicWebTarget.id`. That made an automatic organization target effectively require a new source-policy record for every company.
+
+L01 separates those identities. `provision_public_web_target()` generates an exact runtime `SourcePolicy` and `SourceAuthorization` from a deployment-approved organization/domain policy. The generated authorization is limited to:
+
+- the canonical website host;
+- approved path prefixes;
+- the `corporate-public-footprint` purpose;
+- bounded automated collection;
+- no raw-content storage.
+
+Policy evaluation still happens before the robots request and before every discovered resource request.
+
+### Deterministic target identity
+
+The target id is derived from the canonical organization UUID:
+
+```text
+public-web-<organization UUID hex>
+```
+
+The source identity for this capability is:
+
+```text
+automatic-public-company-web
+```
+
+Raw observations and public-resource projections retain the governed source identity while the organization id and target id preserve target lineage.
+
+## Initial discovery behavior
+
+L01 provisions:
+
+- canonical homepage as an explicit `DIRECT` seed;
+- `/.well-known/security.txt` discovery;
+- exact crawl-scope budgets;
+- first-crawl timestamp;
+- refresh interval metadata.
+
+It intentionally does not guess that `/sitemap.xml` exists. Automatic robots/sitemap/feed discovery and recursive traversal are owned by the following SA-16 crawler increments.
+
+## Deterministic validation
+
+Unit coverage must prove:
+
+- a canonical website is mandatory;
+- target identity is deterministic;
+- source and target identities remain distinct;
+- homepage and security.txt remain same-origin;
+- generated governance permits the approved host and denies another host before collection;
+- raw storage remains disabled;
+- expired authorization fails closed;
+- legacy target source-id behavior remains compatible.
+
+Unit tests remain network-free.
+
+## Controlled live validation
+
+The dedicated production-path runner uses the public Python Software Foundation website as the neutral approved validation target:
+
+```text
+Organization(Python Software Foundation, https://www.python.org/)
+-> automatic target provisioning
+-> generated exact host/path authorization
+-> real PublicWebClient
+-> real robots.txt request
+-> real homepage request
+-> optional security.txt handling
+-> non-empty RawObservation / PublicResource projection
+```
+
+The live gate fails unless:
+
+1. the generated homepage is checkpointed;
+2. at least one real observation and projection are produced;
+3. every observation and projection uses `automatic-public-company-web` provenance;
+4. no canonical resource escapes `https://www.python.org/`;
+5. the production collector, not a mock transport, performs the network requests.
+
+## Completion rule
+
+L01 becomes `IMPLEMENTED_VALIDATED` / `live_tested` only after:
+
+1. deterministic tests pass;
+2. Ruff passes;
+3. strict Mypy passes;
+4. architecture/release contracts pass;
+5. migration gates remain green;
+6. complete backend coverage remains at or above repository thresholds;
+7. frontend quality remains green;
+8. the SA-16 L01 real-network workflow passes using the production client and collector;
+9. the live proof is recorded in this document;
+10. the documentation/live-state commit is itself revalidated by both normal CI and the live workflow on the exact final SHA.
+
+A skipped live job, mocked HTTP response, documentation-only claim, or earlier SHA does not satisfy this gate.

--- a/scripts/live_validate_sa16_l01.py
+++ b/scripts/live_validate_sa16_l01.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.provisioning import (
+    AUTOMATIC_PUBLIC_WEB_SOURCE_ID,
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.modules.organizations.domain.entities import Organization
+
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+_TARGET_URL = "https://www.python.org/"
+
+
+def main() -> None:
+    now = datetime.now(UTC)
+    organization = Organization(
+        id=_ORG_ID,
+        canonical_name="Python Software Foundation",
+        website_url=_TARGET_URL,
+        created_at=now,
+        updated_at=now,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l01-controlled-python-org-public-target",
+            reviewed_at=now,
+            allowed_path_prefixes=("/",),
+            refresh_interval_seconds=86_400,
+            max_pages=2,
+            max_total_bytes=2_000_000,
+            max_resource_bytes=1_000_000,
+            max_redirects=1,
+        ),
+        first_crawl_at=now,
+    )
+    with httpx.Client(timeout=30.0) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            provisioned.source_entry,
+            provisioned.target,
+            collection_job_id=uuid4(),
+            collected_at=now,
+            retention_until=now + timedelta(days=365),
+        )
+
+    homepage = provisioned.target.seed_urls[0]
+    if homepage not in batch.checkpoint.pages:
+        raise RuntimeError("SA16-L01 live crawl did not checkpoint the generated homepage seed")
+    if not batch.observations or not batch.projections:
+        raise RuntimeError("SA16-L01 live crawl returned no public-web data")
+    if any(item.source_id != AUTOMATIC_PUBLIC_WEB_SOURCE_ID for item in batch.observations):
+        raise RuntimeError("SA16-L01 observations lost governed source provenance")
+    if any(
+        projection.resource.source_id != AUTOMATIC_PUBLIC_WEB_SOURCE_ID
+        for projection in batch.projections
+    ):
+        raise RuntimeError("SA16-L01 projections lost governed source provenance")
+    if any(
+        not projection.resource.canonical_url.startswith(_TARGET_URL)
+        for projection in batch.projections
+    ):
+        raise RuntimeError("SA16-L01 live crawl escaped the approved origin")
+
+    print(
+        "SA-16 L01 live validation passed: "
+        f"organization={organization.canonical_name!r} target={provisioned.target.id} "
+        f"source={AUTOMATIC_PUBLIC_WEB_SOURCE_ID} observations={len(batch.observations)} "
+        f"projections={len(batch.projections)} homepage={homepage}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -79,8 +79,8 @@ def collect_public_web_target(
     checkpoint: PublicWebCheckpoint | None = None,
 ) -> PublicWebCollectionBatch:
     collected = require_aware_utc(collected_at, field_name="collected_at")
-    if entry.policy.id != target.id:
-        raise ValueError("public web source policy and target id must match")
+    if entry.policy.id != target.source_id:
+        raise ValueError("public web source policy and target source_id must match")
     if not target.executable_at(collected):
         raise PublicWebCollectionDeniedError("target_authorization_inactive")
     _authorize(entry, target.robots_url, now=collected)
@@ -147,6 +147,16 @@ def _discover_candidates(
     candidates: list[PublicWebDiscoveryCandidate] = []
     seen: set[str] = set()
     total_bytes = _checked_total_bytes(target, initial_bytes)
+    for seed_url in target.seed_urls:
+        _append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=seed_url,
+                discovery_method=DiscoveryMethod.DIRECT,
+            ),
+            max_pages=target.max_pages,
+        )
     if target.discover_security_txt:
         _append_candidate(
             candidates,

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -156,7 +156,7 @@ def _resource(
     kind = _resource_kind(result, previous)
     return PublicResource(
         organization_id=target.organization_id,
-        source_id=target.id,
+        source_id=target.source_id or target.id,
         source_record_key=result.requested_url,
         canonical_url=result.fetched_url,
         source_url=discovery_source_url or result.requested_url,
@@ -236,7 +236,7 @@ def _observation(
     if not tombstoned and include_technology_category:
         categories.add(DataCategory.TECHNOLOGY_OBSERVATION)
     return RawObservation(
-        source_id=target.id,
+        source_id=target.source_id or target.id,
         adapter_id="public-web-sitemap",
         adapter_version="1",
         collection_job_id=collection_job_id,

--- a/src/cip/adapters/sources/public_web/provisioning.py
+++ b/src/cip/adapters/sources/public_web/provisioning.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    DataCategory,
+    SourceAuthorization,
+    SourcePolicy,
+    SourceStatus,
+    SourceType,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+from cip.shared.kernel.time import require_aware_utc
+
+AUTOMATIC_PUBLIC_WEB_SOURCE_ID = "automatic-public-company-web"
+_PURPOSE = "corporate-public-footprint"
+_PROHIBITED_DATA = frozenset(
+    {
+        DataCategory.CREDENTIAL,
+        DataCategory.VICTIM_FILE,
+        DataCategory.PRIVATE_COMMUNICATION,
+        DataCategory.PRIVATE_PERSONAL_DATA,
+        DataCategory.RESTRICTED_CONTENT,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AutomaticPublicWebPolicy:
+    authorization_reference: str
+    reviewed_at: datetime
+    expires_at: datetime | None = None
+    allowed_path_prefixes: tuple[str, ...] = ("/",)
+    refresh_interval_seconds: int = 86_400
+    max_pages: int = 100
+    max_total_bytes: int = 10_000_000
+    max_resource_bytes: int = 1_000_000
+    max_redirects: int = 3
+
+    def __post_init__(self) -> None:
+        reference = self.authorization_reference.strip()
+        if not reference:
+            raise ValueError("authorization_reference is required")
+        reviewed = require_aware_utc(self.reviewed_at, field_name="reviewed_at")
+        expires = self.expires_at
+        if expires is not None:
+            expires = require_aware_utc(expires, field_name="expires_at")
+            if expires <= reviewed:
+                raise ValueError("expires_at must follow reviewed_at")
+        if not self.allowed_path_prefixes or any(
+            not prefix.startswith("/") for prefix in self.allowed_path_prefixes
+        ):
+            raise ValueError("allowed_path_prefixes must contain absolute paths")
+        if self.refresh_interval_seconds < 60:
+            raise ValueError("refresh_interval_seconds must be at least 60")
+        object.__setattr__(self, "authorization_reference", reference)
+        object.__setattr__(self, "reviewed_at", reviewed)
+        object.__setattr__(self, "expires_at", expires)
+
+
+@dataclass(frozen=True, slots=True)
+class ProvisionedPublicWebTarget:
+    target: PublicWebTarget
+    source_entry: SourceRegistryEntry
+    first_crawl_at: datetime
+    refresh_interval_seconds: int
+
+
+def provision_public_web_target(
+    organization: Organization,
+    policy: AutomaticPublicWebPolicy,
+    *,
+    first_crawl_at: datetime,
+) -> ProvisionedPublicWebTarget:
+    if organization.website_url is None:
+        raise ValueError("organization requires a canonical website_url")
+    first_crawl = require_aware_utc(first_crawl_at, field_name="first_crawl_at")
+    base = CanonicalUrl(organization.website_url)
+    homepage = f"{base.origin}/"
+    target = PublicWebTarget(
+        id=f"public-web-{organization.id.hex}",
+        source_id=AUTOMATIC_PUBLIC_WEB_SOURCE_ID,
+        organization_id=organization.id,
+        canonical_name=organization.canonical_name,
+        base_url=homepage,
+        seed_urls=(homepage,),
+        sitemap_urls=(),
+        feed_urls=(),
+        discover_security_txt=True,
+        allowed_path_prefixes=policy.allowed_path_prefixes,
+        enabled=True,
+        authorization_reference=policy.authorization_reference,
+        authorization_reviewed_at=policy.reviewed_at,
+        authorization_expires_at=policy.expires_at,
+        max_pages=policy.max_pages,
+        max_total_bytes=policy.max_total_bytes,
+        max_resource_bytes=policy.max_resource_bytes,
+        max_redirects=policy.max_redirects,
+    )
+    return ProvisionedPublicWebTarget(
+        target=target,
+        source_entry=_source_entry(target, policy),
+        first_crawl_at=first_crawl,
+        refresh_interval_seconds=policy.refresh_interval_seconds,
+    )
+
+
+def _source_entry(
+    target: PublicWebTarget,
+    policy: AutomaticPublicWebPolicy,
+) -> SourceRegistryEntry:
+    source_policy = SourcePolicy(
+        id=AUTOMATIC_PUBLIC_WEB_SOURCE_ID,
+        name="Automatic public company website research",
+        base_url=target.base_url,
+        status=SourceStatus.ENABLED,
+        source_type=SourceType.STATIC_HTTP,
+        owner=target.canonical_name,
+        licence="Deployment-approved bounded first-party public web research",
+        allowed_data_categories=frozenset({DataCategory.OFFICIAL_DOCUMENT_DISCOVERY}),
+        prohibited_data_categories=_PROHIBITED_DATA,
+        retention_days=365,
+        attribution_required=True,
+        raw_content_storage=False,
+        human_review_required=False,
+    )
+    authorization = SourceAuthorization(
+        status=AuthorizationStatus.APPROVED,
+        document_reference=policy.authorization_reference,
+        reviewed_at=policy.reviewed_at,
+        expires_at=policy.expires_at,
+        approved_hosts=frozenset({target.host}),
+        approved_path_prefixes=target.allowed_path_prefixes,
+        approved_purposes=frozenset({_PURPOSE}),
+        automated_collection_allowed=True,
+        raw_storage_allowed=False,
+    )
+    return SourceRegistryEntry(
+        policy=source_policy,
+        authorization=authorization,
+        economics={"monthly_cost": 0},
+        notes="Generated from a deployment-approved canonical organization domain.",
+    )

--- a/src/cip/adapters/sources/public_web/provisioning.py
+++ b/src/cip/adapters/sources/public_web/provisioning.py
@@ -122,7 +122,12 @@ def _source_entry(
         source_type=SourceType.STATIC_HTTP,
         owner=target.canonical_name,
         licence="Deployment-approved bounded first-party public web research",
-        allowed_data_categories=frozenset({DataCategory.OFFICIAL_DOCUMENT_DISCOVERY}),
+        allowed_data_categories=frozenset(
+            {
+                DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,
+                DataCategory.TECHNOLOGY_OBSERVATION,
+            }
+        ),
         prohibited_data_categories=_PROHIBITED_DATA,
         retention_days=365,
         attribution_required=True,

--- a/src/cip/adapters/sources/public_web/registry.py
+++ b/src/cip/adapters/sources/public_web/registry.py
@@ -37,7 +37,9 @@ class PublicWebTarget:
     authorization_expires_at: datetime | None = None
     terms_url: str | None = None
     feed_urls: tuple[str, ...] = ()
+    seed_urls: tuple[str, ...] = ()
     discover_security_txt: bool = False
+    source_id: str | None = None
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -50,9 +52,10 @@ class PublicWebTarget:
             raise ValueError("public web target id and canonical_name are required")
         base = CanonicalUrl(self.base_url)
         _validate_public_hostname(base.host)
+        seeds = _same_origin_urls(base, self.seed_urls, label="seed")
         sitemaps = _same_origin_urls(base, self.sitemap_urls, label="sitemap")
         feeds = _same_origin_urls(base, self.feed_urls, label="feed")
-        if not sitemaps and not feeds and not self.discover_security_txt:
+        if not seeds and not sitemaps and not feeds and not self.discover_security_txt:
             raise ValueError("public web target requires an explicit discovery path")
         reviewed_at = _optional_time(
             self.authorization_reviewed_at,
@@ -67,6 +70,7 @@ class PublicWebTarget:
         reference = _optional_text(self.authorization_reference)
         if self.enabled and (reference is None or reviewed_at is None):
             raise ValueError("enabled public web target requires reviewed authorization")
+        source_id = _optional_text(self.source_id) or identifier
         terms_url = CanonicalUrl(self.terms_url).value if self.terms_url else None
         prefixes = self.allowed_path_prefixes
         if self.discover_security_txt and _SECURITY_TXT_PATH not in prefixes:
@@ -83,12 +87,14 @@ class PublicWebTarget:
         object.__setattr__(self, "id", identifier)
         object.__setattr__(self, "canonical_name", name)
         object.__setattr__(self, "base_url", base.value)
+        object.__setattr__(self, "seed_urls", seeds)
         object.__setattr__(self, "sitemap_urls", sitemaps)
         object.__setattr__(self, "feed_urls", feeds)
         object.__setattr__(self, "allowed_path_prefixes", scope.allowed_path_prefixes)
         object.__setattr__(self, "authorization_reference", reference)
         object.__setattr__(self, "authorization_reviewed_at", reviewed_at)
         object.__setattr__(self, "authorization_expires_at", expires_at)
+        object.__setattr__(self, "source_id", source_id)
         object.__setattr__(self, "terms_url", terms_url)
 
     @property
@@ -161,9 +167,11 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
         organization_id=UUID(_required_string(payload, "organization_id")),
         canonical_name=_required_string(payload, "canonical_name"),
         base_url=_required_string(payload, "base_url"),
+        seed_urls=_string_tuple(payload, "seed_urls", minimum=0),
         sitemap_urls=_string_tuple(payload, "sitemap_urls", minimum=0),
         feed_urls=_string_tuple(payload, "feed_urls", minimum=0),
         discover_security_txt=_optional_bool(payload, "discover_security_txt", default=False),
+        source_id=_optional_string(payload, "source_id"),
         allowed_path_prefixes=_string_tuple(
             payload,
             "allowed_path_prefixes",

--- a/src/cip/adapters/sources/public_web/security_txt_mapper.py
+++ b/src/cip/adapters/sources/public_web/security_txt_mapper.py
@@ -41,9 +41,10 @@ def map_security_txt(
         and previous.canonical_url == result.fetched_url
     )
     excerpt = bounded_security_txt_excerpt(document)
+    source_id = target.source_id or target.id
     resource = PublicResource(
         organization_id=target.organization_id,
-        source_id=target.id,
+        source_id=source_id,
         source_record_key=result.requested_url,
         canonical_url=result.fetched_url,
         source_url=result.requested_url,
@@ -78,7 +79,7 @@ def map_security_txt(
     observation = None
     if not unchanged:
         observation = RawObservation(
-            source_id=target.id,
+            source_id=source_id,
             adapter_id="public-web-sitemap",
             adapter_version="1",
             collection_job_id=collection_job_id,

--- a/tests/unit/adapters/public_web/test_provisioning.py
+++ b/tests/unit/adapters/public_web/test_provisioning.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
+
+import pytest
+
+from cip.adapters.sources.public_web.provisioning import (
+    AUTOMATIC_PUBLIC_WEB_SOURCE_ID,
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    DecisionReason,
+    SourceRuntimeState,
+)
+
+_NOW = datetime(2026, 8, 12, 10, 0, tzinfo=UTC)
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+
+
+def _organization(*, website_url: str | None = "https://www.python.org/about/") -> Organization:
+    return Organization(
+        id=_ORG_ID,
+        canonical_name="Python Software Foundation",
+        website_url=website_url,
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+def _policy(**overrides: object) -> AutomaticPublicWebPolicy:
+    values: dict[str, object] = {
+        "authorization_reference": "sa16-l01-controlled-target",
+        "reviewed_at": _NOW,
+        "allowed_path_prefixes": ("/",),
+        "refresh_interval_seconds": 86_400,
+    }
+    values.update(overrides)
+    return AutomaticPublicWebPolicy(**values)  # type: ignore[arg-type]
+
+
+def test_provisioning_creates_deterministic_governed_homepage_target() -> None:
+    provisioned = provision_public_web_target(
+        _organization(),
+        _policy(),
+        first_crawl_at=_NOW + timedelta(minutes=5),
+    )
+
+    target = provisioned.target
+    assert target.id == f"public-web-{_ORG_ID.hex}"
+    assert target.source_id == AUTOMATIC_PUBLIC_WEB_SOURCE_ID
+    assert target.id != target.source_id
+    assert target.base_url == "https://www.python.org/"
+    assert target.seed_urls == ("https://www.python.org/",)
+    assert target.sitemap_urls == ()
+    assert target.feed_urls == ()
+    assert target.discover_security_txt is True
+    assert target.security_txt_url == "https://www.python.org/.well-known/security.txt"
+    assert target.executable_at(_NOW) is True
+    assert provisioned.first_crawl_at == _NOW + timedelta(minutes=5)
+    assert provisioned.refresh_interval_seconds == 86_400
+
+
+def test_generated_source_governance_allows_scope_and_denies_other_hosts() -> None:
+    provisioned = provision_public_web_target(
+        _organization(),
+        _policy(),
+        first_crawl_at=_NOW,
+    )
+    entry = provisioned.source_entry
+
+    allowed = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,
+            target_url="https://www.python.org/robots.txt",
+            purpose="corporate-public-footprint",
+            automated=True,
+            store_raw_content=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=_NOW,
+    )
+    denied = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,
+            target_url="https://example.com/",
+            purpose="corporate-public-footprint",
+            automated=True,
+            store_raw_content=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=_NOW,
+    )
+
+    assert allowed.allowed is True
+    assert denied.allowed is False
+    assert denied.reason is DecisionReason.HOST_NOT_ALLOWED
+    assert entry.authorization.raw_storage_allowed is False
+
+
+def test_provisioning_requires_canonical_website() -> None:
+    with pytest.raises(ValueError, match="canonical website_url"):
+        provision_public_web_target(
+            _organization(website_url=None),
+            _policy(),
+            first_crawl_at=_NOW,
+        )
+
+
+def test_expired_target_fails_closed() -> None:
+    provisioned = provision_public_web_target(
+        _organization(),
+        _policy(expires_at=_NOW + timedelta(hours=1)),
+        first_crawl_at=_NOW,
+    )
+
+    assert provisioned.target.executable_at(_NOW + timedelta(hours=2)) is False
+
+
+def test_legacy_target_defaults_source_id_to_target_id() -> None:
+    target = PublicWebTarget(
+        id="legacy-source",
+        organization_id=_ORG_ID,
+        canonical_name="Legacy",
+        base_url="https://example.com/",
+        seed_urls=("https://example.com/",),
+        sitemap_urls=(),
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="legacy-review",
+        authorization_reviewed_at=_NOW,
+    )
+
+    assert target.source_id == "legacy-source"


### PR DESCRIPTION
## Scope

Implements SA16-L01 as a vertical production path from a resolved `Organization.website_url` to a governed first public-web crawl without developer-edited per-company YAML.

### Automatic target provisioning
- reuses the canonical `PublicWebTarget` model rather than introducing a competing target type;
- adds explicit same-origin homepage `seed_urls` for first collection;
- separates unique organization target identity from governed acquisition `source_id`;
- deterministically derives the target id from the organization UUID;
- records first-crawl time, refresh interval and bounded crawl budgets.

### Governance
- generates an exact runtime `SourcePolicy` / `SourceAuthorization` from a deployment-approved organization-domain policy;
- authorization remains exact-host / path / purpose scoped and is evaluated before robots and every resource request;
- raw-content storage remains disabled;
- off-host acquisition fails closed.

### Collector and provenance
- removes the historical `target.id == source policy id` coupling that would otherwise require one source YAML record per company;
- existing targets remain backward compatible when `source_id` is omitted;
- generated homepage seeds flow through the existing production `PublicWebClient` / collector;
- `RawObservation` and `PublicResource` keep the governed source id instead of the organization-specific target id.

### Deterministic tests
- canonical website requirement;
- deterministic target/source identity;
- generated host/path authorization and off-host denial;
- raw-storage denial;
- authorization expiry;
- legacy source-id compatibility.

### Real live gate
A dedicated PR workflow executes the real production path against the public Python Software Foundation website:

`Organization -> automatic target -> generated governance -> robots.txt -> homepage -> RawObservation/PublicResource`.

The workflow fails unless real non-empty data is produced, the generated homepage is checkpointed, provenance is correct and no resource escapes the approved origin.

## Completion truth

This PR remains draft and SA16-L01 remains `IN_PROGRESS` until **both** normal exact-head CI and the dedicated SA-16 L01 live workflow pass on the exact same final candidate SHA. A skipped or mocked live job does not count. After the first successful live proof, the proof/state documentation must be updated and the resulting documentation commit must itself rerun both gates before merge.