### PR TITLE
SA15-L08: fail-closed GDELT current-contract gate

### DIFF
--- a/docs/source_activation/SA_15_L08_GDELT_CONTRACT_GATE.md
+++ b/docs/source_activation/SA_15_L08_GDELT_CONTRACT_GATE.md
@@ -1,0 +1,67 @@
+# SA-15 L08 — GDELT current-contract gate
+
+## Status
+
+SA15-L08 is **not** an executable GDELT adapter and does not claim `adapter_present`, `executable`, or `live_tested`.
+
+As reviewed on 2026-08-12, GDELT's own 2026 publications still describe GDELT 5 as an upcoming launch and describe the migration of the search/API infrastructure to Spanner as still underway. The repository therefore must not relabel the historical DOC/GEO 1.x/2.x APIs as a GDELT 5 implementation.
+
+The checked-in truth is machine-readable in `policies/gdelt_api_contract.yml` and enforced by `cip.adapters.sources.gdelt.contract`.
+
+## Official references reviewed
+
+- `https://blog.gdeltproject.org/scaling-gdelt-for-a-new-era-migrating-to-spanner-with-agentic-interactive-gemini/`
+- `https://blog.gdeltproject.org/2026/06/`
+- `https://blog.gdeltproject.org/using-the-new-web-ngrams-dataset-to-find-relevant-coverage/`
+
+Those references describe the GDELT 5 / Spanner migration state but do not provide the stable current API base URL, contract version, and schema reference required for a production provider adapter.
+
+## Fail-closed contract
+
+Current manifest state:
+
+- product generation: `GDELT 5`;
+- status: `awaiting_official_contract`;
+- API base URL: unset;
+- API version: unset;
+- schema reference: unset;
+- storage/retention terms reference: unset.
+
+`GdeltApiContract.require_adapter_contract()` fails while that status remains pending.
+
+A future `stable_public_contract` manifest is valid only when:
+
+1. an actual API base URL is recorded;
+2. an actual contract/version identifier is recorded;
+3. an official schema/documentation reference is recorded;
+4. all contract references use official HTTPS `gdeltproject.org` hosts or their exact subdomains;
+5. lookalike domains are rejected;
+6. the API base URL is not a legacy `/api/v1/` or `/api/v2/` endpoint.
+
+The test values named `future-api`, `future-schema`, and `future-storage-terms` are deliberately synthetic unit-test values on the official hostname. They are not assertions that those paths exist.
+
+## Why legacy DOC 2.0 is not used
+
+The historical DOC 2.0 API is a real legacy GDELT interface, but implementing it now and calling it "GDELT 5" would make the activation inventory misleading and would bind CIP to an interface GDELT is actively replacing.
+
+If product requirements later call for a temporary legacy-GDELT adapter as a distinct source, that adapter must have its own source ID, governance, lifecycle, and live proof. It must never satisfy the GDELT 5 completion gate.
+
+## Exact exit criteria
+
+When GDELT publishes the current stable API contract, L08 continues with a second implementation tranche:
+
+1. re-review the official provider documentation;
+2. update `policies/gdelt_api_contract.yml` with the real stable contract values;
+3. document storage/retention rights;
+4. add the governed source policy and authorization;
+5. define provider-specific response schemas;
+6. implement the isolated GDELT adapter;
+7. register runtime/checkpoint/retry/quota behavior;
+8. map provider results to discovery metadata / `RawObservation` without converting search results directly into facts;
+9. add deterministic network-free tests;
+10. add a controlled real-provider live-validation workflow;
+11. obtain a non-empty real payload on the production adapter;
+12. run complete exact-head CI on the same final SHA;
+13. only then promote the source to `live_tested`.
+
+Until those conditions are met, the correct state is a mandatory implementation prerequisite rather than a fabricated adapter or terminal abandonment.

--- a/policies/gdelt_api_contract.yml
+++ b/policies/gdelt_api_contract.yml
@@ -1,0 +1,14 @@
+version: 1
+
+contract:
+  product_generation: GDELT 5
+  status: awaiting_official_contract
+  reviewed_at: 2026-08-12
+  official_references:
+    - https://blog.gdeltproject.org/scaling-gdelt-for-a-new-era-migrating-to-spanner-with-agentic-interactive-gemini/
+    - https://blog.gdeltproject.org/2026/06/
+    - https://blog.gdeltproject.org/using-the-new-web-ngrams-dataset-to-find-relevant-coverage/
+  api_base_url: null
+  api_version: null
+  schema_reference: null
+  storage_terms_reference: null

