### PR TITLE
SA15-C1: bridge Common Crawl into normalized discovery

### DIFF
--- a/.github/workflows/sa15-live-validation.yml
+++ b/.github/workflows/sa15-live-validation.yml
@@ -31,3 +31,23 @@ jobs:
 
       - name: Controlled Internet Archive CDX production-adapter live validation
         run: python scripts/live_validate_sa15_cdx.py
+
+  live-common-crawl-normalized-discovery:
+    if: github.event.pull_request.head.ref == 'agent/sa15-c1-common-crawl-serp-bridge'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled Common Crawl normalized production live validation
+        run: python scripts/live_validate_sa15_common_crawl_bridge.py

--- a/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
+++ b/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
@@ -1,0 +1,99 @@
+# SA-15 C1 — Common Crawl normalized discovery bridge
+
+## Status
+
+`IN_PROGRESS` until the exact final candidate SHA passes both normal repository CI and the real Common Crawl production live workflow.
+
+Common Crawl already has a real production adapter and historical `live_tested` proof from SA-14. C1 closes the remaining SA-15 consolidation gap: Common Crawl archive-index discoveries must enter the same normalized discovery and governed acquisition path introduced by SA15-L01/L09.
+
+## Objective
+
+The required runtime chain is:
+
+```text
+PublicWebTarget
+-> CommonCrawlIndexAdapter
+-> immutable RawObservation + quarantined ARCHIVE_SNAPSHOT projection
+-> Common Crawl normalized bridge
+-> SearchProviderExecution
+-> normalize_search_executions()
+-> SearchDiscoveryCandidate
+-> governed SA15-L09 acquisition routing
+```
+
+The bridge does not relabel Common Crawl as a general web-search engine. It uses an explicit archive-discovery template and preserves `common-crawl-index` as the provider/source identity.
+
+## Implementation contract
+
+`common_crawl_search_bridge.py` provides:
+
+- `build_common_crawl_search_plan()` with the explicit `common-crawl-archive-discovery` template;
+- `common_crawl_batch_to_search_execution()` to translate bounded Common Crawl projections into the canonical L01 `SearchProviderExecution` contract;
+- `normalize_common_crawl_batch()` to execute the existing `normalize_search_executions()` path without a parallel normalization implementation.
+
+The bridge fails closed when:
+
+- the template, version, purpose or provider identity is not the Common Crawl archive-discovery contract;
+- a projection belongs to another organization;
+- a projection originates from another source;
+- archive metadata contains claims;
+- archive metadata escaped quarantine;
+- more than the Common Crawl adapter's 50-result bound reaches normalization.
+
+## Evidence boundary
+
+C1 preserves all existing archive restrictions:
+
+- Common Crawl index metadata is discovery lineage, not proof of current website state;
+- WARC bodies are not retrieved by this path;
+- no automatic claim is created;
+- normalized candidates begin as `UNROUTED`;
+- only SA15-L09 may choose an approved acquisition route;
+- a candidate outside an executable same-organization public-web target remains source-review work.
+
+## Deterministic validation
+
+Network-free tests cover:
+
+- explicit archive-plan identity;
+- real adapter-batch to `SearchProviderExecution` conversion;
+- canonical URL normalization;
+- provider provenance;
+- deterministic ordering;
+- `UNROUTED` initial acquisition state;
+- non-archive plan rejection;
+- cross-organization rejection.
+
+## Controlled production live validation
+
+The C1 live runner uses the real production `CommonCrawlIndexAdapter` against Common Crawl's public index and the neutral Common Crawl Foundation website target.
+
+The exact live chain must produce:
+
+1. between 1 and 50 real Common Crawl observations;
+2. one quarantined archive projection per observation;
+3. zero claims;
+4. at least one normalized `SearchDiscoveryCandidate`;
+5. preserved provider identity `common-crawl-index` in every normalized hit;
+6. candidate count no greater than the underlying observation count after canonical deduplication;
+7. one SA15-L09 route per candidate;
+8. every controlled candidate routed through the executable governed `PublicWebTarget` rather than an unrestricted fetch.
+
+The runner performs real network I/O through the production Common Crawl client. A mock, skipped workflow, earlier SA-14 run, or documentation-only assertion does not satisfy the C1 completion gate.
+
+## Completion rule
+
+C1 becomes `IMPLEMENTED_VALIDATED` only after:
+
+1. deterministic tests pass;
+2. Ruff passes;
+3. strict Mypy passes;
+4. architecture/release contracts pass;
+5. reversible migration gates remain green;
+6. complete backend tests and coverage remain above repository thresholds;
+7. frontend gates remain green;
+8. the C1 real Common Crawl workflow succeeds;
+9. the exact live proof is recorded in this document;
+10. that documentation commit itself passes both CI and the C1 live workflow on the same final SHA.
+
+Only after those ten conditions are met may the SA-15 audit mark the Common Crawl normalized-pipeline row green.

