### PR TITLE
SA15: complete internal search-provider and routing hardening

### DIFF
--- a/.github/workflows/sa15-live-validation.yml
+++ b/.github/workflows/sa15-live-validation.yml
@@ -33,7 +33,9 @@ jobs:
         run: python scripts/live_validate_sa15_cdx.py
 
   live-common-crawl-normalized-discovery:
-    if: github.event.pull_request.head.ref == 'agent/sa15-c1-common-crawl-serp-bridge'
+    if: >-
+      github.event.pull_request.head.ref == 'agent/sa15-c1-common-crawl-serp-bridge' ||
+      github.event.pull_request.head.ref == 'agent/sa15-internal-completion-pass'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/sa15-live-validation.yml
+++ b/.github/workflows/sa15-live-validation.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Check out repository
+      - name: Check out exact PR head
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
@@ -39,8 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Check out repository
+      - name: Check out exact PR head
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5

--- a/.github/workflows/sa15-provider-live-validation.yml
+++ b/.github/workflows/sa15-provider-live-validation.yml
@@ -10,7 +10,6 @@ on:
         options:
           - brave
           - mojeek
-          - patentsview
       organization_name:
         description: Controlled organization name used by search validation
         required: true
@@ -20,11 +19,6 @@ on:
         description: Controlled public organization URL used by search validation
         required: true
         default: https://archive.org/
-        type: string
-      patentsview_assignee:
-        description: Exact PatentsView assignee_organization (required only for patentsview)
-        required: false
-        default: ""
         type: string
 
 permissions:
@@ -41,11 +35,8 @@ jobs:
     env:
       BRAVE_SEARCH_API_TOKEN: ${{ secrets.BRAVE_SEARCH_API_TOKEN }}
       MOJEEK_API_KEY: ${{ secrets.MOJEEK_API_KEY }}
-      PATENTSVIEW_API_KEY: ${{ secrets.PATENTSVIEW_API_KEY }}
       SA15_SEARCH_ORGANIZATION: ${{ inputs.organization_name }}
       SA15_SEARCH_ORGANIZATION_URL: ${{ inputs.organization_url }}
-      SA15_PATENTSVIEW_CANONICAL_NAME: ${{ inputs.organization_name }}
-      SA15_PATENTSVIEW_ASSIGNEE: ${{ inputs.patentsview_assignee }}
     steps:
       - name: Check out requested exact ref
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -69,9 +60,6 @@ jobs:
               ;;
             mojeek)
               python scripts/live_validate_sa15_mojeek.py
-              ;;
-            patentsview)
-              python scripts/live_validate_sa15_patentsview.py
               ;;
             *)
               echo "Unsupported SA-15 provider" >&2

--- a/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
+++ b/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-`IMPLEMENTED` / real provider live proof exists / production-integration revalidation pending on the current internal-completion candidate.
+`IMPLEMENTED_VALIDATED` on the corrected production-wired path, subject only to repetition of the gates on the final documentation head before merge.
 
 Common Crawl already had a real production adapter and provider `live_tested` proof from SA-14. C1 then proved the real provider path through normalized discovery and governed routing on PR #130. That proof was genuine, but a post-merge review found an integration gap: the live runner manually composed the normalization/router after `CommonCrawlIndexAdapter.collect()`, while scheduled production collection itself stopped after the quarantined archive projections.
 
@@ -35,20 +35,45 @@ The bridge does not relabel Common Crawl as a general web-search engine. It pres
 - off-origin/out-of-scope/budget-exhausted candidates require source review.
 - normalized provider execution timestamps are preserved for audit/replay.
 
-## Existing real live proof
+## Corrected production-integration proof
 
-PR #130 final head `71bf84001592e6d294f6f1db2a868e04eef3133a` passed SA-15 Live Validation run #34 against the real Common Crawl public index. The earlier proof demonstrated non-empty provider observations, normalization and governed routing. It remains valid proof that the provider/bridge combination works, but it is not by itself proof of the new production-wired implementation.
+The first corrected candidate was:
 
-## Current revalidation gate
+`e508822ddeaf56594b6a48db9599a9bfae862087`
 
-The internal-completion candidate must independently pass, on its exact final SHA:
+SA-15 Live Validation run #49 (`31622886737`) checked out that exact PR head SHA rather than GitHub's synthetic merge ref and executed the real production `CommonCrawlIndexAdapter` against the public Common Crawl index. It passed with:
+
+- **43** real observations;
+- **43** quarantined archive projections;
+- **0** automatic claims;
+- **23** canonical normalized discovery candidates;
+- **23 / 23** governed automatic `PUBLIC_WEB` routes;
+- **0** source-review routes on the controlled first-party target;
+- normalization/routing produced inside the production adapter and persisted in the `normalized_discovery` checkpoint;
+- no WARC body retrieval.
+
+Normal repository CI run #1974 (`31622886771`) also passed for the same candidate change against current `main` integration:
+
+- dependency consistency: pass;
+- Python dependency audit: pass, no known vulnerabilities;
+- Ruff: pass;
+- strict Mypy: pass on **695** source files;
+- architecture/release contracts: **36 passed**;
+- reversible Alembic migrations: pass;
+- complete backend suite: **1485 passed**;
+- branch-aware coverage: **90.07%**;
+- frontend audit/typecheck/build: pass.
+
+This proves the production-wired C1 implementation itself, not merely a validation-only composition.
+
+## Final merge gate
+
+This documentation update creates a new branch head, so the earlier candidate cannot be used as the final merge candidate. The exact final documentation head must independently repeat:
 
 1. complete repository CI;
-2. `live-common-crawl-normalized-discovery` using the real provider;
-3. a non-empty production-adapter batch;
-4. a non-empty `normalized_discovery` checkpoint produced by the adapter itself;
-5. all normalized candidates routed consistently with the controlled governed target;
-6. zero unsupported claims;
-7. zero unresolved review threads.
+2. the real `live-common-crawl-normalized-discovery` job with an exact PR-head checkout;
+3. a non-empty production-adapter batch and `normalized_discovery` checkpoint;
+4. zero unsupported claims;
+5. zero unresolved review threads.
 
-No skipped workflow, mock, prior SHA, or manually recomposed bridge execution satisfies this new integration gate.
+A skipped workflow, mock, earlier SHA or manually recomposed bridge execution does not satisfy this final gate.

--- a/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
+++ b/docs/source_activation/SA_15_C1_COMMON_CRAWL_NORMALIZED_DISCOVERY.md
@@ -2,109 +2,53 @@
 
 ## Status
 
-`IMPLEMENTED_VALIDATED` / normalized integration `live_tested` candidate.
+`IMPLEMENTED` / real provider live proof exists / production-integration revalidation pending on the current internal-completion candidate.
 
-Common Crawl already had a real production adapter and provider `live_tested` proof from SA-14. C1 closes the remaining SA-15 consolidation gap: Common Crawl archive-index discoveries now enter the same normalized discovery and governed acquisition path introduced by SA15-L01/L09.
+Common Crawl already had a real production adapter and provider `live_tested` proof from SA-14. C1 then proved the real provider path through normalized discovery and governed routing on PR #130. That proof was genuine, but a post-merge review found an integration gap: the live runner manually composed the normalization/router after `CommonCrawlIndexAdapter.collect()`, while scheduled production collection itself stopped after the quarantined archive projections.
 
-The first complete candidate `d82297cbdd2fb22641a41f66bb2c001be46791cf` passed both the real Common Crawl live workflow and the complete repository CI. This documentation commit intentionally creates a new candidate SHA; C1 is mergeable only after that final documentation SHA independently repeats both gates successfully.
+The SA15 internal-completion pass closes that gap instead of relabeling the earlier proof. `CommonCrawlIndexAdapter.collect()` now invokes the C1 normalized-discovery/routing contract itself and records a bounded `normalized_discovery` checkpoint containing the provider id, canonical candidate count, governed route counts and route target identifiers. The C1 live runner no longer calls the bridge/router manually; it succeeds only if the real production adapter itself produced that checkpoint.
 
-## Objective
-
-The runtime chain is:
+## Production chain
 
 ```text
 PublicWebTarget
 -> CommonCrawlIndexAdapter
+-> real Common Crawl public index
 -> immutable RawObservation + quarantined ARCHIVE_SNAPSHOT projection
--> Common Crawl normalized bridge
+-> common_crawl_search_bridge
 -> SearchProviderExecution
 -> normalize_search_executions()
 -> SearchDiscoveryCandidate
--> governed SA15-L09 acquisition routing
+-> SA15-L09 governed acquisition routing
+-> durable normalized_discovery checkpoint
 ```
 
-The bridge does not relabel Common Crawl as a general web-search engine. It uses an explicit archive-discovery template and preserves `common-crawl-index` as the provider/source identity.
+The bridge does not relabel Common Crawl as a general web-search engine. It preserves `common-crawl-index` provider/source identity and archive-discovery purpose.
 
-## Implementation contract
+## Fail-closed and evidence boundary
 
-`common_crawl_search_bridge.py` provides:
+- Common Crawl index metadata is discovery lineage, not proof of current website state.
+- WARC bodies are not retrieved by this path.
+- no automatic claim is created.
+- only same-organization URLs admitted by an executable `PublicWebTarget` can route automatically to `PUBLIC_WEB`.
+- L09 cumulative target budgets are enforced across candidates.
+- off-origin/out-of-scope/budget-exhausted candidates require source review.
+- normalized provider execution timestamps are preserved for audit/replay.
 
-- `build_common_crawl_search_plan()` with the explicit `common-crawl-archive-discovery` template;
-- `common_crawl_batch_to_search_execution()` to translate bounded Common Crawl projections into the canonical L01 `SearchProviderExecution` contract;
-- `normalize_common_crawl_batch()` to execute the existing `normalize_search_executions()` path without a parallel normalization implementation.
+## Existing real live proof
 
-The bridge fails closed when:
+PR #130 final head `71bf84001592e6d294f6f1db2a868e04eef3133a` passed SA-15 Live Validation run #34 against the real Common Crawl public index. The earlier proof demonstrated non-empty provider observations, normalization and governed routing. It remains valid proof that the provider/bridge combination works, but it is not by itself proof of the new production-wired implementation.
 
-- the template, version, purpose or provider identity is not the Common Crawl archive-discovery contract;
-- a projection belongs to another organization;
-- a projection originates from another source;
-- archive metadata contains claims;
-- archive metadata escaped quarantine;
-- more than the Common Crawl adapter's 50-result bound reaches normalization.
+## Current revalidation gate
 
-## Evidence boundary
-
-C1 preserves all existing archive restrictions:
-
-- Common Crawl index metadata is discovery lineage, not proof of current website state;
-- WARC bodies are not retrieved by this path;
-- no automatic claim is created;
-- normalized candidates begin as `UNROUTED`;
-- only SA15-L09 may choose an approved acquisition route;
-- a candidate outside an executable same-organization public-web target remains source-review work.
-
-## Deterministic validation
-
-Network-free tests cover:
-
-- explicit archive-plan identity;
-- real adapter-batch to `SearchProviderExecution` conversion;
-- canonical URL normalization;
-- provider provenance;
-- deterministic ordering;
-- `UNROUTED` initial acquisition state;
-- non-archive plan rejection;
-- cross-organization rejection.
-
-## Controlled production live validation
-
-The C1 live runner uses the real production `CommonCrawlIndexAdapter` against Common Crawl's public index and the neutral Common Crawl Foundation website target.
-
-### First complete proof
-
-Candidate SHA:
-
-`d82297cbdd2fb22641a41f66bb2c001be46791cf`
-
-SA-15 Live Validation run #33 passed the production path with:
-
-- **43** real Common Crawl observations;
-- **43** quarantined archive projections;
-- **0** automatic claims;
-- **23** canonical normalized `SearchDiscoveryCandidate` objects after URL deduplication;
-- provider provenance `common-crawl-index` preserved for every normalized hit;
-- **23 / 23** candidates routed automatically through SA15-L09 to the governed `PUBLIC_WEB` route;
-- no WARC body retrieval and no unrestricted HTTP fallback.
-
-Normal repository CI #1928 also passed on the same candidate:
-
-- dependency consistency and dependency audit: pass;
-- Ruff: pass;
-- strict Mypy: pass;
-- architecture/release contracts: pass;
-- reversible migration validation: pass;
-- complete backend tests and coverage gate: pass;
-- frontend dependency audit, typecheck and production build: pass.
-
-The earlier C1 live attempt failed because the SA16-L01 `PublicWebTarget` model now requires an explicit discovery path. C1 was corrected by declaring the controlled homepage seed instead of weakening the target invariant. The subsequent production run is the proof recorded above.
-
-## Final completion rule
-
-C1 is finally mergeable only when the exact documentation head containing this proof itself passes:
+The internal-completion candidate must independently pass, on its exact final SHA:
 
 1. complete repository CI;