--- a/src/cip/adapters/sources/gdelt/__init__.py
+++ b/src/cip/adapters/sources/gdelt/__init__.py
@@ -1,0 +1,1 @@
+"""GDELT source-contract gate pending the official current API contract."""

--- a/src/cip/adapters/sources/gdelt/contract.py
+++ b/src/cip/adapters/sources/gdelt/contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class GdeltContractStatus(StrEnum):
+    AWAITING_OFFICIAL_CONTRACT = "awaiting_official_contract"
+    STABLE_PUBLIC_CONTRACT = "stable_public_contract"
+
+
+class GdeltContractUnavailable(RuntimeError):
+    """Raised when the current official GDELT API contract is not implementation-ready."""
+
+
+class _GdeltContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product_generation: str = Field(min_length=1, max_length=100)
+    status: GdeltContractStatus
+    reviewed_at: date
+    official_references: tuple[str, ...] = Field(min_length=1)
+    api_base_url: str | None = None
+    api_version: str | None = Field(default=None, max_length=100)
+    schema_reference: str | None = None
+    storage_terms_reference: str | None = None
+
+    @model_validator(mode="after")
+    def validate_contract_readiness(self) -> _GdeltContractModel:
+        _validate_official_references(self.official_references)
+        if self.status is GdeltContractStatus.STABLE_PUBLIC_CONTRACT:
+            if not self.api_base_url or not self.api_version or not self.schema_reference:
+                raise ValueError(
+                    "stable GDELT contract requires API base URL, version, and schema reference"
+                )
+            _validate_current_endpoint(self.api_base_url)
+            _validate_official_url(self.schema_reference)
+        return self
+
+
+class _GdeltRegistryModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1)
+    contract: _GdeltContractModel
+
+
+@dataclass(frozen=True, slots=True)
+class GdeltApiContract:
+    product_generation: str
+    status: GdeltContractStatus
+    reviewed_at: date
+    official_references: tuple[str, ...]
+    api_base_url: str | None
+    api_version: str | None
+    schema_reference: str | None
+    storage_terms_reference: str | None
+
+    @property
+    def adapter_implementation_allowed(self) -> bool:
+        return self.status is GdeltContractStatus.STABLE_PUBLIC_CONTRACT
+
+    def require_adapter_contract(self) -> None:
+        if not self.adapter_implementation_allowed:
+            raise GdeltContractUnavailable(
+                "GDELT adapter implementation is blocked until an official stable current API "
+                "contract is published and recorded"
+            )
+
+
+def load_gdelt_api_contract(path: Path) -> GdeltApiContract:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    parsed = _GdeltRegistryModel.model_validate(payload).contract
+    return GdeltApiContract(
+        product_generation=parsed.product_generation.strip(),
+        status=parsed.status,
+        reviewed_at=parsed.reviewed_at,
+        official_references=parsed.official_references,
+        api_base_url=parsed.api_base_url,
+        api_version=parsed.api_version,
+        schema_reference=parsed.schema_reference,
+        storage_terms_reference=parsed.storage_terms_reference,
+    )
+
+
+def _validate_official_references(references: tuple[str, ...]) -> None:
+    for reference in references:
+        _validate_official_url(reference)
+
+
+def _validate_official_url(value: str) -> None:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").casefold()
+    if parsed.scheme != "https" or not _is_official_gdelt_host(host):
+        raise ValueError("GDELT contract references must use an official HTTPS GDELT host")
+
+
+def _is_official_gdelt_host(host: str) -> bool:
+    return host == "gdeltproject.org" or host.endswith(".gdeltproject.org")
+
+
+def _validate_current_endpoint(value: str) -> None:
+    _validate_official_url(value)
+    path = urlparse(value).path.casefold()
+    if "/api/v1/" in path or "/api/v2/" in path:
+        raise ValueError(
+            "legacy GDELT API endpoints cannot satisfy the current GDELT contract gate"
+        )