--- a/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
+++ b/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
@@ -2,13 +2,15 @@
 
 ## Status
 
-`IN_PROGRESS` until the exact final candidate SHA passes both normal repository CI and the real Common Crawl production live workflow.
+`IMPLEMENTED_VALIDATED` / normalized integration `live_tested` candidate.
 
-Common Crawl already has a real production adapter and historical `live_tested` proof from SA-14. C1 closes the remaining SA-15 consolidation gap: Common Crawl archive-index discoveries must enter the same normalized discovery and governed acquisition path introduced by SA15-L01/L09.
+Common Crawl already had a real production adapter and provider `live_tested` proof from SA-14. C1 closes the remaining SA-15 consolidation gap: Common Crawl archive-index discoveries now enter the same normalized discovery and governed acquisition path introduced by SA15-L01/L09.
+
+The first complete candidate `d82297cbdd2fb22641a41f66bb2c001be46791cf` passed both the real Common Crawl live workflow and the complete repository CI. This documentation commit intentionally creates a new candidate SHA; C1 is mergeable only after that final documentation SHA independently repeats both gates successfully.
 
 ## Objective
 
-The required runtime chain is:
+The runtime chain is:
 
 ```text
 PublicWebTarget
@@ -68,32 +70,41 @@ Network-free tests cover:
 
 The C1 live runner uses the real production `CommonCrawlIndexAdapter` against Common Crawl's public index and the neutral Common Crawl Foundation website target.
 
-The exact live chain must produce:
+### First complete proof
 
-1. between 1 and 50 real Common Crawl observations;
-2. one quarantined archive projection per observation;
-3. zero claims;
-4. at least one normalized `SearchDiscoveryCandidate`;
-5. preserved provider identity `common-crawl-index` in every normalized hit;
-6. candidate count no greater than the underlying observation count after canonical deduplication;
-7. one SA15-L09 route per candidate;
-8. every controlled candidate routed through the executable governed `PublicWebTarget` rather than an unrestricted fetch.
+Candidate SHA:
 
-The runner performs real network I/O through the production Common Crawl client. A mock, skipped workflow, earlier SA-14 run, or documentation-only assertion does not satisfy the C1 completion gate.
+`d82297cbdd2fb22641a41f66bb2c001be46791cf`
 
-## Completion rule
+SA-15 Live Validation run #33 passed the production path with:
 
-C1 becomes `IMPLEMENTED_VALIDATED` only after:
+- **43** real Common Crawl observations;
+- **43** quarantined archive projections;
+- **0** automatic claims;
+- **23** canonical normalized `SearchDiscoveryCandidate` objects after URL deduplication;
+- provider provenance `common-crawl-index` preserved for every normalized hit;
+- **23 / 23** candidates routed automatically through SA15-L09 to the governed `PUBLIC_WEB` route;
+- no WARC body retrieval and no unrestricted HTTP fallback.
 
-1. deterministic tests pass;
-2. Ruff passes;
-3. strict Mypy passes;
-4. architecture/release contracts pass;
-5. reversible migration gates remain green;
-6. complete backend tests and coverage remain above repository thresholds;
-7. frontend gates remain green;
-8. the C1 real Common Crawl workflow succeeds;
-9. the exact live proof is recorded in this document;
-10. that documentation commit itself passes both CI and the C1 live workflow on the same final SHA.
+Normal repository CI #1928 also passed on the same candidate:
 
-Only after those ten conditions are met may the SA-15 audit mark the Common Crawl normalized-pipeline row green.
+- dependency consistency and dependency audit: pass;
+- Ruff: pass;
+- strict Mypy: pass;
+- architecture/release contracts: pass;
+- reversible migration validation: pass;
+- complete backend tests and coverage gate: pass;
+- frontend dependency audit, typecheck and production build: pass.
+
+The earlier C1 live attempt failed because the SA16-L01 `PublicWebTarget` model now requires an explicit discovery path. C1 was corrected by declaring the controlled homepage seed instead of weakening the target invariant. The subsequent production run is the proof recorded above.
+
+## Final completion rule
+
+C1 is finally mergeable only when the exact documentation head containing this proof itself passes:
+
+1. complete repository CI;
+2. the real SA-15 Common Crawl normalized live workflow;
+3. all live invariants again with a non-empty provider payload;
+4. zero unresolved review threads.
+
+A skipped job, mock, earlier SHA or successful run that does not execute the production adapter does not satisfy this gate.

--- a/scripts/live_validate_sa15_common_crawl_bridge.py
+++ b/scripts/live_validate_sa15_common_crawl_bridge.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.common_crawl_adapter import (
+    CommonCrawlIndexAdapter,
+)
+from cip.modules.collection_orchestration.application.common_crawl_search_bridge import (
+    COMMON_CRAWL_PROVIDER_ID,
+    build_common_crawl_search_plan,
+    normalize_common_crawl_batch,
+)
+from cip.modules.collection_orchestration.application.search_acquisition_router import (
+    SearchAcquisitionRouteKind,
+    route_search_discovery_candidates,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+POLICY_PATH = Path("policies/sources.search_archives.yml")
+ORG_ID = UUID("7a0b182e-353e-5a61-8be4-703e935e227d")
+
+
+def main() -> None:
+    now = datetime.now(UTC)
+    entry = next(
+        item
+        for item in load_source_registry(POLICY_PATH)
+        if item.policy.id == COMMON_CRAWL_PROVIDER_ID
+    )
+    target = _target(now)
+    batch = CommonCrawlIndexAdapter(entry, (target,), timeout_seconds=30).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=365),
+    )
+    plan = build_common_crawl_search_plan(
+        organization_id=ORG_ID,
+        organization_name="Common Crawl Foundation",
+        target_base_url=target.base_url,
+        created_at=now,
+    )
+    candidates = normalize_common_crawl_batch(plan, batch, executed_at=now)
+    routes = route_search_discovery_candidates(candidates, (target,), routed_at=now)
+    _assert_live_truth(batch, candidates, routes)
+    print(
+        "SA-15 C1 live validation passed: "
+        f"observations={len(batch.observations)} "
+        f"normalized_candidates={len(candidates)} "
+        f"automatic_routes={len(routes)} "
+        f"provider={COMMON_CRAWL_PROVIDER_ID}"
+    )
+
+
+def _target(now: datetime) -> PublicWebTarget:
+    return PublicWebTarget(
+        id="sa15-common-crawl-normalized-live",
+        organization_id=ORG_ID,
+        canonical_name="Common Crawl Foundation",
+        base_url="https://commoncrawl.org",
+        sitemap_urls=(),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="sa15-c1-controlled-common-crawl-live",
+        authorization_reviewed_at=now,
+        terms_url="https://commoncrawl.org/terms-of-use",
+        max_pages=50,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=0,
+    )
+
+
+def _assert_live_truth(batch, candidates, routes) -> None:
+    observations = len(batch.observations)
+    if observations < 1 or observations > 50:
+        raise RuntimeError("Common Crawl live bridge returned an invalid observation count")
+    if len(batch.public_footprint_projections) != observations:
+        raise RuntimeError("Common Crawl live bridge lost archive projections")
+    if len(candidates) < 1 or len(candidates) > observations:
+        raise RuntimeError("Common Crawl live bridge produced invalid normalized candidates")
+    if len(routes) != len(candidates):
+        raise RuntimeError("Common Crawl normalized candidates did not all enter routing")
+    if any(projection.claims for projection in batch.public_footprint_projections):
+        raise RuntimeError("Common Crawl archive metadata unexpectedly produced claims")
+    if any(candidate.provider_count != 1 for candidate in candidates):
+        raise RuntimeError("Common Crawl provider provenance was not preserved")
+    if any(
+        hit.provider_id != COMMON_CRAWL_PROVIDER_ID
+        for candidate in candidates
+        for hit in candidate.provider_hits
+    ):
+        raise RuntimeError("Common Crawl normalized provider id drifted")
+    if any(route.route_kind is not SearchAcquisitionRouteKind.PUBLIC_WEB for route in routes):
+        raise RuntimeError("Common Crawl normalized candidate failed governed public-web routing")
+    if any(not route.automatic for route in routes):
+        raise RuntimeError("Common Crawl normalized route is not automatic")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/live_validate_sa15_common_crawl_bridge.py
+++ b/scripts/live_validate_sa15_common_crawl_bridge.py
@@ -66,6 +66,7 @@ def _target(now: datetime) -> PublicWebTarget:
         base_url="https://commoncrawl.org",
         sitemap_urls=(),
         feed_urls=(),
+        seed_urls=("https://commoncrawl.org/",),
         discover_security_txt=False,
         allowed_path_prefixes=("/",),
         enabled=True,

--- a/scripts/live_validate_sa15_common_crawl_bridge.py
+++ b/scripts/live_validate_sa15_common_crawl_bridge.py
@@ -13,10 +13,13 @@ from cip.modules.collection_orchestration.application.common_crawl_search_bridge
     build_common_crawl_search_plan,
     normalize_common_crawl_batch,
 )
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
 from cip.modules.collection_orchestration.application.search_acquisition_router import (
+    SearchAcquisitionRoute,
     SearchAcquisitionRouteKind,
     route_search_discovery_candidates,
 )
+from cip.modules.public_footprint.domain.search_core import SearchDiscoveryCandidate
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
 
 POLICY_PATH = Path("policies/sources.search_archives.yml")
@@ -76,7 +79,11 @@ def _target(now: datetime) -> PublicWebTarget:
     )
 
 
-def _assert_live_truth(batch, candidates, routes) -> None:
+def _assert_live_truth(
+    batch: AdapterCollectionBatch,
+    candidates: tuple[SearchDiscoveryCandidate, ...],
+    routes: tuple[SearchAcquisitionRoute, ...],
+) -> None:
     observations = len(batch.observations)
     if observations < 1 or observations > 50:
         raise RuntimeError("Common Crawl live bridge returned an invalid observation count")

--- a/src/cip/modules/collection_orchestration/application/common_crawl_search_bridge.py
+++ b/src/cip/modules/collection_orchestration/application/common_crawl_search_bridge.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
+from cip.modules.public_footprint.domain.search import SearchResultLead
+from cip.modules.public_footprint.domain.search_core import (
+    SearchDiscoveryCandidate,
+    SearchProviderExecution,
+    SearchQueryPlan,
+    normalize_search_executions,
+)
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+from cip.shared.kernel.time import require_aware_utc
+
+COMMON_CRAWL_PROVIDER_ID = "common-crawl-index"
+COMMON_CRAWL_TEMPLATE_ID = "common-crawl-archive-discovery"
+COMMON_CRAWL_TEMPLATE_VERSION = 1
+COMMON_CRAWL_PURPOSE = "archive-discovery"
+_MAX_COMMON_CRAWL_RESULTS = 50
+
+
+def build_common_crawl_search_plan(
+    *,
+    organization_id: UUID,
+    organization_name: str,
+    target_base_url: str,
+    created_at: datetime,
+) -> SearchQueryPlan:
+    origin = CanonicalUrl(target_base_url).origin
+    return SearchQueryPlan(
+        organization_id=organization_id,
+        organization_name=organization_name,
+        template_id=COMMON_CRAWL_TEMPLATE_ID,
+        template_version=COMMON_CRAWL_TEMPLATE_VERSION,
+        purpose=COMMON_CRAWL_PURPOSE,
+        rendered_query=f"common-crawl:{origin}/*",
+        provider_ids=(COMMON_CRAWL_PROVIDER_ID,),
+        created_at=created_at,
+    )
+
+
+def common_crawl_batch_to_search_execution(
+    plan: SearchQueryPlan,
+    batch: AdapterCollectionBatch,
+    *,
+    executed_at: datetime,
+) -> SearchProviderExecution:
+    executed_at = require_aware_utc(executed_at, field_name="executed_at")
+    _validate_plan(plan)
+    projections = batch.public_footprint_projections
+    if len(projections) > _MAX_COMMON_CRAWL_RESULTS:
+        raise ValueError("Common Crawl normalized discovery exceeds the provider result bound")
+    results = tuple(
+        _search_result(plan, projection, rank=index + 1)
+        for index, projection in enumerate(projections)
+    )
+    return SearchProviderExecution(
+        provider_id=COMMON_CRAWL_PROVIDER_ID,
+        organization_id=plan.organization_id,
+        rendered_query=plan.rendered_query,
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+        executed_at=executed_at,
+        results=results,
+    )
+
+
+def normalize_common_crawl_batch(
+    plan: SearchQueryPlan,
+    batch: AdapterCollectionBatch,
+    *,
+    executed_at: datetime,
+) -> tuple[SearchDiscoveryCandidate, ...]:
+    execution = common_crawl_batch_to_search_execution(
+        plan,
+        batch,
+        executed_at=executed_at,
+    )
+    return normalize_search_executions(plan, (execution,))
+
+
+def _validate_plan(plan: SearchQueryPlan) -> None:
+    if plan.template_id != COMMON_CRAWL_TEMPLATE_ID:
+        raise ValueError("Common Crawl bridge requires the archive-discovery template")
+    if plan.template_version != COMMON_CRAWL_TEMPLATE_VERSION:
+        raise ValueError("Common Crawl bridge requires the current template version")
+    if plan.purpose != COMMON_CRAWL_PURPOSE:
+        raise ValueError("Common Crawl bridge requires the archive-discovery purpose")
+    if plan.provider_ids != (COMMON_CRAWL_PROVIDER_ID,):
+        raise ValueError("Common Crawl bridge requires the Common Crawl provider only")
+
+
+def _search_result(plan: SearchQueryPlan, projection, *, rank: int) -> SearchResultLead:
+    resource = projection.resource
+    version = projection.version
+    if resource.organization_id != plan.organization_id:
+        raise ValueError("Common Crawl projection organization does not match the query plan")
+    if resource.source_id != COMMON_CRAWL_PROVIDER_ID:
+        raise ValueError("Common Crawl bridge rejects projections from another source")
+    if projection.claims:
+        raise ValueError("Common Crawl archive discovery must not contain claims")
+    if resource.retrieval_state.value != "quarantined":
+        raise ValueError("Common Crawl archive discovery must remain quarantined")
+    title = resource.title or f"Common Crawl capture of {resource.canonical_url}"
+    snippet = version.excerpt or "Common Crawl archive index metadata; WARC body not retrieved."
+    return SearchResultLead(
+        organization_id=plan.organization_id,
+        source_id=COMMON_CRAWL_PROVIDER_ID,
+        source_record_key=resource.source_record_key,
+        target_url=resource.canonical_url,
+        title=title,
+        snippet=snippet,
+        rank=rank,
+        observed_at=version.fetched_at,
+        query_template_id=plan.template_id,
+        query_template_version=plan.template_version,
+    )

--- a/src/cip/modules/collection_orchestration/application/common_crawl_search_bridge.py
+++ b/src/cip/modules/collection_orchestration/application/common_crawl_search_bridge.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID
 
 from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
+from cip.modules.public_footprint.domain.models import PublicFootprintProjection
 from cip.modules.public_footprint.domain.search import SearchResultLead
 from cip.modules.public_footprint.domain.search_core import (
     SearchDiscoveryCandidate,
@@ -92,7 +93,12 @@ def _validate_plan(plan: SearchQueryPlan) -> None:
         raise ValueError("Common Crawl bridge requires the Common Crawl provider only")
 
 
-def _search_result(plan: SearchQueryPlan, projection, *, rank: int) -> SearchResultLead:
+def _search_result(
+    plan: SearchQueryPlan,
+    projection: PublicFootprintProjection,
+    *,
+    rank: int,
+) -> SearchResultLead:
     resource = projection.resource
     version = projection.version
     if resource.organization_id != plan.organization_id:

--- a/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
@@ -151,6 +151,7 @@ def _target() -> PublicWebTarget:
         base_url="https://example.com",
         sitemap_urls=(),
         feed_urls=(),
+        seed_urls=("https://example.com/",),
         discover_security_txt=False,
         allowed_path_prefixes=("/public",),
         enabled=True,

--- a/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from cip.modules.collection_orchestration.application.common_crawl_search_bridge import (
+    COMMON_CRAWL_PROVIDER_ID,
+    COMMON_CRAWL_PURPOSE,
+    COMMON_CRAWL_TEMPLATE_ID,
+    build_common_crawl_search_plan,
+)
+
+NOW = datetime(2026, 8, 12, 11, 0, tzinfo=UTC)
+ORG_ID = UUID("5b49c59a-cd47-5b9c-bdf0-dba39055cce5")
+
+
+def test_common_crawl_search_plan_uses_explicit_archive_identity() -> None:
+    plan = build_common_crawl_search_plan(
+        organization_id=ORG_ID,
+        organization_name="Controlled Example",
+        target_base_url="https://example.com:443/path?b=2&a=1",
+        created_at=NOW,
+    )
+    assert plan.template_id == COMMON_CRAWL_TEMPLATE_ID
+    assert plan.purpose == COMMON_CRAWL_PURPOSE
+    assert plan.provider_ids == (COMMON_CRAWL_PROVIDER_ID,)
+    assert plan.rendered_query == "common-crawl:https://example.com/*"

--- a/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
@@ -20,11 +20,15 @@ from cip.modules.collection_orchestration.application.common_crawl_search_bridge
     common_crawl_batch_to_search_execution,
     normalize_common_crawl_batch,
 )
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
 from cip.modules.public_footprint.domain.search_core import (
     SearchAcquisitionState,
     SearchQueryPlan,
 )
-from cip.modules.source_governance.infrastructure.registry import load_source_registry
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
 
 NOW = datetime(2026, 8, 12, 11, 0, tzinfo=UTC)
 RETENTION = NOW + timedelta(days=365)
@@ -108,7 +112,7 @@ def test_common_crawl_bridge_rejects_cross_organization_projection() -> None:
         common_crawl_batch_to_search_execution(other_plan, _batch(), executed_at=NOW)
 
 
-def _batch():
+def _batch() -> AdapterCollectionBatch:
     adapter = CommonCrawlIndexAdapter(
         _entry(),
         (_target(),),
@@ -131,7 +135,7 @@ def _plan() -> SearchQueryPlan:
     )
 
 
-def _entry():
+def _entry() -> SourceRegistryEntry:
     return next(
         entry
         for entry in load_source_registry(POLICY_PATH)

--- a/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_search_bridge.py
@@ -1,17 +1,35 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from uuid import UUID
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
 
+import httpx
+import pytest
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.common_crawl_adapter import (
+    CommonCrawlIndexAdapter,
+)
 from cip.modules.collection_orchestration.application.common_crawl_search_bridge import (
     COMMON_CRAWL_PROVIDER_ID,
     COMMON_CRAWL_PURPOSE,
     COMMON_CRAWL_TEMPLATE_ID,
     build_common_crawl_search_plan,
+    common_crawl_batch_to_search_execution,
+    normalize_common_crawl_batch,
 )
+from cip.modules.public_footprint.domain.search_core import (
+    SearchAcquisitionState,
+    SearchQueryPlan,
+)
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
 
 NOW = datetime(2026, 8, 12, 11, 0, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=365)
 ORG_ID = UUID("5b49c59a-cd47-5b9c-bdf0-dba39055cce5")
+POLICY_PATH = Path("policies/sources.search_archives.yml")
 
 
 def test_common_crawl_search_plan_uses_explicit_archive_identity() -> None:
@@ -25,3 +43,152 @@ def test_common_crawl_search_plan_uses_explicit_archive_identity() -> None:
     assert plan.purpose == COMMON_CRAWL_PURPOSE
     assert plan.provider_ids == (COMMON_CRAWL_PROVIDER_ID,)
     assert plan.rendered_query == "common-crawl:https://example.com/*"
+
+
+def test_common_crawl_batch_enters_normalized_discovery_with_provenance() -> None:
+    batch = _batch()
+    plan = _plan()
+    execution = common_crawl_batch_to_search_execution(plan, batch, executed_at=NOW)
+    candidates = normalize_common_crawl_batch(plan, batch, executed_at=NOW)
+
+    assert execution.provider_id == COMMON_CRAWL_PROVIDER_ID
+    assert len(execution.results) == 2
+    assert [result.rank for result in execution.results] == [1, 2]
+    assert all(result.source_id == COMMON_CRAWL_PROVIDER_ID for result in execution.results)
+    assert len(candidates) == 2
+    assert {candidate.target_url for candidate in candidates} == {
+        "https://example.com/public/alpha",
+        "https://example.com/public/beta?a=1&b=2",
+    }
+    assert all(
+        candidate.acquisition_state is SearchAcquisitionState.UNROUTED
+        for candidate in candidates
+    )
+    assert all(candidate.provider_count == 1 for candidate in candidates)
+    assert all(
+        hit.provider_id == COMMON_CRAWL_PROVIDER_ID
+        for candidate in candidates
+        for hit in candidate.provider_hits
+    )
+    assert all("WARC body not retrieved" in candidate.snippet for candidate in candidates)
+    assert all(not projection.claims for projection in batch.public_footprint_projections)
+
+
+def test_common_crawl_normalization_is_deterministic() -> None:
+    batch = _batch()
+    first = normalize_common_crawl_batch(_plan(), batch, executed_at=NOW)
+    second = normalize_common_crawl_batch(_plan(), batch, executed_at=NOW)
+    assert first == second
+    assert [candidate.best_rank for candidate in first] == [1, 2]
+
+
+def test_common_crawl_bridge_rejects_non_archive_plan() -> None:
+    invalid_plan = SearchQueryPlan(
+        organization_id=ORG_ID,
+        organization_name="Controlled Example",
+        template_id="generic-search",
+        template_version=1,
+        purpose="company-research",
+        rendered_query="Controlled Example",
+        provider_ids=(COMMON_CRAWL_PROVIDER_ID,),
+        created_at=NOW,
+    )
+    with pytest.raises(ValueError, match="archive-discovery template"):
+        common_crawl_batch_to_search_execution(invalid_plan, _batch(), executed_at=NOW)
+
+
+def test_common_crawl_bridge_rejects_cross_organization_projection() -> None:
+    other_plan = build_common_crawl_search_plan(
+        organization_id=UUID("d4d28967-bf52-553a-937e-719f6185c940"),
+        organization_name="Other Organization",
+        target_base_url="https://example.com",
+        created_at=NOW,
+    )
+    with pytest.raises(ValueError, match="organization does not match"):
+        common_crawl_batch_to_search_execution(other_plan, _batch(), executed_at=NOW)
+
+
+def _batch():
+    adapter = CommonCrawlIndexAdapter(
+        _entry(),
+        (_target(),),
+        transport=httpx.MockTransport(_provider_handler),
+    )
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )
+
+
+def _plan() -> SearchQueryPlan:
+    return build_common_crawl_search_plan(
+        organization_id=ORG_ID,
+        organization_name="Controlled Example",
+        target_base_url="https://example.com",
+        created_at=NOW,
+    )
+
+
+def _entry():
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == COMMON_CRAWL_PROVIDER_ID
+    )
+
+
+def _target() -> PublicWebTarget:
+    return PublicWebTarget(
+        id="common-crawl-normalized-discovery-test",
+        organization_id=ORG_ID,
+        canonical_name="Controlled Example",
+        base_url="https://example.com",
+        sitemap_urls=(),
+        feed_urls=(),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/public",),
+        enabled=True,
+        authorization_reference="sa15-c1-test",
+        authorization_reviewed_at=NOW,
+        terms_url="https://example.com/",
+    )
+
+
+def _provider_handler(request: httpx.Request) -> httpx.Response:
+    if request.url.path == "/collinfo.json":
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": "CC-MAIN-2026-30",
+                    "name": "July 2026 Index",
+                    "timegate": "https://index.commoncrawl.org/CC-MAIN-2026-30/",
+                    "cdx-api": "https://index.commoncrawl.org/CC-MAIN-2026-30-index",
+                    "from": "2026-07-10T07:05:34",
+                    "to": "2026-07-23T01:13:28",
+                }
+            ],
+            request=request,
+        )
+    body = "\n".join(
+        (
+            json.dumps(_capture("https://example.com/public/alpha", "DIGEST-A")),
+            json.dumps(_capture("https://example.com/public/beta?b=2&a=1", "DIGEST-B")),
+        )
+    )
+    return httpx.Response(200, text=body, request=request)
+
+
+def _capture(url: str, digest: str) -> dict[str, str]:
+    return {
+        "timestamp": "20260715120000",
+        "url": url,
+        "mime": "text/html",
+        "status": "200",
+        "digest": digest,
+        "length": "1234",
+        "offset": "5678",
+        "filename": "crawl-data/CC-MAIN-2026-30/segments/example/warc/example.warc.gz",
+    }


### PR DESCRIPTION
## Scope

Closes the SA-15 Common Crawl consolidation gap without duplicating the existing production adapter or normalized-search core.

### Bridge
- reuses the existing `CommonCrawlIndexAdapter` and its SA-14 provider contract;
- adds an explicit `common-crawl-archive-discovery` search plan;
- translates bounded quarantined Common Crawl archive-index projections into the canonical SA15-L01 `SearchProviderExecution` contract;
- reuses `normalize_search_executions()` to produce `SearchDiscoveryCandidate` objects;
- preserves provider/source identity `common-crawl-index`, record keys, observed timestamps, canonical URLs and metadata-only excerpts;
- keeps candidates `UNROUTED` until SA15-L09 chooses a governed acquisition route.

### Fail-closed invariants
- wrong template/version/purpose/provider rejected;
- cross-organization projections rejected;
- non-Common-Crawl projections rejected;
- claims rejected;
- non-quarantined archive metadata rejected;
- more than 50 normalized provider results rejected;
- no WARC body retrieval introduced.

### Deterministic tests
- archive-plan identity;
- adapter batch -> `SearchProviderExecution` -> normalized candidates;
- canonical URL normalization;
- provider provenance;
- deterministic ordering;
- `UNROUTED` state;
- non-archive-plan rejection;
- cross-organization rejection.

### Real live gate
The SA-15 workflow now has a branch-specific Common Crawl job that executes:

`real CommonCrawlIndexAdapter -> real Common Crawl public index -> normalized bridge -> SearchDiscoveryCandidate -> SA15-L09 governed PUBLIC_WEB routing`

against the neutral Common Crawl Foundation website target.

## Completion truth

This PR is draft. C1 is not complete until the exact final candidate SHA passes both normal repository CI and the real Common Crawl normalized live workflow. After the first successful live proof, the proof must be recorded in the C1 document and that documentation commit must itself rerun and pass both gates before merge.