-2. the real SA-15 Common Crawl normalized live workflow;
-3. all live invariants again with a non-empty provider payload;
-4. zero unresolved review threads.
+2. `live-common-crawl-normalized-discovery` using the real provider;
+3. a non-empty production-adapter batch;
+4. a non-empty `normalized_discovery` checkpoint produced by the adapter itself;
+5. all normalized candidates routed consistently with the controlled governed target;
+6. zero unsupported claims;
+7. zero unresolved review threads.
 
-A skipped job, mock, earlier SHA or successful run that does not execute the production adapter does not satisfy this gate.
+No skipped workflow, mock, prior SHA, or manually recomposed bridge execution satisfies this new integration gate.

--- a/docs/source_activation/SA_15_C2_PATENTSVIEW_PROVIDER_EQUIVALENT_ASSESSMENT.md
+++ b/docs/source_activation/SA_15_C2_PATENTSVIEW_PROVIDER_EQUIVALENT_ASSESSMENT.md
@@ -2,67 +2,35 @@
 
 ## Outcome
 
-C2 is complete as an **assessment and blocker-resolution tranche**, not as a PatentsView live promotion.
+C2 is complete as an **assessment and fail-closed transition**, not as a PatentsView live promotion.
 
-The PatentsView capability remains **not `live_tested`**. No API, bulk-download, browser, mock, skipped workflow, readiness state, or historical archive is being relabeled as a successful production PatentsView run.
+The capability remains **not `live_tested`**. A real historical provider-equivalent attempt reached the PatentsView bulk S3 path and returned HTTP 403. Current PatentsView access has moved to the USPTO Open Data Portal (ODP), which requires legitimate current provider access/credentials and a fresh contract/schema review.
 
-## What was tested in production
+## Internal-completion hardening
 
-A candidate provider-equivalent implementation was built against the historical official PatentsView bulk artifact path:
+A post-merge review identified that the historical `https://search.patentsview.org/api/v1/patent/` route was still enabled/authorized. That could have caused a future current-provider credential to be sent to a legacy endpoint.
 
-- `https://s3.amazonaws.com/data.patentsview.org/download/g_assignee_disambiguated.tsv.zip`
-- `https://s3.amazonaws.com/data.patentsview.org/download/g_patent.tsv.zip`
+The SA15 internal-completion pass fixes this by making the legacy route fail closed at every checked-in execution layer:
 
-The production GitHub Actions run reached the provider and received **HTTP 403 Forbidden** on the first assignee artifact. This is treated as a real negative live result, not as live success and not as a condition that can be ignored or mocked away.
+- Source Governance: source `paused`, authorization `revoked`, no approved hosts/paths/purposes, automation disabled;
+- Source Activation: `blocked`, with only `catalogued -> reviewed -> mapped -> adapter_present` retained;
+- Source Portfolio: `paused`, `executable: false`, `authorization_status: revoked`, current contract explicitly `USPTO_ODP`;
+- credentialed SA15 workflow: PatentsView removed;
+- legacy live runner: stops before reading `PATENTSVIEW_API_KEY` or constructing the historical adapter.
 
-The experimental S3 runtime implementation was therefore removed from the final C2 candidate rather than merging a dead provider path.
-
-## Current provider state
-
-PatentsView data access has moved to the USPTO Open Data Portal (ODP). The current provider path requires legitimate USPTO.gov access, and API use requires provider-issued credentials/API-key authorization.
-
-CIP must therefore fail closed until a legitimate current ODP account/key and the applicable provider terms are available for controlled validation. A missing account/key is a prerequisite, not a completed activation state.
-
-## Historical archives are not an equivalent live replacement
-
-Older public PatentsView releases and mirrors may remain useful for historical research, deterministic fixtures, or backfill after a separate governance review. They do **not** satisfy C2's current-provider live requirement because they are not the current production data-access path and may lag the provider's latest published corpus.
-
-Accordingly, CIP must not use a stale historical release to mark the current PatentsView capability `live_tested`.
-
-## Existing API adapter
-
-The existing `patentsview-patent-metadata` adapter remains the authoritative current PatentsView query implementation in CIP. It continues to:
-
-- require a real provider API key;
-- fail closed with `provider_not_connected` when the key is absent;
-- retain only bounded patent metadata;
-- revalidate returned assignee identity before persistence;
-- produce quarantined discovery metadata rather than direct commercial/evidence claims.
-
-No change in C2 weakens that behavior.
+The old adapter remains in the repository only as reviewed implementation history. It is not an authorized production route.
 
 ## Exact external prerequisite
 
-To resume PatentsView activation, all of the following must be true:
+PatentsView activation can resume only when all of the following are available:
 
-1. a legitimate USPTO.gov / ODP account is available to the deployment owner;
-2. a current provider-issued API key or other officially documented ODP credential is available;
-3. current ODP API/schema and storage/use terms are reviewed and recorded in Source Governance;
-4. the production adapter is updated if the current ODP contract differs from the existing PatentSearch contract;
-5. a controlled real provider run returns non-empty, organization-bound patent metadata;
-6. observations/projections preserve provider provenance, remain bounded and quarantined, and produce zero unsupported claims;
-7. normal repository CI passes on the exact same final candidate SHA;
-8. only then may the activation matrix record `live_tested`.
+1. legitimate deployment-owner USPTO.gov / ODP access;
+2. current provider-issued API credential or officially documented equivalent;
+3. reviewed current ODP API endpoint, schema and storage/use terms;
+4. a provider-specific implementation updated to that current contract;
+5. controlled non-empty organization-bound real-provider validation;
+6. bounded/quarantined projections with provenance and zero unsupported claims;
+7. complete repository CI on the same final SHA;
+8. only then, a truthful `live_tested` promotion.
 
-## C2 exit decision
-
-C2's decision is therefore:
-
-- **historical PatentsView S3 bulk path:** rejected after controlled production HTTP 403;
-- **historical/stale archives:** retained only as possible historical/backfill sources, not current live replacement;
-- **current PatentsView capability:** remains externally blocked on legitimate current USPTO ODP access/credential;
-- **existing API adapter:** retained fail-closed;
-- **`live_tested`:** remains false;
-- **next SA-15 work:** proceed to C3 while this external prerequisite remains tracked explicitly.
-
-This satisfies the C2 assessment objective without fabricating provider readiness or weakening the project's live-validation standard.
+Historical archives, mocks, skipped workflows and the HTTP 403 attempt do not satisfy the current-provider live gate.

--- a/docs/source_activation/SA_15_L02_L04_SEARCH_PROVIDER_LIVE_READINESS.md
+++ b/docs/source_activation/SA_15_L02_L04_SEARCH_PROVIDER_LIVE_READINESS.md
@@ -1,114 +1,56 @@
 # SA-15 L02-L04 — Credentialed search-provider live readiness
 
-## Status
+## Current truth after the SA15 internal-completion pass
 
-This tranche completes the production live-validation path for:
+Normal CI, mocks, deterministic adapter tests, missing-secret skips and runner presence are not provider live proof.
 
-- SA15-L02 — Mojeek Web Search API metadata;
-- SA15-L03 — PatentsView assignee patent metadata;
-- SA15-L04 — Brave Search API metadata.
+### L02 — Mojeek
 
-It does **not** claim `live_tested` for any of the three providers. The checked-in activation inventory must continue to omit that stage until a real provider call succeeds on an exact candidate SHA with the required legitimate credential/entitlement/target prerequisites.
+`MojeekSearchAdapter` and its production live runner remain implemented. The runner now constructs a valid governed `PublicWebTarget` with an explicit seed, so the target model no longer blocks execution before the provider call.
 
-Normal CI, mocks, deterministic adapter tests, a missing-secret skip, or a manually successful workflow that did not execute the production adapter are never provider proof.
+The source remains **not `live_tested`**. Real execution still requires both:
 
-## Common live-proof contract
+- a legitimate `MOJEEK_API_KEY`;
+- reviewed durable-storage rights recorded in `policies/mojeek_search_entitlement.yml` with evidence.
 
-`.github/workflows/sa15-provider-live-validation.yml` is a manually dispatched, credentialed validation workflow. It checks out the exact selected ref, installs the production package, and invokes one of the provider-specific runners under `scripts/`.
+The checked-in entitlement remains fail-closed. No provider call may be used as persistent-ingestion proof until those rights are actually available.
 
-A successful provider proof must show all of the following:
+### L03 — PatentsView
 
-1. the real production adapter performed the network request;
-2. the real provider returned at least one normalized record;
-3. no more than the adapter's 20-result bound was retained;
-4. observation and projection counts match;
-5. source provenance is preserved;
-6. all projections remain quarantined discovery metadata;
-7. zero automatic claims are created;
-8. no third-party page body is fetched through the search adapter;
-9. the single controlled target/checkpoint converges;
-10. no provider secret is printed or stored in an observation/projection.
+The old PatentSearch route is no longer considered a current executable production route. C2 established that PatentsView access has moved to the USPTO Open Data Portal and a controlled attempt against the historical bulk path returned HTTP 403.
 
-Only after the provider-specific live run and the complete repository CI pass on the same final candidate SHA may a separate activation change add `live_tested`.
+The internal-completion pass therefore:
 
-## SA15-L02 — Mojeek
+- pauses the legacy source policy;
+- revokes its network authorization;
+- removes `authorized` and `executable` from Source Activation;
+- marks the Source Portfolio entry paused/non-executable;
+- removes PatentsView from the credentialed SA15 workflow;
+- makes `scripts/live_validate_sa15_patentsview.py` fail before reading any credential or performing network I/O.
 
-Production source id: `mojeek-web-search-metadata`.
+The historical adapter code is retained as implementation history only. It must not receive a future ODP credential. PatentsView remains **not `live_tested`** until the current ODP endpoint/schema/terms/credential model is reviewed, implemented and successfully exercised on an exact candidate SHA.
 
-Production adapter: `MojeekSearchAdapter`.
+### L04 — Brave Search
 
-Provider endpoint: `https://api.mojeek.com/search`.
+`BraveSearchAdapter` and its live runner remain implemented. The runner now supplies an explicit governed seed and can reach the provider stage when a legitimate token exists.
 
-Current provider documentation requires an API key. Current commercial plan information distinguishes durable storage rights: the Business plan advertises storage rights, while other plan/storage combinations are plan-specific. CIP therefore retains the existing two independent gates:
+Brave remains **not `live_tested`** because no real `BRAVE_SEARCH_API_TOKEN` has been provisioned/run through the workflow. A real provider response and complete exact-SHA CI are still required before activation promotion.
 
-- legitimate provider API key;
-- reviewed durable-storage entitlement for the bounded URL/title/query-dependent snippet/rank metadata retained by CIP.
+## Credentialed workflow
 
-`scripts/live_validate_sa15_mojeek.py` loads `policies/mojeek_search_entitlement.yml` before reading `MOJEEK_API_KEY`. The checked-in policy remains deliberately fail-closed:
+`.github/workflows/sa15-provider-live-validation.yml` now exposes only the currently legitimate runnable credentialed candidates:
 
-- `durable_storage_authorized: false`;
-- `plan: unprovisioned`;
-- `evidence_reference: null`.
+- `brave`;
+- `mojeek`.
 
-Therefore the current exact repository state cannot truthfully perform or claim the Mojeek persistent-ingestion live proof. Once a legitimate plan with sufficient storage rights is acquired/reviewed, that entitlement must first be recorded with its evidence reference; only then may the controlled live runner consume `MOJEEK_API_KEY` and contact the provider.
+PatentsView is intentionally absent until the current ODP contract is implemented.
 
-## SA15-L03 — PatentsView
+## Activation matrix
 
-Production source id: `patentsview-patent-metadata`.
+| Source | Production implementation | Current route authorized/executable | External prerequisite | `live_tested` |
+|---|---:|---:|---|---:|
+| Brave Search | yes | yes | legitimate subscription token + real run | no |
+| Mojeek | yes | yes, entitlement-gated | legitimate key + durable-storage rights + real run | no |
+| PatentsView legacy PatentSearch | historical adapter retained | **no; paused/revoked** | replace with current USPTO ODP contract | no |
 