--- a/tests/unit/adapters/test_gdelt_contract_gate.py
+++ b/tests/unit/adapters/test_gdelt_contract_gate.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from cip.adapters.sources.gdelt.contract import (
+    GdeltApiContract,
+    GdeltContractStatus,
+    GdeltContractUnavailable,
+    load_gdelt_api_contract,
+)
+
+_POLICY_PATH = Path("policies/gdelt_api_contract.yml")
+
+
+def test_checked_in_gdelt_contract_is_fail_closed() -> None:
+    contract = load_gdelt_api_contract(_POLICY_PATH)
+
+    assert contract.product_generation == "GDELT 5"
+    assert contract.status is GdeltContractStatus.AWAITING_OFFICIAL_CONTRACT
+    assert contract.api_base_url is None
+    assert contract.api_version is None
+    assert contract.schema_reference is None
+    assert contract.storage_terms_reference is None
+    assert contract.adapter_implementation_allowed is False
+    with pytest.raises(GdeltContractUnavailable):
+        contract.require_adapter_contract()
+
+
+def test_stable_contract_requires_endpoint_version_and_schema(tmp_path: Path) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        """version: 1
+contract:
+  product_generation: GDELT 5
+  status: stable_public_contract
+  reviewed_at: 2026-08-12
+  official_references:
+    - https://blog.gdeltproject.org/2026/06/
+  api_base_url: null
+  api_version: null
+  schema_reference: null
+  storage_terms_reference: null
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="requires API base URL"):
+        load_gdelt_api_contract(policy)
+
+
+@pytest.mark.parametrize(
+    "legacy_url",
+    (
+        "https://api.gdeltproject.org/api/v1/search",
+        "https://api.gdeltproject.org/api/v2/doc/doc",
+    ),
+)
+def test_legacy_api_cannot_satisfy_gdelt5_gate(tmp_path: Path, legacy_url: str) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        _stable_contract_yaml(api_base_url=legacy_url),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="legacy GDELT API endpoints"):
+        load_gdelt_api_contract(policy)
+
+
+@pytest.mark.parametrize(
+    "untrusted_url",
+    (
+        "https://example.com/future-api",
+        "https://evilgdeltproject.org/future-api",
+        "https://gdeltproject.org.example.com/future-api",
+    ),
+)
+def test_future_stable_contract_rejects_non_gdelt_lookalikes(
+    tmp_path: Path,
+    untrusted_url: str,
+) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        _stable_contract_yaml(api_base_url=untrusted_url),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="official HTTPS GDELT host"):
+        load_gdelt_api_contract(policy)
+
+
+def test_complete_official_future_contract_opens_only_the_contract_gate(tmp_path: Path) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        _stable_contract_yaml(api_base_url="https://api.gdeltproject.org/future-api"),
+        encoding="utf-8",
+    )
+
+    contract = load_gdelt_api_contract(policy)
+
+    assert isinstance(contract, GdeltApiContract)
+    assert contract.adapter_implementation_allowed is True
+    contract.require_adapter_contract()
+
+
+def _stable_contract_yaml(*, api_base_url: str) -> str:
+    return f"""version: 1
+contract:
+  product_generation: GDELT 5
+  status: stable_public_contract
+  reviewed_at: 2026-08-12
+  official_references:
+    - https://blog.gdeltproject.org/2026/06/
+  api_base_url: {api_base_url}
+  api_version: future-contract-version
+  schema_reference: https://gdeltproject.org/future-schema
+  storage_terms_reference: https://gdeltproject.org/future-storage-terms
+"""


### PR DESCRIPTION
## Scope

Restacked on the current `main` after SA15-L02/L03/L04.

Implements the SA15-L08 prerequisite gate without pretending that a stable GDELT 5 API contract already exists.

- machine-readable `policies/gdelt_api_contract.yml`
- typed `GdeltApiContract` loader and readiness gate
- official HTTPS `gdeltproject.org` root/subdomain validation
- lookalike-host rejection
- explicit rejection of legacy `/api/v1/` and `/api/v2/` endpoints as satisfaction of the GDELT 5 gate
- deterministic tests for pending/stable/legacy/off-host states
- closeout with exact future adapter/live-proof exit criteria

## Current provider truth

Official GDELT 2026 material still describes GDELT 5 / the Spanner migration as ongoing and does not publish the stable current API base URL + version + schema contract required by CIP. This PR therefore adds no provider adapter, no executable stage and no `live_tested` claim.

When GDELT publishes the stable current contract, the manifest must be updated first; only then can the provider-specific adapter/runtime/live-validation tranche proceed.