-Production adapter: `PatentsViewPatentAdapter`.
-
-Provider endpoint: `https://search.patentsview.org/api/v1/patent/`.
-
-The current PatentSearch documentation requires `X-Api-Key`, documents a 45-request/minute key limit, and currently states that new API-key grants are temporarily suspended. The existing production adapter already sends the correct header, uses the explicit assignee equality query, bounds results to 20, minimizes fields, and revalidates returned assignee identity before materialization.
-
-`scripts/live_validate_sa15_patentsview.py` additionally requires:
-
-- `PATENTSVIEW_API_KEY`;
-- `SA15_PATENTSVIEW_ASSIGNEE`, containing an exact provider `assignee_organization` known to return data;
-- optional `SA15_PATENTSVIEW_CANONICAL_NAME` for analyst-readable context.
-
-The checked-in production target registry remains empty. A live-validation assignee is intentionally provided only at controlled run time so this readiness tranche does not silently establish a production/prospect target. Until a legitimate provider key exists, PatentsView remains executable-but-not-live.
-
-## SA15-L04 — Brave Search
-
-Production source id: `brave-search-api`.
-
-Production adapter: `BraveSearchAdapter`.
-
-Provider endpoint: `https://api.search.brave.com/res/v1/web/search`.
-
-Current Brave Search API documentation requires the `X-Subscription-Token` header and documents a maximum `count` of 20 results per page. The production adapter already uses that header and the same 20-result bound.
-
-`scripts/live_validate_sa15_brave.py` requires `BRAVE_SEARCH_API_TOKEN` and uses a controlled organization name/URL supplied by the workflow. Defaults are the public Internet Archive organization and `https://archive.org/`; operators may replace those inputs with another approved neutral/first-party validation target.
-
-A real subscription token is the remaining live-provider prerequisite. The repository never embeds or echoes it.
-
-## Workflow inputs and secrets
-
-Manual workflow inputs:
-
-- provider: `brave`, `mojeek`, or `patentsview`;
-- controlled organization name;
-- controlled organization URL;
-- exact PatentsView assignee when PatentsView is selected.
-
-Repository/environment secrets consumed only at execution time:
-
-- `BRAVE_SEARCH_API_TOKEN`;
-- `MOJEEK_API_KEY`;
-- `PATENTSVIEW_API_KEY`.
-
-No secret value is accepted through a workflow input, command-line argument, checked-in YAML, query-template record, observation, projection, or documentation file.
-
-## Activation truth after this tranche
-
-Expected source truth remains:
-
-| Source | Adapter | Authorized | Executable | Credential/entitlement ready | `live_tested` |
-|---|---:|---:|---:|---:|---:|
-| Brave Search | yes | yes | yes | no deployment token in repository | no |
-| Mojeek | yes | yes | yes | no approved durable-storage entitlement/key | no |
-| PatentsView | yes | yes | yes | no legitimate deployment key/production target | no |
-
-The next change for any one of these rows is a provider-specific live-proof/promotion commit, not another mocked adapter implementation.
+No row may be promoted by association with another provider's successful workflow.

--- a/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
+++ b/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
@@ -1,93 +1,31 @@
 # SA-15 L06/L07 — Search diversity and governed dork library
 
-## Scope
-
-This increment implements two SA-15 search work items without overstating provider activation:
-
-- **L06** — add a current independent general web-search provider implementation path through Marginalia Search API2;
-- **L07** — replace the three generic search templates with the complete versioned analyst dork/query library required by the SA-15 roadmap.
-
-Search-result metadata remains discovery material. It does not become evidence merely because a provider returned it; downstream retrieval still goes through the governed search-to-acquisition routing path.
-
 ## L06 — Marginalia Search API2
 
-### Implemented
+The current independent-search implementation remains **not live tested** and not production-authorized. The production client targets `https://api2.marginalia-search.com/search`; the shared `public` development key is rejected.
 
-- production client targets `https://api2.marginalia-search.com/search`;
-- API key is sent through the provider-documented `API-Key` header;
-- response parsing is bounded and schema validated for `query`, `license`, and result `url` / `title` / `description` fields;
-- redirects are disabled;
-- response body size is bounded;
-- HTTP 429 and 5xx responses are classified retryable;
-- transport failures are classified retryable;
-- schema/content-type failures fail closed;
-- the provider's shared `public` development key is explicitly rejected by the production client;
-- source policy, portfolio state, activation truth, and entitlement prerequisites are represented separately;
-- deterministic tests use `httpx.MockTransport` and never rely on provider network access.
+The SA15 internal-completion pass closes two post-merge defects:
 
-### Current activation truth
+- `MarginaliaSearchEntitlement.assert_live_collection_ready()` is now evaluated before query/key processing and before any network I/O, so a non-public development/test key cannot bypass commercial-use authorization;
+- response bodies are read through a bounded streaming path and collection stops once the 2 MiB response limit would be exceeded, instead of downloading an oversized response first.
 
-`marginalia-web-search-metadata` is **not live tested** and is not production-authorized yet.
+Deterministic tests prove that missing commercial entitlement prevents the HTTP transport from being reached.
 
-Current proven stages:
+Current proven state remains:
 
 `catalogued -> reviewed -> mapped -> adapter_present`
 
-Missing prerequisites remain owned work:
+Remaining external prerequisites are a legitimate commercial API key, commercial-use entitlement evidence, Provider Onboarding secret reference, exact deployment authorization, controlled real-endpoint validation, and exact-SHA CI/live proof. No `live_tested` promotion is made by this pass.
 
-1. legitimate commercial API key;
-2. commercial-use entitlement evidence;
-3. Provider Onboarding secret reference;
-4. exact deployment authorization for host/path/purpose;
-5. controlled production-adapter real-endpoint validation;
-6. exact-head CI/live proof before `live_tested` may be added.
+## L07 — governed dork/query library
 
-The shared development key is not an acceptable substitute for these prerequisites.
+The version-2 library retains the required SA15 query families and operators. The internal-completion pass fixes the `site:` contract: domain-scoped templates now use `{domain}` rather than interpolating the organization display name into `site:`.
 
-## L07 — versioned dork/query library
+`SearchQueryTemplate` supports exactly one of `{organization}` or `{domain}`. Domain templates require a bare canonical hostname; schemes, paths and whitespace are rejected. `SearchQueryPlan.from_template()` and the analyst Google URL renderer accept the explicit domain separately from the display name.
 
-The registry is upgraded from three generic templates to version-2 coverage for:
+All checked-in templates remain disabled by default. The analyst Google URL renderer performs no network I/O and is not automated Google live proof.
 
-- `site:` company/domain research;
-- `filetype:` document discovery;
-- `intitle:` and `inurl:` research patterns;
-- procurement and contracts;
-- cyber products/providers;
-- SOC/SIEM/MDR/XDR/SOAR;
-- IAM/PAM/IGA/Zero Trust;
-- cloud/Kubernetes;
-- AppSec/DevSecOps/SAST/DAST/SCA/SBOM;
-- pentest/red-team/purple-team;
-- GRC/NIS2/DORA/ISO 27001/SOC 2/PCI DSS/HDS;
-- incident/ransomware/breach/regulator signals;
-- recruitment and security-team growth;
-- architecture/migration/transformation;
-- partner/customer/case-study evidence;
-- annual reports, presentations, standards and technical publications;
-- code/package/developer evidence.
+## Completion truth
 
-Every checked-in template is disabled by default. `build_google_analyst_search_url()` renders an analyst-opened Google search URL locally and performs no network request. Automated Google collection therefore remains unavailable until a legitimate provider/API entitlement and governed execution path are implemented.
-
-## Deterministic gates
-
-Tests enforce:
-
-- exact required template inventory;
-- unique template patterns;
-- template version 2;
-- one `{organization}` placeholder per template;
-- disabled-by-default behavior;
-- explicit `site:`, `filetype:`, `intitle:`, and `inurl:` coverage;
-- representative SA-15 cybersecurity coverage terms;
-- deterministic analyst-link URL rendering;
-- Marginalia commercial entitlement fail-closed behavior;
-- rejection of the shared development key;
-- current API2 host/path/header/query contract;
-- HTTP and schema failure classification.
-
-## Exit state
-
-- **L07:** implementation-complete once the PR exact-head CI is green.
-- **L06:** adapter/governance prerequisite implementation complete, but provider activation remains open until legitimate commercial access exists and the exact production adapter receives controlled real-endpoint live proof.
-
-No `live_tested` stage is added by this increment for Marginalia.
+- **L07 internal implementation:** complete subject to exact-final-head CI for this pass.
+- **L06 internal fail-closed implementation:** complete subject to exact-final-head CI, but provider activation remains externally blocked and not `live_tested`.

--- a/docs/source_activation/SA_15_L08_GDELT_CONTRACT_GATE.md
+++ b/docs/source_activation/SA_15_L08_GDELT_CONTRACT_GATE.md
@@ -2,66 +2,27 @@
 
 ## Status
 
-SA15-L08 is **not** an executable GDELT adapter and does not claim `adapter_present`, `executable`, or `live_tested`.
+SA15-L08 still does **not** provide an executable GDELT 5 adapter and does not claim `adapter_present`, `executable` or `live_tested`.
 
-As reviewed on 2026-08-12, GDELT's own 2026 publications still describe GDELT 5 as an upcoming launch and describe the migration of the search/API infrastructure to Spanner as still underway. The repository therefore must not relabel the historical DOC/GEO 1.x/2.x APIs as a GDELT 5 implementation.
-
-The checked-in truth is machine-readable in `policies/gdelt_api_contract.yml` and enforced by `cip.adapters.sources.gdelt.contract`.
-
-## Official references reviewed
-
-- `https://blog.gdeltproject.org/scaling-gdelt-for-a-new-era-migrating-to-spanner-with-agentic-interactive-gemini/`
-- `https://blog.gdeltproject.org/2026/06/`
-- `https://blog.gdeltproject.org/using-the-new-web-ngrams-dataset-to-find-relevant-coverage/`
-
-Those references describe the GDELT 5 / Spanner migration state but do not provide the stable current API base URL, contract version, and schema reference required for a production provider adapter.
+As reviewed on 2026-08-12, the repository still lacks the stable official current GDELT 5 public API contract required for a provider-specific production implementation. Historical DOC/GEO APIs must not be relabeled as GDELT 5.
 
 ## Fail-closed contract
 
-Current manifest state:
+`policies/gdelt_api_contract.yml` remains `awaiting_official_contract`. The internal-completion pass hardens `cip.adapters.sources.gdelt.contract` so a future stable manifest can open the implementation gate only when:
 
-- product generation: `GDELT 5`;
-- status: `awaiting_official_contract`;
-- API base URL: unset;
-- API version: unset;
-- schema reference: unset;
-- storage/retention terms reference: unset.
+- `product_generation` is exactly `GDELT 5` after normalization;
+- a real API base URL exists;
+- the contract/API version is nonblank after trimming;
+- official schema documentation is recorded;
+- official storage/retention terms are recorded;
+- all provider references use HTTPS on `gdeltproject.org` or an exact subdomain;
+- lookalike hosts are rejected;
+- `/api/v1`, `/api/v2` and their descendants are rejected whether or not a trailing slash is present.
 
-`GdeltApiContract.require_adapter_contract()` fails while that status remains pending.
+Deterministic tests cover the pending state, exact product generation, whitespace-only versions, storage-terms host validation, lookalike hosts and legacy API roots.
 
-A future `stable_public_contract` manifest is valid only when:
+## External blocker and continuation
 
-1. an actual API base URL is recorded;
-2. an actual contract/version identifier is recorded;
-3. an official schema/documentation reference is recorded;
-4. all contract references use official HTTPS `gdeltproject.org` hosts or their exact subdomains;
-5. lookalike domains are rejected;
-6. the API base URL is not a legacy `/api/v1/` or `/api/v2/` endpoint.
+No further honest provider adapter can be implemented until GDELT publishes a sufficiently stable current GDELT 5 execution contract. When that happens, L08 must continue with a second implementation tranche: re-review official docs, record the real endpoint/version/schema/terms, add Source Governance, implement the provider schemas/adapter/runtime/checkpoint behavior, add network-free tests, obtain a non-empty controlled real-provider result, and pass exact-final-SHA CI before any `live_tested` promotion.
 
-The test values named `future-api`, `future-schema`, and `future-storage-terms` are deliberately synthetic unit-test values on the official hostname. They are not assertions that those paths exist.
-
-## Why legacy DOC 2.0 is not used
-
-The historical DOC 2.0 API is a real legacy GDELT interface, but implementing it now and calling it "GDELT 5" would make the activation inventory misleading and would bind CIP to an interface GDELT is actively replacing.
-
-If product requirements later call for a temporary legacy-GDELT adapter as a distinct source, that adapter must have its own source ID, governance, lifecycle, and live proof. It must never satisfy the GDELT 5 completion gate.
-
-## Exact exit criteria
-
-When GDELT publishes the current stable API contract, L08 continues with a second implementation tranche:
-
-1. re-review the official provider documentation;
-2. update `policies/gdelt_api_contract.yml` with the real stable contract values;
-3. document storage/retention rights;
-4. add the governed source policy and authorization;
-5. define provider-specific response schemas;
-6. implement the isolated GDELT adapter;
-7. register runtime/checkpoint/retry/quota behavior;
-8. map provider results to discovery metadata / `RawObservation` without converting search results directly into facts;
-9. add deterministic network-free tests;
-10. add a controlled real-provider live-validation workflow;
-11. obtain a non-empty real payload on the production adapter;
-12. run complete exact-head CI on the same final SHA;
-13. only then promote the source to `live_tested`.
-
-Until those conditions are met, the correct state is a mandatory implementation prerequisite rather than a fabricated adapter or terminal abandonment.
+The current state is therefore **internally hardened but externally contract-blocked**.

--- a/policies/search_query_templates.yml
+++ b/policies/search_query_templates.yml
@@ -5,7 +5,7 @@ templates:
     version: 2
     enabled: false
     purpose: corporate-public-footprint-domain
-    query_pattern: 'site:{organization} (security OR cybersecurity OR technology OR architecture)'
+    query_pattern: 'site:{domain} (security OR cybersecurity OR technology OR architecture)'
 
   - id: q-filetype-documents
     version: 2

--- a/policies/source_activation.search_archives_sa14.yml
+++ b/policies/source_activation.search_archives_sa14.yml
@@ -49,16 +49,19 @@ sources:
   - source_id: patentsview-patent-metadata
     display_name: PatentsView assignee patent metadata
     category: corporate_public_footprint
-    disposition: active
-    activation_wave: SA-14
+    disposition: blocked
+    activation_wave: SA-15-C2
     requires_schedule: false
+    reason: >-
+      The historical PatentSearch endpoint is no longer an authorized current provider route.
+      PatentsView access has moved to the USPTO Open Data Portal; activation must remain blocked
+      until the current ODP endpoint, schema, terms and deployment credential are reviewed and a
+      controlled production-adapter run succeeds on an exact candidate SHA.
     stages:
       - catalogued
       - reviewed
       - mapped
       - adapter_present
-      - authorized
-      - executable
 
   - source_id: w3c-affiliation-specification-metadata
     display_name: W3C affiliation standards metadata

--- a/policies/source_portfolio.search_archives.yml
+++ b/policies/source_portfolio.search_archives.yml
@@ -148,19 +148,21 @@ sources:
       cost_per_request: 0
 
   - source_id: patentsview-patent-metadata
-    display_name: PatentsView assignee patent metadata
+    display_name: PatentsView assignee patent metadata (legacy PatentSearch route)
     canonical_url: https://search.patentsview.org/api/v1/patent/
     category: corporate_public_footprint
-    status: executable
+    status: paused
     freshness_max_age_seconds: 604800
     commercial_use_cases: [organization_research, patent_discovery, public_evidence_map]
-    candidate_origin: SA-14
+    candidate_origin: SA-15-C2
     monthly_cost_limit: 0
     metadata:
-      executable: true
-      authorization_status: approved
+      executable: false
+      authorization_status: revoked
       provider_onboarding_required: true
       target_registry_required: true
+      current_contract_required: USPTO_ODP
+      legacy_endpoint_execution: forbidden
       raw_abstract_storage: false
       raw_claim_storage: false
       raw_full_text_storage: false

--- a/policies/sources.search_archives.yml
+++ b/policies/sources.search_archives.yml
@@ -1,5 +1,5 @@
 version: 1
-reviewed_at: 2026-08-11
+reviewed_at: 2026-08-12
 
 sources:
   - id: brave-search-api
@@ -192,13 +192,13 @@ sources:
       owns, deploys, endorses, or commercially needs anything described by the work.
 
   - id: patentsview-patent-metadata
-    name: PatentsView assignee patent metadata
+    name: PatentsView assignee patent metadata (legacy PatentSearch route)
     base_url: https://search.patentsview.org/api/v1/patent/
-    status: enabled
+    status: paused
     source_type: search_provider
     owner: USPTO PatentsView
     terms_url: https://patentsview.org/policies
-    licence: PatentsView API data licensed CC BY 4.0
+    licence: Historical PatentsView API contract; current ODP terms require fresh review
     allowed_data_categories: [public_result_metadata]
     prohibited_data_categories: *prohibited
     rate_limit_per_minute: 10
@@ -207,28 +207,26 @@ sources:
     raw_content_storage: false
     human_review_required: false
     authorization:
-      status: approved
-      document_reference: docs/source_activation/SA_14_PATENTSVIEW_PATENTS.md
-      reviewed_at: "2026-08-11T13:15:00+00:00"
+      status: revoked
+      document_reference: docs/source_activation/SA_15_C2_PATENTSVIEW_PROVIDER_EQUIVALENT_ASSESSMENT.md
+      reviewed_at: "2026-08-12T13:30:00+00:00"
       expires_at: null
-      approved_hosts: [search.patentsview.org]
-      approved_path_prefixes: [/api/v1/patent/]
-      approved_purposes: [patent-discovery]
-      automated_collection_allowed: true
+      approved_hosts: []
+      approved_path_prefixes: []
+      approved_purposes: []
+      automated_collection_allowed: false
       raw_storage_allowed: false
     economics:
       commercial_value: medium
       monthly_cost: 0
       implementation_cost: medium
       maintenance_cost: medium
-      expected_stability: medium
+      expected_stability: low
     notes: >-
-      Real PatentsView PatentSearch adapter scoped to explicit organization-bound assignee labels.
-      Runtime execution additionally requires a connected `api_key`. CIP retains only patent id,
-      title, grant date, type and exact assignee organization; abstracts, claims, inventors,
-      classifications and full text are excluded. Returned assignee identity is revalidated before
-      persistence. Patent presence is quarantined discovery metadata and not evidence of deployment,
-      vulnerability, compromise, cyber need, opportunity or outreach authorization.
+      The historical PatentSearch adapter is retained only as reviewed implementation history and
+      must not execute. Current PatentsView access has moved to the USPTO Open Data Portal. Before
+      any credential can be consumed, CIP must review and implement the current ODP endpoint,
+      schema, credential model and terms, then perform controlled exact-SHA live validation.
 
   - id: w3c-affiliation-specification-metadata
     name: W3C affiliation standards metadata

--- a/scripts/live_validate_sa15_brave.py
+++ b/scripts/live_validate_sa15_brave.py
@@ -65,6 +65,7 @@ def _controlled_target() -> PublicWebTarget:
         base_url=base_url,
         sitemap_urls=(),
         feed_urls=(),
+        seed_urls=(base_url,),
         discover_security_txt=False,
         allowed_path_prefixes=("/",),
         enabled=True,

--- a/scripts/live_validate_sa15_common_crawl_bridge.py
+++ b/scripts/live_validate_sa15_common_crawl_bridge.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -10,20 +11,13 @@ from cip.modules.collection_orchestration.application.common_crawl_adapter impor
 )
 from cip.modules.collection_orchestration.application.common_crawl_search_bridge import (
     COMMON_CRAWL_PROVIDER_ID,
-    build_common_crawl_search_plan,
-    normalize_common_crawl_batch,
 )
 from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
-from cip.modules.collection_orchestration.application.search_acquisition_router import (
-    SearchAcquisitionRoute,
-    SearchAcquisitionRouteKind,
-    route_search_discovery_candidates,
-)
-from cip.modules.public_footprint.domain.search_core import SearchDiscoveryCandidate
 from cip.modules.source_governance.infrastructure.registry import load_source_registry
 
 POLICY_PATH = Path("policies/sources.search_archives.yml")
 ORG_ID = UUID("7a0b182e-353e-5a61-8be4-703e935e227d")
+_TARGET_ID = "sa15-common-crawl-normalized-live"
 
 
 def main() -> None:
@@ -40,27 +34,19 @@ def main() -> None:
         collected_at=now,
         retention_until=now + timedelta(days=365),
     )
-    plan = build_common_crawl_search_plan(
-        organization_id=ORG_ID,
-        organization_name="Common Crawl Foundation",
-        target_base_url=target.base_url,
-        created_at=now,
-    )
-    candidates = normalize_common_crawl_batch(plan, batch, executed_at=now)
-    routes = route_search_discovery_candidates(candidates, (target,), routed_at=now)
-    _assert_live_truth(batch, candidates, routes)
+    routing = _assert_live_truth(batch)
     print(
-        "SA-15 C1 live validation passed: "
+        "SA-15 C1 production-integrated live validation passed: "
         f"observations={len(batch.observations)} "
-        f"normalized_candidates={len(candidates)} "
-        f"automatic_routes={len(routes)} "
+        f"normalized_candidates={routing['candidate_count']} "
+        f"automatic_routes={routing['public_web_route_count']} "
         f"provider={COMMON_CRAWL_PROVIDER_ID}"
     )
 
 
 def _target(now: datetime) -> PublicWebTarget:
     return PublicWebTarget(
-        id="sa15-common-crawl-normalized-live",
+        id=_TARGET_ID,
         organization_id=ORG_ID,
         canonical_name="Common Crawl Foundation",
         base_url="https://commoncrawl.org",
@@ -80,34 +66,43 @@ def _target(now: datetime) -> PublicWebTarget:
     )
 
 
-def _assert_live_truth(
-    batch: AdapterCollectionBatch,
-    candidates: tuple[SearchDiscoveryCandidate, ...],
-    routes: tuple[SearchAcquisitionRoute, ...],
-) -> None:
+def _assert_live_truth(batch: AdapterCollectionBatch) -> Mapping[str, object]:
     observations = len(batch.observations)
     if observations < 1 or observations > 50:
-        raise RuntimeError("Common Crawl live bridge returned an invalid observation count")
+        raise RuntimeError("Common Crawl live adapter returned an invalid observation count")
     if len(batch.public_footprint_projections) != observations:
-        raise RuntimeError("Common Crawl live bridge lost archive projections")
-    if len(candidates) < 1 or len(candidates) > observations:
-        raise RuntimeError("Common Crawl live bridge produced invalid normalized candidates")
-    if len(routes) != len(candidates):
-        raise RuntimeError("Common Crawl normalized candidates did not all enter routing")
+        raise RuntimeError("Common Crawl live adapter lost archive projections")
     if any(projection.claims for projection in batch.public_footprint_projections):
         raise RuntimeError("Common Crawl archive metadata unexpectedly produced claims")
-    if any(candidate.provider_count != 1 for candidate in candidates):
-        raise RuntimeError("Common Crawl provider provenance was not preserved")
-    if any(
-        hit.provider_id != COMMON_CRAWL_PROVIDER_ID
-        for candidate in candidates
-        for hit in candidate.provider_hits
-    ):
+
+    checkpoint = batch.checkpoint_payload
+    if not isinstance(checkpoint, Mapping):
+        raise RuntimeError("Common Crawl live adapter did not persist a checkpoint")
+    routing = checkpoint.get("normalized_discovery")
+    if not isinstance(routing, Mapping):
+        raise RuntimeError(
+            "Common Crawl production adapter did not execute normalized discovery routing"
+        )
+    if routing.get("provider_id") != COMMON_CRAWL_PROVIDER_ID:
         raise RuntimeError("Common Crawl normalized provider id drifted")
-    if any(route.route_kind is not SearchAcquisitionRouteKind.PUBLIC_WEB for route in routes):
-        raise RuntimeError("Common Crawl normalized candidate failed governed public-web routing")
-    if any(not route.automatic for route in routes):
-        raise RuntimeError("Common Crawl normalized route is not automatic")
+
+    candidate_count = routing.get("candidate_count")
+    public_web_count = routing.get("public_web_route_count")
+    source_review_count = routing.get("source_review_route_count")
+    routes = routing.get("routes")
+    if not isinstance(candidate_count, int) or not 1 <= candidate_count <= observations:
+        raise RuntimeError("Common Crawl production adapter produced invalid normalized candidates")
+    if public_web_count != candidate_count or source_review_count != 0:
+        raise RuntimeError("Common Crawl normalized candidates did not all route to PUBLIC_WEB")
+    if not isinstance(routes, list) or len(routes) != candidate_count:
+        raise RuntimeError("Common Crawl production routing checkpoint lost routes")
+    if any(not isinstance(route, Mapping) for route in routes):
+        raise RuntimeError("Common Crawl production routing checkpoint contains invalid routes")
+    if any(route.get("route_kind") != "public_web" for route in routes):
+        raise RuntimeError("Common Crawl normalized candidate failed governed PUBLIC_WEB routing")
+    if any(route.get("public_web_target_id") != _TARGET_ID for route in routes):
+        raise RuntimeError("Common Crawl normalized route lost governed target provenance")
+    return routing
 
 
 if __name__ == "__main__":

--- a/scripts/live_validate_sa15_mojeek.py
+++ b/scripts/live_validate_sa15_mojeek.py
@@ -77,6 +77,7 @@ def _controlled_target() -> PublicWebTarget:
         base_url=base_url,
         sitemap_urls=(),
         feed_urls=(),
+        seed_urls=(base_url,),
         discover_security_txt=False,
         allowed_path_prefixes=("/",),
         enabled=True,

--- a/scripts/live_validate_sa15_patentsview.py
+++ b/scripts/live_validate_sa15_patentsview.py
@@ -1,86 +1,16 @@
 from __future__ import annotations
 
-import os
-from datetime import UTC, datetime, timedelta
-from pathlib import Path
-from uuid import UUID, uuid4
 
-from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
-from cip.modules.collection_orchestration.application.patentsview_patent_adapter import (
-    PatentsViewPatentAdapter,
-)
-from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
-from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
-from cip.modules.source_governance.infrastructure.registry import load_source_registry
-
-_POLICY_PATH = Path("policies/sources.search_archives.yml")
-_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
-_MAX_RESULTS = 20
+class PatentsViewCurrentContractUnavailable(RuntimeError):
+    """Raised while the current USPTO ODP production contract is not implemented."""
 
 
 def main() -> None:
-    token = _required_env("PATENTSVIEW_API_KEY")
-    assignee = _required_env("SA15_PATENTSVIEW_ASSIGNEE")
-    canonical_name = os.environ.get("SA15_PATENTSVIEW_CANONICAL_NAME", assignee).strip()
-    if not canonical_name:
-        raise RuntimeError("SA15_PATENTSVIEW_CANONICAL_NAME cannot be empty")
-    target = PatentsViewPatentTarget(
-        target_id="sa15-controlled-patentsview-assignee",
-        organization_id=_ORG_ID,
-        canonical_name=canonical_name,
-        assignee_organization=assignee,
-        enabled=True,
+    raise PatentsViewCurrentContractUnavailable(
+        "PatentsView legacy PatentSearch live validation is disabled. "
+        "Implement and govern the current USPTO Open Data Portal endpoint/schema/credential "
+        "contract before any provider credential is read or any network request is attempted."
     )
-    entry = next(
-        item
-        for item in load_source_registry(_POLICY_PATH)
-        if item.policy.id == "patentsview-patent-metadata"
-    )
-    now = datetime.now(UTC)
-    batch = PatentsViewPatentAdapter(
-        entry,
-        (target,),
-        token_provider=lambda: token,
-        timeout_seconds=60,
-    ).collect(
-        collection_job_id=uuid4(),
-        checkpoint_payload=None,
-        collected_at=now,
-        retention_until=now + timedelta(days=365),
-    )
-    _validate_batch(batch)
-    print(
-        "SA-15 L03 live validation passed: "
-        f"assignee={assignee!r} "
-        f"patentsview_observations={len(batch.observations)} "
-        f"patentsview_projections={len(batch.public_footprint_projections)} claims=0 bodies=0"
-    )
-
-
-def _validate_batch(batch: AdapterCollectionBatch) -> None:
-    observations = batch.observations
-    projections = batch.public_footprint_projections
-    if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
-        raise RuntimeError("PatentsView live validation returned invalid result counts")
-    if any(observation.source_id != "patentsview-patent-metadata" for observation in observations):
-        raise RuntimeError("PatentsView live validation lost source provenance")
-    if any(projection.claims for projection in projections):
-        raise RuntimeError("PatentsView patent metadata unexpectedly produced claims")
-    if any(
-        projection.resource.kind is not PublicResourceKind.SEARCH_RESULT
-        or projection.resource.retrieval_state is not ResourceRetrievalState.QUARANTINED
-        for projection in projections
-    ):
-        raise RuntimeError("PatentsView results escaped discovery quarantine")
-    if batch.checkpoint_payload != {"target_index": 0}:
-        raise RuntimeError("PatentsView live validation checkpoint did not converge")
-
-
-def _required_env(name: str) -> str:
-    value = os.environ.get(name, "").strip()
-    if not value:
-        raise RuntimeError(f"{name} is required for controlled live validation")
-    return value
 
 
 if __name__ == "__main__":

--- a/src/cip/adapters/sources/gdelt/contract.py
+++ b/src/cip/adapters/sources/gdelt/contract.py
@@ -33,14 +33,24 @@ class _GdeltContractModel(BaseModel):
 
     @model_validator(mode="after")
     def validate_contract_readiness(self) -> _GdeltContractModel:
+        if self.product_generation.strip() != "GDELT 5":
+            raise ValueError("GDELT contract gate requires product_generation exactly GDELT 5")
         _validate_official_references(self.official_references)
         if self.status is GdeltContractStatus.STABLE_PUBLIC_CONTRACT:
-            if not self.api_base_url or not self.api_version or not self.schema_reference:
+            api_version = (self.api_version or "").strip()
+            if (
+                not self.api_base_url
+                or not api_version
+                or not self.schema_reference
+                or not self.storage_terms_reference
+            ):
                 raise ValueError(
-                    "stable GDELT contract requires API base URL, version, and schema reference"
+                    "stable GDELT contract requires API base URL, version, schema reference, "
+                    "and storage terms reference"
                 )
             _validate_current_endpoint(self.api_base_url)
             _validate_official_url(self.schema_reference)
+            _validate_official_url(self.storage_terms_reference)
         return self
 
 
@@ -83,7 +93,7 @@ def load_gdelt_api_contract(path: Path) -> GdeltApiContract:
         reviewed_at=parsed.reviewed_at,
         official_references=parsed.official_references,
         api_base_url=parsed.api_base_url,
-        api_version=parsed.api_version,
+        api_version=parsed.api_version.strip() if parsed.api_version else None,
         schema_reference=parsed.schema_reference,
         storage_terms_reference=parsed.storage_terms_reference,
     )
@@ -107,8 +117,12 @@ def _is_official_gdelt_host(host: str) -> bool:
 
 def _validate_current_endpoint(value: str) -> None:
     _validate_official_url(value)
-    path = urlparse(value).path.casefold()
-    if "/api/v1/" in path or "/api/v2/" in path:
+    path = urlparse(value).path.casefold().rstrip("/")
+    if path == "/api/v1" or path.startswith("/api/v1/"):
+        raise ValueError(
+            "legacy GDELT API endpoints cannot satisfy the current GDELT contract gate"
+        )
+    if path == "/api/v2" or path.startswith("/api/v2/"):
         raise ValueError(
             "legacy GDELT API endpoints cannot satisfy the current GDELT contract gate"
         )

--- a/src/cip/adapters/sources/marginalia_search/client.py
+++ b/src/cip/adapters/sources/marginalia_search/client.py
@@ -58,12 +58,13 @@ class MarginaliaSearchClient:
             )
 
         try:
-            with httpx.Client(
-                timeout=self._timeout_seconds,
-                follow_redirects=False,
-                transport=self._transport,
-            ) as client:
-                with client.stream(
+            with (
+                httpx.Client(
+                    timeout=self._timeout_seconds,
+                    follow_redirects=False,
+                    transport=self._transport,
+                ) as client,
+                client.stream(
                     "GET",
                     _API_URL,
                     headers={
@@ -77,17 +78,18 @@ class MarginaliaSearchClient:
                         "dc": "3",
                         "nsfw": "1",
                     },
-                ) as response:
-                    response.raise_for_status()
-                    content_type = response.headers.get("content-type", "").casefold()
-                    if "json" not in content_type:
-                        raise MarginaliaSearchClientError(
-                            "Marginalia response is not JSON",
-                            code="unsafe_source_response",
-                            retryable=False,
-                        )
-                    content = _read_bounded_body(response)
-                    request_url = str(response.request.url)
+                ) as response,
+            ):
+                response.raise_for_status()
+                content_type = response.headers.get("content-type", "").casefold()
+                if "json" not in content_type:
+                    raise MarginaliaSearchClientError(
+                        "Marginalia response is not JSON",
+                        code="unsafe_source_response",
+                        retryable=False,
+                    )
+                content = _read_bounded_body(response)
+                request_url = str(response.request.url)
         except MarginaliaSearchClientError:
             raise
         except httpx.HTTPStatusError as exc:

--- a/src/cip/adapters/sources/marginalia_search/client.py
+++ b/src/cip/adapters/sources/marginalia_search/client.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import httpx
 from pydantic import ValidationError
 
+from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
 from cip.adapters.sources.marginalia_search.schemas import MarginaliaSearchResponse
 
 _MAX_RESPONSE_BYTES = 2 * 1024 * 1024
@@ -32,16 +33,19 @@ class MarginaliaQueryResult:
 class MarginaliaSearchClient:
     def __init__(
         self,
+        entitlement: MarginaliaSearchEntitlement,
         *,
         timeout_seconds: float = 30.0,
         transport: httpx.BaseTransport | None = None,
     ) -> None:
         if timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be positive")
+        self._entitlement = entitlement
         self._timeout_seconds = timeout_seconds
         self._transport = transport
 
     def search(self, *, query: str, api_key: str) -> MarginaliaQueryResult:
+        self._entitlement.assert_live_collection_ready()
         normalized_query = query.strip()
         normalized_key = api_key.strip()
         if not normalized_query:
@@ -59,7 +63,8 @@ class MarginaliaSearchClient:
                 follow_redirects=False,
                 transport=self._transport,
             ) as client:
-                response = client.get(
+                with client.stream(
+                    "GET",
                     _API_URL,
                     headers={
                         "Accept": "application/json",
@@ -72,8 +77,19 @@ class MarginaliaSearchClient:
                         "dc": "3",
                         "nsfw": "1",
                     },
-                )
-                response.raise_for_status()
+                ) as response:
+                    response.raise_for_status()
+                    content_type = response.headers.get("content-type", "").casefold()
+                    if "json" not in content_type:
+                        raise MarginaliaSearchClientError(
+                            "Marginalia response is not JSON",
+                            code="unsafe_source_response",
+                            retryable=False,
+                        )
+                    content = _read_bounded_body(response)
+                    request_url = str(response.request.url)
+        except MarginaliaSearchClientError:
+            raise
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
             raise MarginaliaSearchClientError(
@@ -88,21 +104,8 @@ class MarginaliaSearchClient:
                 retryable=True,
             ) from exc
 
-        content_type = response.headers.get("content-type", "").casefold()
-        if "json" not in content_type:
-            raise MarginaliaSearchClientError(
-                "Marginalia response is not JSON",
-                code="unsafe_source_response",
-                retryable=False,
-            )
-        if len(response.content) > _MAX_RESPONSE_BYTES:
-            raise MarginaliaSearchClientError(
-                "Marginalia response exceeds size limit",
-                code="unsafe_source_response",
-                retryable=False,
-            )
         try:
-            parsed = MarginaliaSearchResponse.model_validate_json(response.content)
+            parsed = MarginaliaSearchResponse.model_validate_json(content)
         except ValidationError as exc:
             raise MarginaliaSearchClientError(
                 "Marginalia response schema changed",
@@ -111,5 +114,18 @@ class MarginaliaSearchClient:
             ) from exc
         return MarginaliaQueryResult(
             response=parsed,
-            request_url=str(response.request.url),
+            request_url=request_url,
         )
+
+
+def _read_bounded_body(response: httpx.Response) -> bytes:
+    body = bytearray()
+    for chunk in response.iter_bytes():
+        if len(body) + len(chunk) > _MAX_RESPONSE_BYTES:
+            raise MarginaliaSearchClientError(
+                "Marginalia response exceeds size limit",
+                code="unsafe_source_response",
+                retryable=False,
+            )
+        body.extend(chunk)
+    return bytes(body)

--- a/src/cip/modules/collection_orchestration/application/common_crawl_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/common_crawl_adapter.py
@@ -14,6 +14,9 @@ from cip.adapters.sources.common_crawl.client import (
 )
 from cip.adapters.sources.common_crawl.schemas import CommonCrawlCapture
 from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.common_crawl_search_bridge import (
+    build_common_crawl_routing_checkpoint,
+)
 from cip.modules.collection_orchestration.application.ports import (
     AdapterCollectionBatch,
     AdapterExecutionError,
@@ -86,7 +89,7 @@ class CommonCrawlIndexAdapter:
         )
         next_crawl_ids = dict(crawl_ids)
         next_crawl_ids[_pair_key(target, prefix)] = collection.id
-        return AdapterCollectionBatch(
+        batch = AdapterCollectionBatch(
             observations=tuple(
                 _observation(
                     capture,
@@ -112,6 +115,21 @@ class CommonCrawlIndexAdapter:
             ),
             checkpoint_payload={"pair_index": next_index, "crawl_ids": next_crawl_ids},
             not_modified=not captures,
+        )
+        routing_checkpoint = build_common_crawl_routing_checkpoint(
+            target,
+            batch,
+            executed_at=collected_at,
+        )
+        return AdapterCollectionBatch(
+            observations=batch.observations,
+            public_footprint_projections=batch.public_footprint_projections,
+            checkpoint_payload={
+                "pair_index": next_index,
+                "crawl_ids": next_crawl_ids,
+                "normalized_discovery": routing_checkpoint,
+            },
+            not_modified=batch.not_modified,
         )
 
 

--- a/src/cip/modules/collection_orchestration/application/common_crawl_search_bridge.py
+++ b/src/cip/modules/collection_orchestration/application/common_crawl_search_bridge.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
+from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
+from cip.modules.collection_orchestration.application.search_acquisition_router import (
+    route_search_discovery_candidates,
+)
 from cip.modules.public_footprint.domain.models import PublicFootprintProjection
 from cip.modules.public_footprint.domain.search import SearchResultLead
 from cip.modules.public_footprint.domain.search_core import (
@@ -80,6 +84,40 @@ def normalize_common_crawl_batch(
         executed_at=executed_at,
     )
     return normalize_search_executions(plan, (execution,))
+
+
+def build_common_crawl_routing_checkpoint(
+    target: PublicWebTarget,
+    batch: AdapterCollectionBatch,
+    *,
+    executed_at: datetime,
+) -> dict[str, object]:
+    plan = build_common_crawl_search_plan(
+        organization_id=target.organization_id,
+        organization_name=target.canonical_name,
+        target_base_url=target.base_url,
+        created_at=executed_at,
+    )
+    candidates = normalize_common_crawl_batch(plan, batch, executed_at=executed_at)
+    routes = route_search_discovery_candidates(
+        candidates,
+        (target,),
+        routed_at=executed_at,
+    )
+    return {
+        "provider_id": COMMON_CRAWL_PROVIDER_ID,
+        "candidate_count": len(candidates),
+        "public_web_route_count": sum(route.automatic for route in routes),
+        "source_review_route_count": sum(not route.automatic for route in routes),
+        "routes": [
+            {
+                "target_url": route.requested_url,
+                "route_kind": route.route_kind.value,
+                "public_web_target_id": route.public_web_target_id,
+            }
+            for route in routes
+        ],
+    }
 
 
 def _validate_plan(plan: SearchQueryPlan) -> None:

--- a/src/cip/modules/collection_orchestration/application/search_acquisition_router.py
+++ b/src/cip/modules/collection_orchestration/application/search_acquisition_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import StrEnum
@@ -50,15 +51,28 @@ def route_search_discovery_candidates(
     targets: tuple[PublicWebTarget, ...],
     *,
     routed_at: datetime,
+    target_usage: Mapping[str, CrawlUsage] | None = None,
 ) -> tuple[SearchAcquisitionRoute, ...]:
     now = require_aware_utc(routed_at, field_name="routed_at")
-    routes = tuple(_route_candidate(candidate, targets, now=now) for candidate in candidates)
+    usage_by_target = dict(target_usage or {})
+    routes: list[SearchAcquisitionRoute] = []
+    for candidate in candidates:
+        route = _route_candidate(candidate, targets, usage_by_target, now=now)
+        routes.append(route)
+        target_id = route.public_web_target_id
+        if target_id is not None:
+            current = usage_by_target.get(target_id, CrawlUsage())
+            usage_by_target[target_id] = CrawlUsage(
+                pages_fetched=current.pages_fetched + 1,
+                bytes_fetched=current.bytes_fetched,
+            )
     return tuple(sorted(routes, key=_route_sort_key))
 
 
 def _route_candidate(
     candidate: SearchDiscoveryCandidate,
     targets: tuple[PublicWebTarget, ...],
+    usage_by_target: Mapping[str, CrawlUsage],
     *,
     now: datetime,
 ) -> SearchAcquisitionRoute:
@@ -72,7 +86,7 @@ def _route_candidate(
             candidate.target_url,
             depth=0,
             redirects=0,
-            usage=CrawlUsage(),
+            usage=usage_by_target.get(target.id, CrawlUsage()),
         ).allowed
     )
     if len(matching) > 1:
@@ -100,7 +114,7 @@ def _route_candidate(
         requested_url=review_candidate.target_url,
         public_web_target_id=None,
         reason=(
-            "candidate URL is not inside an executable governed public-web target; "
+            "candidate URL is not admissible to an executable governed public-web target; "
             "provider/source review is required before retrieval"
         ),
     )

--- a/src/cip/modules/public_footprint/domain/search.py
+++ b/src/cip/modules/public_footprint/domain/search.py
@@ -43,13 +43,32 @@ class SearchQueryTemplate:
         purpose = _required_text(self.purpose, field_name="purpose", max_length=200)
         if self.version < 1:
             raise ValueError("search query template version must be positive")
-        if pattern.count("{organization}") != 1:
-            raise ValueError("search query pattern requires one {organization} placeholder")
+        organization_placeholders = pattern.count("{organization}")
+        domain_placeholders = pattern.count("{domain}")
+        if organization_placeholders + domain_placeholders != 1:
+            raise ValueError(
+                "search query pattern requires exactly one {organization} or {domain} placeholder"
+            )
+        remainder = pattern.replace("{organization}", "").replace("{domain}", "")
+        if "{" in remainder or "}" in remainder:
+            raise ValueError("search query pattern contains an unsupported placeholder")
         object.__setattr__(self, "id", identifier)
         object.__setattr__(self, "query_pattern", pattern)
         object.__setattr__(self, "purpose", purpose)
 
-    def render(self, organization_name: str) -> str:
+    @property
+    def requires_domain(self) -> bool:
+        return "{domain}" in self.query_pattern
+
+    def render(
+        self,
+        organization_name: str,
+        *,
+        organization_domain: str | None = None,
+    ) -> str:
+        if self.requires_domain:
+            domain = _required_domain(organization_domain)
+            return self.query_pattern.replace("{domain}", domain)
         name = _required_text(
             organization_name,
             field_name="organization_name",
@@ -187,6 +206,21 @@ def _metadata_material(lead: SearchResultLead) -> bytes:
         separators=(",", ":"),
         sort_keys=True,
     ).encode()
+
+
+def _required_domain(value: str | None) -> str:
+    if value is None:
+        raise ValueError("organization_domain is required for domain-scoped search templates")
+    domain = _required_text(value, field_name="organization_domain", max_length=253).rstrip(".")
+    if "://" in domain or "/" in domain or any(character.isspace() for character in domain):
+        raise ValueError("organization_domain must be a bare public hostname")
+    try:
+        canonical = CanonicalUrl(f"https://{domain}")
+    except ValueError as exc:
+        raise ValueError("organization_domain must be a bare public hostname") from exc
+    if not canonical.host or "." not in canonical.host:
+        raise ValueError("organization_domain must be a bare public hostname")
+    return canonical.host
 
 
 def _required_text(value: str, *, field_name: str, max_length: int) -> str:

--- a/src/cip/modules/public_footprint/domain/search_core.py
+++ b/src/cip/modules/public_footprint/domain/search_core.py
@@ -64,6 +64,7 @@ class SearchQueryPlan:
         template: SearchQueryTemplate,
         provider_ids: tuple[str, ...],
         created_at: datetime,
+        organization_domain: str | None = None,
     ) -> SearchQueryPlan:
         if not template.enabled:
             raise ValueError("search query template must be enabled before execution")
@@ -73,7 +74,10 @@ class SearchQueryPlan:
             template_id=template.id,
             template_version=template.version,
             purpose=template.purpose,
-            rendered_query=template.render(organization_name),
+            rendered_query=template.render(
+                organization_name,
+                organization_domain=organization_domain,
+            ),
             provider_ids=provider_ids,
             created_at=created_at,
         )
@@ -131,6 +135,7 @@ class SearchProviderHit:
     source_record_key: str
     rank: int
     observed_at: datetime
+    executed_at: datetime
     title: str
     snippet: str
     rendered_query: str
@@ -165,6 +170,7 @@ class SearchProviderHit:
         if self.query_template_version < 1:
             raise ValueError("search query template version must be positive")
         observed_at = require_aware_utc(self.observed_at, field_name="observed_at")
+        executed_at = require_aware_utc(self.executed_at, field_name="executed_at")
         object.__setattr__(self, "provider_id", provider_id)
         object.__setattr__(self, "source_record_key", record_key)
         object.__setattr__(self, "title", title)
@@ -172,6 +178,7 @@ class SearchProviderHit:
         object.__setattr__(self, "rendered_query", rendered_query)
         object.__setattr__(self, "query_template_id", template_id)
         object.__setattr__(self, "observed_at", observed_at)
+        object.__setattr__(self, "executed_at", executed_at)
 
 
 @dataclass(frozen=True, slots=True)
@@ -254,6 +261,7 @@ def _provider_hit(
         source_record_key=result.source_record_key,
         rank=result.rank,
         observed_at=result.observed_at,
+        executed_at=execution.executed_at,
         title=result.title,
         snippet=result.snippet,
         rendered_query=execution.rendered_query,

--- a/src/cip/modules/public_footprint/infrastructure/manual_search.py
+++ b/src/cip/modules/public_footprint/infrastructure/manual_search.py
@@ -10,7 +10,12 @@ _GOOGLE_SEARCH_URL = "https://www.google.com/search"
 def build_google_analyst_search_url(
     template: SearchQueryTemplate,
     organization: str,
+    *,
+    organization_domain: str | None = None,
 ) -> str:
     """Build an analyst-opened Google search URL without performing network I/O."""
-    query = template.render(organization)
+    query = template.render(
+        organization,
+        organization_domain=organization_domain,
+    )
     return f"{_GOOGLE_SEARCH_URL}?{urlencode({'q': query})}"

--- a/tests/test_search_query_registry.py
+++ b/tests/test_search_query_registry.py
@@ -17,9 +17,17 @@ def test_repository_search_query_templates_are_versioned_and_disabled() -> None:
     assert all(not template.enabled for template in templates)
     assert len({(template.id, template.version) for template in templates}) == len(templates)
     for template in templates:
-        rendered = template.render("Example Corp")
-        assert "{organization}" not in rendered
-        assert "Example Corp" in rendered
+        if template.requires_domain:
+            rendered = template.render(
+                "Example Corp",
+                organization_domain="example.com",
+            )
+            assert "{domain}" not in rendered
+            assert "example.com" in rendered
+        else:
+            rendered = template.render("Example Corp")
+            assert "{organization}" not in rendered
+            assert "Example Corp" in rendered
 
 
 def test_search_query_registry_rejects_duplicate_versions(tmp_path: Path) -> None:

--- a/tests/test_search_serp_core.py
+++ b/tests/test_search_serp_core.py
@@ -40,6 +40,36 @@ def test_query_plan_requires_an_enabled_template_and_unique_providers() -> None:
         )
 
 
+def test_domain_scoped_query_plan_requires_and_uses_a_bare_domain() -> None:
+    template = SearchQueryTemplate(
+        id="site-security",
+        version=1,
+        query_pattern="site:{domain} security",
+        purpose="corporate-public-footprint-domain",
+        enabled=True,
+    )
+
+    with pytest.raises(ValueError, match="organization_domain"):
+        SearchQueryPlan.from_template(
+            organization_id=ORGANIZATION_ID,
+            organization_name="Example Corp",
+            template=template,
+            provider_ids=("brave-web-search",),
+            created_at=NOW,
+        )
+
+    plan = SearchQueryPlan.from_template(
+        organization_id=ORGANIZATION_ID,
+        organization_name="Example Corp",
+        organization_domain="Example.COM.",
+        template=template,
+        provider_ids=("brave-web-search",),
+        created_at=NOW,
+    )
+
+    assert plan.rendered_query == "site:example.com security"
+
+
 def test_normalization_deduplicates_canonical_url_and_preserves_each_provider_hit() -> None:
     plan = _plan()
     brave = SearchProviderExecution(
@@ -59,13 +89,14 @@ def test_normalization_deduplicates_canonical_url_and_preserves_each_provider_hi
             ),
         ),
     )
+    mojeek_executed_at = NOW + timedelta(seconds=1)
     mojeek = SearchProviderExecution(
         provider_id="mojeek-web-search-metadata",
         organization_id=ORGANIZATION_ID,
         rendered_query=plan.rendered_query,
         query_template_id=plan.template_id,
         query_template_version=plan.template_version,
-        executed_at=NOW + timedelta(seconds=1),
+        executed_at=mojeek_executed_at,
         results=(
             _lead(
                 provider="mojeek-web-search-metadata",
@@ -100,6 +131,12 @@ def test_normalization_deduplicates_canonical_url_and_preserves_each_provider_hi
         "brave-1",
         "mojeek-7",
     }
+    execution_times = {hit.provider_id: hit.executed_at for hit in shared.provider_hits}
+    assert execution_times == {
+        "brave-web-search": NOW,
+        "mojeek-web-search-metadata": mojeek_executed_at,
+    }
+    assert all(hit.observed_at == NOW for hit in shared.provider_hits)
     assert shared.acquisition_state is SearchAcquisitionState.UNROUTED
     assert candidates[1].target_url == "https://example.com/architecture"
 

--- a/tests/unit/adapters/test_gdelt_contract_gate.py
+++ b/tests/unit/adapters/test_gdelt_contract_gate.py
@@ -29,7 +29,23 @@ def test_checked_in_gdelt_contract_is_fail_closed() -> None:
         contract.require_adapter_contract()
 
 
-def test_stable_contract_requires_endpoint_version_and_schema(tmp_path: Path) -> None:
+def test_contract_requires_exact_gdelt5_generation(tmp_path: Path) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        _stable_contract_yaml(
+            api_base_url="https://api.gdeltproject.org/future-api",
+            product_generation="GDELT 4",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="exactly GDELT 5"):
+        load_gdelt_api_contract(policy)
+
+
+def test_stable_contract_requires_endpoint_version_schema_and_storage_terms(
+    tmp_path: Path,
+) -> None:
     policy = tmp_path / "gdelt.yml"
     policy.write_text(
         """version: 1
@@ -51,10 +67,26 @@ contract:
         load_gdelt_api_contract(policy)
 
 
+def test_stable_contract_rejects_blank_api_version(tmp_path: Path) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        _stable_contract_yaml(
+            api_base_url="https://api.gdeltproject.org/future-api",
+            api_version="   ",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="requires API base URL"):
+        load_gdelt_api_contract(policy)
+
+
 @pytest.mark.parametrize(
     "legacy_url",
     (
+        "https://api.gdeltproject.org/api/v1",
         "https://api.gdeltproject.org/api/v1/search",
+        "https://api.gdeltproject.org/api/v2",
         "https://api.gdeltproject.org/api/v2/doc/doc",
     ),
 )
@@ -91,6 +123,20 @@ def test_future_stable_contract_rejects_non_gdelt_lookalikes(
         load_gdelt_api_contract(policy)
 
 
+def test_stable_contract_rejects_untrusted_storage_terms_reference(tmp_path: Path) -> None:
+    policy = tmp_path / "gdelt.yml"
+    policy.write_text(
+        _stable_contract_yaml(
+            api_base_url="https://api.gdeltproject.org/future-api",
+            storage_terms_reference="https://example.com/terms",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="official HTTPS GDELT host"):
+        load_gdelt_api_contract(policy)
+
+
 def test_complete_official_future_contract_opens_only_the_contract_gate(tmp_path: Path) -> None:
     policy = tmp_path / "gdelt.yml"
     policy.write_text(
@@ -105,16 +151,22 @@ def test_complete_official_future_contract_opens_only_the_contract_gate(tmp_path
     contract.require_adapter_contract()
 
 
-def _stable_contract_yaml(*, api_base_url: str) -> str:
+def _stable_contract_yaml(
+    *,
+    api_base_url: str,
+    product_generation: str = "GDELT 5",
+    api_version: str = "future-contract-version",
+    storage_terms_reference: str = "https://gdeltproject.org/future-storage-terms",
+) -> str:
     return f"""version: 1
 contract:
-  product_generation: GDELT 5
+  product_generation: {product_generation}
   status: stable_public_contract
   reviewed_at: 2026-08-12
   official_references:
     - https://blog.gdeltproject.org/2026/06/
   api_base_url: {api_base_url}
-  api_version: future-contract-version
+  api_version: "{api_version}"
   schema_reference: https://gdeltproject.org/future-schema
-  storage_terms_reference: https://gdeltproject.org/future-storage-terms
+  storage_terms_reference: {storage_terms_reference}
 """

--- a/tests/unit/adapters/test_marginalia_search.py
+++ b/tests/unit/adapters/test_marginalia_search.py
@@ -33,16 +33,30 @@ def test_marginalia_entitlement_accepts_only_current_api_host() -> None:
     with pytest.raises(ValueError, match="not approved"):
         MarginaliaSearchEntitlement(api_host="api.marginalia.nu")
 
-    entitlement = MarginaliaSearchEntitlement(
-        api_host=MARGINALIA_API_HOST,
-        commercial_use_rights=True,
-        api_key_secret_ref="secret://marginalia/commercial",
-    )
+    entitlement = _ready_entitlement()
     entitlement.assert_live_collection_ready()
 
 
+def test_marginalia_client_checks_entitlement_before_network() -> None:
+    network_called = False
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal network_called
+        network_called = True
+        raise AssertionError("network must not be reached without commercial entitlement")
+
+    client = MarginaliaSearchClient(
+        MarginaliaSearchEntitlement(api_key_secret_ref="secret://marginalia"),
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(PermissionError, match="commercial-use rights"):
+        client.search(query="example", api_key="commercial-test-key")
+    assert network_called is False
+
+
 def test_marginalia_client_rejects_shared_public_development_key() -> None:
-    client = MarginaliaSearchClient()
+    client = MarginaliaSearchClient(_ready_entitlement())
 
     with pytest.raises(PermissionError, match="public development key"):
         client.search(query="cyber security", api_key="public")
@@ -74,7 +88,10 @@ def test_marginalia_client_uses_current_api2_contract() -> None:
             content=json.dumps(body).encode(),
         )
 
-    client = MarginaliaSearchClient(transport=httpx.MockTransport(handler))
+    client = MarginaliaSearchClient(
+        _ready_entitlement(),
+        transport=httpx.MockTransport(handler),
+    )
     result = client.search(
         query="example cybersecurity",
         api_key="commercial-test-key",
@@ -85,9 +102,29 @@ def test_marginalia_client_uses_current_api2_contract() -> None:
     assert result.request_url.startswith("https://api2.marginalia-search.com/search?")
 
 
+def test_marginalia_client_rejects_oversized_response_while_streaming() -> None:
+    oversized = b"x" * (2 * 1024 * 1024 + 1)
+    client = MarginaliaSearchClient(
+        _ready_entitlement(),
+        transport=httpx.MockTransport(
+            lambda _: httpx.Response(
+                200,
+                headers={"content-type": "application/json"},
+                content=oversized,
+            )
+        ),
+    )
+
+    with pytest.raises(MarginaliaSearchClientError) as error:
+        client.search(query="example", api_key="commercial-test-key")
+    assert error.value.code == "unsafe_source_response"
+    assert error.value.retryable is False
+
+
 def test_marginalia_client_classifies_http_and_schema_failures() -> None:
     throttled = MarginaliaSearchClient(
-        transport=httpx.MockTransport(lambda _: httpx.Response(429))
+        _ready_entitlement(),
+        transport=httpx.MockTransport(lambda _: httpx.Response(429)),
     )
     with pytest.raises(MarginaliaSearchClientError) as http_error:
         throttled.search(query="example", api_key="commercial-test-key")
@@ -95,15 +132,24 @@ def test_marginalia_client_classifies_http_and_schema_failures() -> None:
     assert http_error.value.retryable is True
 
     drifted = MarginaliaSearchClient(
+        _ready_entitlement(),
         transport=httpx.MockTransport(
             lambda _: httpx.Response(
                 200,
                 headers={"content-type": "application/json"},
                 content=b'{"unexpected": true}',
             )
-        )
+        ),
     )
     with pytest.raises(MarginaliaSearchClientError) as schema_error:
         drifted.search(query="example", api_key="commercial-test-key")
     assert schema_error.value.code == "source_schema_drift"
     assert schema_error.value.retryable is False
+
+
+def _ready_entitlement() -> MarginaliaSearchEntitlement:
+    return MarginaliaSearchEntitlement(
+        api_host=MARGINALIA_API_HOST,
+        commercial_use_rights=True,
+        api_key_secret_ref="secret://marginalia/commercial",
+    )

--- a/tests/unit/collection_orchestration/test_common_crawl_adapter.py
+++ b/tests/unit/collection_orchestration/test_common_crawl_adapter.py
@@ -24,7 +24,7 @@ ORG_ID = UUID("86fe6126-5731-5c4d-a206-69a6a736cae5")
 POLICY_PATH = Path("policies/sources.search_archives.yml")
 
 
-def test_common_crawl_uses_latest_collection_and_maps_only_in_scope() -> None:
+def test_common_crawl_uses_latest_collection_maps_and_routes_in_scope() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -59,6 +59,19 @@ def test_common_crawl_uses_latest_collection_and_maps_only_in_scope() -> None:
     assert batch.checkpoint_payload == {
         "pair_index": 0,
         "crawl_ids": {"common-crawl-live:/public": "CC-MAIN-2026-30"},
+        "normalized_discovery": {
+            "provider_id": "common-crawl-index",
+            "candidate_count": 1,
+            "public_web_route_count": 1,
+            "source_review_route_count": 0,
+            "routes": [
+                {
+                    "target_url": "https://example.com/public/report",
+                    "route_kind": "public_web",
+                    "public_web_target_id": "common-crawl-live",
+                }
+            ],
+        },
     }
 
 

--- a/tests/unit/collection_orchestration/test_patentsview_patent_adapter.py
+++ b/tests/unit/collection_orchestration/test_patentsview_patent_adapter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from json import loads
 from pathlib import Path
@@ -16,6 +17,10 @@ from cip.modules.collection_orchestration.application.patentsview_patent_adapter
     PatentsViewPatentAdapter,
 )
 from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    SourceStatus,
+)
 from cip.modules.source_governance.infrastructure.registry import (
     SourceRegistryEntry,
     load_source_registry,
@@ -54,12 +59,39 @@ def test_patentsview_without_enabled_target_performs_no_network_or_secret_read()
     assert secret_reads == []
 
 
-def test_patentsview_requires_connected_api_key_before_network() -> None:
+def test_checked_in_patentsview_policy_denies_before_secret_or_network() -> None:
+    secret_reads: list[int] = []
+    network_reads: list[int] = []
+
+    def token_provider() -> str | None:
+        secret_reads.append(1)
+        return "future-odp-key-must-not-reach-legacy-route"
+
+    def fail_network(_request: httpx.Request) -> httpx.Response:
+        network_reads.append(1)
+        raise AssertionError("revoked legacy route must not reach network")
+
+    adapter = PatentsViewPatentAdapter(
+        _entry(),
+        (_target(),),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(fail_network),
+    )
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+
+    assert exc_info.value.error_code == "source_policy_denied"
+    assert exc_info.value.retryable is False
+    assert secret_reads == []
+    assert network_reads == []
+
+
+def test_historical_adapter_requires_connected_api_key_before_network() -> None:
     def fail_network(_request: httpx.Request) -> httpx.Response:
         raise AssertionError("network must not be used without provider key")
 
     adapter = PatentsViewPatentAdapter(
-        _entry(),
+        _authorized_historical_test_entry(),
         (_target(),),
         token_provider=lambda: None,
         transport=httpx.MockTransport(fail_network),
@@ -70,7 +102,7 @@ def test_patentsview_requires_connected_api_key_before_network() -> None:
     assert exc_info.value.retryable is False
 
 
-def test_patentsview_maps_only_exact_assignee_minimal_metadata() -> None:
+def test_historical_adapter_maps_only_exact_assignee_minimal_metadata() -> None:
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -98,9 +130,9 @@ def test_patentsview_maps_only_exact_assignee_minimal_metadata() -> None:
         )
 
     adapter = PatentsViewPatentAdapter(
-        _entry(),
+        _authorized_historical_test_entry(),
         (_target(),),
-        token_provider=lambda: "live-key",
+        token_provider=lambda: "historical-contract-test-key",
         transport=httpx.MockTransport(handler),
     )
     batch = _collect(adapter)
@@ -108,7 +140,7 @@ def test_patentsview_maps_only_exact_assignee_minimal_metadata() -> None:
     assert len(requests) == 1
     request = requests[0]
     assert request.url.path == "/api/v1/patent/"
-    assert request.headers["X-Api-Key"] == "live-key"
+    assert request.headers["X-Api-Key"] == "historical-contract-test-key"
     assert loads(request.url.params["q"]) == {
         "_eq": {"assignees.assignee_organization": "Example Corporation"}
     }
@@ -130,7 +162,7 @@ def test_patentsview_maps_only_exact_assignee_minimal_metadata() -> None:
     assert batch.checkpoint_payload == {"target_index": 0}
 
 
-def test_patentsview_rejects_invalid_checkpoint() -> None:
+def test_patentsview_rejects_invalid_checkpoint_before_policy_evaluation() -> None:
     adapter = PatentsViewPatentAdapter(
         _entry(),
         (_target(),),
@@ -142,7 +174,7 @@ def test_patentsview_rejects_invalid_checkpoint() -> None:
     assert exc_info.value.error_code == "invalid_checkpoint"
 
 
-def test_patentsview_classifies_schema_rate_limit_and_error_envelope() -> None:
+def test_historical_adapter_classifies_schema_rate_limit_and_error_envelope() -> None:
     def malformed(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
@@ -152,9 +184,9 @@ def test_patentsview_classifies_schema_rate_limit_and_error_envelope() -> None:
         )
 
     malformed_adapter = PatentsViewPatentAdapter(
-        _entry(),
+        _authorized_historical_test_entry(),
         (_target(),),
-        token_provider=lambda: "key",
+        token_provider=lambda: "historical-test-key",
         transport=httpx.MockTransport(malformed),
     )
     with pytest.raises(AdapterExecutionError) as schema_info:
@@ -169,9 +201,9 @@ def test_patentsview_classifies_schema_rate_limit_and_error_envelope() -> None:
         )
 
     rate_adapter = PatentsViewPatentAdapter(
-        _entry(),
+        _authorized_historical_test_entry(),
         (_target(),),
-        token_provider=lambda: "key",
+        token_provider=lambda: "historical-test-key",
         transport=httpx.MockTransport(rate_limited),
     )
     with pytest.raises(AdapterExecutionError) as rate_info:
@@ -188,9 +220,9 @@ def test_patentsview_classifies_schema_rate_limit_and_error_envelope() -> None:
         )
 
     error_adapter = PatentsViewPatentAdapter(
-        _entry(),
+        _authorized_historical_test_entry(),
         (_target(),),
-        token_provider=lambda: "key",
+        token_provider=lambda: "historical-test-key",
         transport=httpx.MockTransport(provider_error),
     )
     with pytest.raises(AdapterExecutionError) as envelope_info:
@@ -203,6 +235,26 @@ def _entry() -> SourceRegistryEntry:
         entry
         for entry in load_source_registry(POLICY_PATH)
         if entry.policy.id == "patentsview-patent-metadata"
+    )
+
+
+def _authorized_historical_test_entry() -> SourceRegistryEntry:
+    """Exercise retained adapter behavior without changing checked-in production governance."""
+    entry = _entry()
+    return SourceRegistryEntry(
+        policy=replace(entry.policy, status=SourceStatus.ENABLED),
+        authorization=replace(
+            entry.authorization,
+            status=AuthorizationStatus.APPROVED,
+            document_reference="test-only-historical-patentsview-contract",
+            reviewed_at=NOW,
+            approved_hosts=frozenset({"search.patentsview.org"}),
+            approved_path_prefixes=("/api/v1/patent/",),
+            approved_purposes=frozenset({"patent-discovery"}),
+            automated_collection_allowed=True,
+        ),
+        economics=entry.economics,
+        notes=entry.notes,
     )
 
 

--- a/tests/unit/collection_orchestration/test_search_acquisition_router.py
+++ b/tests/unit/collection_orchestration/test_search_acquisition_router.py
@@ -10,6 +10,7 @@ from cip.modules.collection_orchestration.application.search_acquisition_router 
     SearchAcquisitionRouteKind,
     route_search_discovery_candidates,
 )
+from cip.modules.public_footprint.domain.scope import CrawlUsage
 from cip.modules.public_footprint.domain.search_core import (
     SearchAcquisitionState,
     SearchDiscoveryCandidate,
@@ -99,6 +100,26 @@ def test_automatic_routes_sort_before_source_review_routes() -> None:
     ]
 
 
+def test_router_consumes_page_budget_across_candidates_and_existing_usage() -> None:
+    target = _target(max_pages=2)
+    routes = route_search_discovery_candidates(
+        (
+            _candidate("https://example.com/security/one"),
+            _candidate("https://example.com/security/two"),
+        ),
+        (target,),
+        routed_at=NOW,
+        target_usage={target.id: CrawlUsage(pages_fetched=1)},
+    )
+
+    assert [route.route_kind for route in routes] == [
+        SearchAcquisitionRouteKind.PUBLIC_WEB,
+        SearchAcquisitionRouteKind.SOURCE_REVIEW,
+    ]
+    assert routes[0].requested_url == "https://example.com/security/one"
+    assert routes[1].requested_url == "https://example.com/security/two"
+
+
 def _candidate(url: str) -> SearchDiscoveryCandidate:
     return SearchDiscoveryCandidate(
         organization_id=ORGANIZATION_ID,
@@ -112,6 +133,7 @@ def _candidate(url: str) -> SearchDiscoveryCandidate:
                 source_record_key=f"record:{url}",
                 rank=1,
                 observed_at=NOW,
+                executed_at=NOW,
                 title="Search discovery",
                 snippet="Provider metadata only",
                 rendered_query='"Example Corp" cybersecurity',
@@ -127,6 +149,7 @@ def _target(
     target_id: str = "example-company",
     allowed_path_prefixes: tuple[str, ...] = ("/",),
     authorization_expires_at: datetime | None = None,
+    max_pages: int = 100,
 ) -> PublicWebTarget:
     return PublicWebTarget(
         id=target_id,
@@ -139,4 +162,5 @@ def _target(
         authorization_reference="sa15-router-test",
         authorization_reviewed_at=NOW - timedelta(days=1),
         authorization_expires_at=authorization_expires_at,
+        max_pages=max_pages,
     )

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -14,7 +14,54 @@ def test_patentsview_has_no_checked_in_production_target() -> None:
     assert "targets: []" in policy
 
 
-def test_manual_live_workflow_references_only_production_runners_and_secret_names() -> None:
+def test_brave_and_mojeek_live_runners_have_valid_controlled_discovery_seed() -> None:
+    for script_name in (
+        "scripts/live_validate_sa15_brave.py",
+        "scripts/live_validate_sa15_mojeek.py",
+    ):
+        with open(script_name, encoding="utf-8") as script_file:
+            script = script_file.read()
+        assert "seed_urls=(base_url,)" in script
+        assert "discover_security_txt=False" in script
+
+
+def test_patentsview_legacy_live_runner_fails_before_reading_any_credential() -> None:
+    with open("scripts/live_validate_sa15_patentsview.py", encoding="utf-8") as script_file:
+        script = script_file.read()
+
+    assert "PatentsViewCurrentContractUnavailable" in script
+    assert "USPTO Open Data Portal" in script
+    assert "PATENTSVIEW_API_KEY" not in script
+    assert "PatentsViewPatentAdapter" not in script
+
+
+def test_patentsview_legacy_governance_and_activation_are_revoked() -> None:
+    with open("policies/sources.search_archives.yml", encoding="utf-8") as policy_file:
+        source_policy = policy_file.read()
+    with open(
+        "policies/source_activation.search_archives_sa14.yml",
+        encoding="utf-8",
+    ) as activation_file:
+        activation = activation_file.read()
+
+    patentsview_policy = source_policy.split("  - id: patentsview-patent-metadata", 1)[1].split(
+        "  - id: w3c-affiliation-specification-metadata", 1
+    )[0]
+    assert "status: paused" in patentsview_policy
+    assert "status: revoked" in patentsview_policy
+    assert "approved_hosts: []" in patentsview_policy
+    assert "automated_collection_allowed: false" in patentsview_policy
+
+    patentsview_activation = activation.split(
+        "  - source_id: patentsview-patent-metadata", 1
+    )[1].split("  - source_id: w3c-affiliation-specification-metadata", 1)[0]
+    assert "disposition: blocked" in patentsview_activation
+    assert "- authorized" not in patentsview_activation
+    assert "- executable" not in patentsview_activation
+    assert "- live_tested" not in patentsview_activation
+
+
+def test_manual_live_workflow_exposes_only_current_credentialed_provider_runners() -> None:
     with open(
         ".github/workflows/sa15-provider-live-validation.yml", encoding="utf-8"
     ) as workflow_file:
@@ -23,13 +70,13 @@ def test_manual_live_workflow_references_only_production_runners_and_secret_name
     for script_name in (
         "live_validate_sa15_brave.py",
         "live_validate_sa15_mojeek.py",
-        "live_validate_sa15_patentsview.py",
     ):
         assert f"python scripts/{script_name}" in workflow
     for secret_name in (
         "BRAVE_SEARCH_API_TOKEN",
         "MOJEEK_API_KEY",
-        "PATENTSVIEW_API_KEY",
     ):
         assert f"secrets.{secret_name}" in workflow
+    assert "live_validate_sa15_patentsview.py" not in workflow
+    assert "PATENTSVIEW_API_KEY" not in workflow
     assert "live_tested" not in workflow

--- a/tests/unit/source_activation/test_sa15_search_query_library.py
+++ b/tests/unit/source_activation/test_sa15_search_query_library.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 from cip.modules.public_footprint.infrastructure.manual_search import (
     build_google_analyst_search_url,
 )
@@ -48,17 +50,29 @@ def test_sa15_dork_library_covers_every_required_family() -> None:
         assert term in combined
 
 
-def test_sa15_dork_library_is_versioned_and_disabled_by_default() -> None:
+def test_sa15_dork_library_is_versioned_disabled_and_uses_correct_placeholders() -> None:
     templates = load_search_query_templates(REGISTRY_PATH)
 
     for template in templates:
         assert template.version == 2
         assert template.purpose.startswith("corporate-public-footprint")
         assert template.enabled is False
-        assert template.query_pattern.count("{organization}") == 1
-        rendered = template.render("Example Corp")
-        assert "{organization}" not in rendered
-        assert "Example Corp" in rendered
+        if template.id == "q-site-company-research":
+            assert template.query_pattern.count("{domain}") == 1
+            assert "{organization}" not in template.query_pattern
+            with pytest.raises(ValueError, match="organization_domain"):
+                template.render("Example Corp")
+            rendered = template.render(
+                "Example Corp",
+                organization_domain="example.com",
+            )
+            assert rendered.startswith("site:example.com ")
+        else:
+            assert template.query_pattern.count("{organization}") == 1
+            assert "{domain}" not in template.query_pattern
+            rendered = template.render("Example Corp")
+            assert "{organization}" not in rendered
+            assert "Example Corp" in rendered
 
 
 def test_sa15_google_route_builds_manual_link_without_network_io() -> None:
@@ -74,3 +88,18 @@ def test_sa15_google_route_builds_manual_link_without_network_io() -> None:
     query = parse_qs(parsed.query)["q"][0]
     assert "Example Corp" in query
     assert "filetype:pdf" in query
+
+
+def test_sa15_google_site_route_uses_domain_not_display_name() -> None:
+    templates = load_search_query_templates(REGISTRY_PATH)
+    template = next(item for item in templates if item.id == "q-site-company-research")
+
+    url = build_google_analyst_search_url(
+        template,
+        "Example Corp",
+        organization_domain="example.com",
+    )
+    query = parse_qs(urlparse(url).query)["q"][0]
+
+    assert query.startswith("site:example.com ")
+    assert "site:Example Corp" not in query


### PR DESCRIPTION
## Scope

Internal-completion pass for the remaining SA15 defects that do not require external provider credentials/contracts.

Implemented so far:
- L01 preserves provider execution timestamps in normalized SERP provenance;
- L07 `site:` templates use a canonical domain rather than an organization display name;
- L09 enforces cumulative per-target page admission across routed candidates;
- L02/L04 Brave and Mojeek controlled live runners now construct valid governed targets;
- L06 Marginalia requires commercial entitlement before network I/O and bounds response reading while streaming;
- L03/C2 legacy PatentsView PatentSearch authorization is paused/revoked, removed from the credentialed live workflow, and its runner fails before reading any credential;
- L08 GDELT5 gate now requires the exact product generation, nonblank contract version, official storage-terms reference, and rejects legacy API roots with or without trailing slashes;
- C1 Common Crawl normalization + governed routing now executes inside the production adapter path and is recorded in the durable checkpoint;
- C1 live validation now validates that production-integrated path rather than manually composing the bridge/router.

Truth boundary:
- Internet Archive CDX remains the already proven L05 live source; this PR does not alter its activation.
- Common Crawl already has real provider live proof; this PR must re-prove the corrected production-integrated normalized path on the exact final SHA.
- Brave, Mojeek, Marginalia and current PatentsView remain NOT live-tested until their legitimate external prerequisites exist and real provider runs succeed.
- GDELT5 remains blocked on a stable official current contract.
- Google remains `awaiting_eligible_route` and NOT live-tested.

This PR remains draft until exact-final-head normal CI, the real Common Crawl SA15 live job, and review-thread cleanup all pass.