### PR TITLE
SA15 L06: make Marginalia runtime-ready and fail-closed

### DIFF
--- a/.github/workflows/sa15-provider-live-validation.yml
+++ b/.github/workflows/sa15-provider-live-validation.yml
@@ -10,6 +10,7 @@ on:
         options:
           - brave
           - mojeek
+          - marginalia
       organization_name:
         description: Controlled organization name used by search validation
         required: true
@@ -35,6 +36,7 @@ jobs:
     env:
       BRAVE_SEARCH_API_TOKEN: ${{ secrets.BRAVE_SEARCH_API_TOKEN }}
       MOJEEK_API_KEY: ${{ secrets.MOJEEK_API_KEY }}
+      MARGINALIA_API_KEY: ${{ secrets.MARGINALIA_API_KEY }}
       SA15_SEARCH_ORGANIZATION: ${{ inputs.organization_name }}
       SA15_SEARCH_ORGANIZATION_URL: ${{ inputs.organization_url }}
     steps:
@@ -60,6 +62,9 @@ jobs:
               ;;
             mojeek)
               python scripts/live_validate_sa15_mojeek.py
+              ;;
+            marginalia)
+              python scripts/live_validate_sa15_marginalia.py
               ;;
             *)
               echo "Unsupported SA-15 provider" >&2

--- a/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
+++ b/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
@@ -2,24 +2,39 @@
 
 ## L06 — Marginalia Search API2
 
-The current independent-search implementation remains **not live tested** and not production-authorized. The production client targets `https://api2.marginalia-search.com/search`; the shared `public` development key is rejected.
+The independent-search capability remains **not live tested** and **not production-authorized**.
 
-The SA15 internal-completion pass closes two post-merge defects:
+The production provider surface is the current API2 endpoint `https://api2.marginalia-search.com/search`; the shared `public` development key is rejected. Search-result payloads are discovery metadata only and remain quarantined; third-party page bodies are not fetched by the search adapter.
 
-- `MarginaliaSearchEntitlement.assert_live_collection_ready()` is now evaluated before query/key processing and before any network I/O, so a non-public development/test key cannot bypass commercial-use authorization;
-- response bodies are read through a bounded streaming path and collection stops once the 2 MiB response limit would be exceeded, instead of downloading an oversized response first.
+### Internal runtime readiness
 
-Deterministic tests prove that missing commercial entitlement prevents the HTTP transport from being reached.
+The SA15 runtime-readiness pass closes the remaining internal implementation gap rather than promoting the provider:
 
-Current proven state remains:
+- `MarginaliaSearchAdapter` now exists in `collection_orchestration` and maps bounded safe API2 results into immutable `RawObservation` records plus quarantined `SEARCH_RESULT` projections with zero claims;
+- Source Governance is evaluated before commercial entitlement, secret resolution and network I/O;
+- `MarginaliaSearchEntitlement` is loaded from a versioned checked-in policy and requires current API2 host, commercial-use rights, entitlement evidence and an API-key secret reference before live collection can proceed;
+- the checked-in entitlement remains `commercial_use_rights: false`, `plan: unprovisioned`, with no evidence and no secret reference;
+- the SA15 search-provider governance registry is now loaded by the collection runtime, and the Marginalia adapter is registered with the worker composition;
+- the runtime secret supplier uses Provider Onboarding and returns no secret when Marginalia is not connected;
+- a controlled `scripts/live_validate_sa15_marginalia.py` runner and manual workflow option are present for the future legitimate provider run;
+- the controlled runner defers environment-secret resolution to the adapter, so the current `draft` / `authorization: missing` governance state denies execution before `MARGINALIA_API_KEY` is read;
+- response bodies remain bounded while streaming at 2 MiB, and commercial entitlement is checked before any client network I/O.
+
+Deterministic tests use a test-only in-memory authorization to exercise result mapping. They separately prove that the real checked-in governance state denies before secret/network. Test authorization is not production authorization.
+
+### Current activation truth
+
+The checked-in source remains:
 
 `catalogued -> reviewed -> mapped -> adapter_present`
 
-Remaining external prerequisites are a legitimate commercial API key, commercial-use entitlement evidence, Provider Onboarding secret reference, exact deployment authorization, controlled real-endpoint validation, and exact-SHA CI/live proof. No `live_tested` promotion is made by this pass.
+Source Governance remains `status: draft` with authorization `missing`, no approved hosts/paths/purposes and `automated_collection_allowed: false`. Source Activation remains `blocked`. No schedule or `live_tested` stage is added by this pass.
+
+Remaining **external** prerequisites are a legitimate commercial API key, reviewed commercial-use/storage entitlement evidence, Provider Onboarding secret reference, explicit approved API2 host/path/purpose and deployment authorization. Only after those are present may the controlled production runner call the real provider; a non-empty provider result plus complete exact-SHA CI/live proof is still required before `live_tested` promotion.
 
 ## L07 — governed dork/query library
 
-The version-2 library retains the required SA15 query families and operators. The internal-completion pass fixes the `site:` contract: domain-scoped templates now use `{domain}` rather than interpolating the organization display name into `site:`.
+The version-2 library retains the required SA15 query families and operators. The internal-completion pass fixed the `site:` contract: domain-scoped templates use `{domain}` rather than interpolating the organization display name into `site:`.
 
 `SearchQueryTemplate` supports exactly one of `{organization}` or `{domain}`. Domain templates require a bare canonical hostname; schemes, paths and whitespace are rejected. `SearchQueryPlan.from_template()` and the analyst Google URL renderer accept the explicit domain separately from the display name.
 
@@ -27,5 +42,6 @@ All checked-in templates remain disabled by default. The analyst Google URL rend
 
 ## Completion truth
 
-- **L07 internal implementation:** complete subject to exact-final-head CI for this pass.
-- **L06 internal fail-closed implementation:** complete subject to exact-final-head CI, but provider activation remains externally blocked and not `live_tested`.
+- **L07 internal implementation:** complete; the corrected implementation already passed the exact-final-head CI of the SA15 internal-completion merge.
+- **L06 internal runtime implementation:** implemented and intentionally fail-closed; it must pass exact-final-head CI for this runtime-readiness PR before merge.
+- **L06 provider activation/live proof:** still externally blocked and not `live_tested`.

--- a/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
+++ b/docs/source_activation/SA_15_L06_L07_SEARCH_DIVERSITY.md
@@ -10,11 +10,14 @@ The production provider surface is the current API2 endpoint `https://api2.margi
 
 The SA15 runtime-readiness pass closes the remaining internal implementation gap rather than promoting the provider:
 
-- `MarginaliaSearchAdapter` now exists in `collection_orchestration` and maps bounded safe API2 results into immutable `RawObservation` records plus quarantined `SEARCH_RESULT` projections with zero claims;
+- `MarginaliaSearchAdapter` now exists in `collection_orchestration` with adapter identity `marginalia-web-search`, matching the existing SA15 source-portfolio capability manifest;
+- the adapter maps bounded safe API2 results into immutable `RawObservation` records plus quarantined `SEARCH_RESULT` projections with zero claims;
 - Source Governance is evaluated before commercial entitlement, secret resolution and network I/O;
 - `MarginaliaSearchEntitlement` is loaded from a versioned checked-in policy and requires current API2 host, commercial-use rights, entitlement evidence and an API-key secret reference before live collection can proceed;
 - the checked-in entitlement remains `commercial_use_rights: false`, `plan: unprovisioned`, with no evidence and no secret reference;
-- the SA15 search-provider governance registry is now loaded by the collection runtime, and the Marginalia adapter is registered with the worker composition;
+- both the SA15 search-provider governance registry and SA15 search-provider portfolio are loaded by the collection runtime;
+- the Marginalia portfolio entry remains `candidate` with `executable: false`; loading its capability manifest does not promote execution eligibility;
+- the Marginalia adapter is registered with the worker composition, while Source Governance remains authoritative and denies the checked-in source before entitlement/secret/network;
 - the runtime secret supplier uses Provider Onboarding and returns no secret when Marginalia is not connected;
 - a controlled `scripts/live_validate_sa15_marginalia.py` runner and manual workflow option are present for the future legitimate provider run;
 - the controlled runner defers environment-secret resolution to the adapter, so the current `draft` / `authorization: missing` governance state denies execution before `MARGINALIA_API_KEY` is read;
@@ -24,11 +27,11 @@ Deterministic tests use a test-only in-memory authorization to exercise result m
 
 ### Current activation truth
 
-The checked-in source remains:
+The checked-in Source Activation stages remain:
 
 `catalogued -> reviewed -> mapped -> adapter_present`
 
-Source Governance remains `status: draft` with authorization `missing`, no approved hosts/paths/purposes and `automated_collection_allowed: false`. Source Activation remains `blocked`. No schedule or `live_tested` stage is added by this pass.
+Source Governance remains `status: draft` with authorization `missing`, no approved hosts/paths/purposes and `automated_collection_allowed: false`. Source Portfolio remains `candidate` / `executable: false`. Source Activation remains `blocked`. No schedule or `live_tested` stage is added by this pass.
 
 Remaining **external** prerequisites are a legitimate commercial API key, reviewed commercial-use/storage entitlement evidence, Provider Onboarding secret reference, explicit approved API2 host/path/purpose and deployment authorization. Only after those are present may the controlled production runner call the real provider; a non-empty provider result plus complete exact-SHA CI/live proof is still required before `live_tested` promotion.
 
@@ -43,5 +46,5 @@ All checked-in templates remain disabled by default. The analyst Google URL rend
 ## Completion truth
 
 - **L07 internal implementation:** complete; the corrected implementation already passed the exact-final-head CI of the SA15 internal-completion merge.
-- **L06 internal runtime implementation:** implemented and intentionally fail-closed; it must pass exact-final-head CI for this runtime-readiness PR before merge.
+- **L06 internal runtime implementation:** implemented and intentionally fail-closed; merge gate is complete exact-final-head CI for this PR.
 - **L06 provider activation/live proof:** still externally blocked and not `live_tested`.

--- a/policies/marginalia_search_entitlement.yml
+++ b/policies/marginalia_search_entitlement.yml
@@ -1,9 +1,7 @@
 version: 1
 entitlement:
-  commercial_use_authorized: false
+  api_host: api2.marginalia-search.com
+  commercial_use_rights: false
   plan: unprovisioned
-  api_key_secret_ref: null
   evidence_reference: null
-  prerequisite_owner: source-activation
-  target_microlot: SA15-L06
-  acceptance_test: controlled production-adapter search with a legitimate commercial API key
+  api_key_secret_ref: null

--- a/scripts/live_validate_sa15_marginalia.py
+++ b/scripts/live_validate_sa15_marginalia.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.marginalia_search.registry import (
+    load_marginalia_search_entitlement,
+)
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.marginalia_search_adapter import (
+    MarginaliaSearchAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterCollectionBatch
+from cip.modules.public_footprint.domain.models import PublicResourceKind, ResourceRetrievalState
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.infrastructure.registry import load_source_registry
+
+_POLICY_PATH = Path("policies/sources.search_providers_sa15.yml")
+_ENTITLEMENT_PATH = Path("policies/marginalia_search_entitlement.yml")
+_ORG_ID = UUID("314457e3-e3d9-5c9a-b112-c5747b14f216")
+_MAX_RESULTS = 20
+
+
+def main() -> None:
+    entitlement = load_marginalia_search_entitlement(_ENTITLEMENT_PATH)
+    target = _controlled_target()
+    template = SearchQueryTemplate(
+        id="sa15-controlled-independent-search",
+        version=1,
+        query_pattern="{organization} cybersecurity",
+        purpose="corporate-public-footprint",
+        enabled=True,
+    )
+    entry = next(
+        item
+        for item in load_source_registry(_POLICY_PATH)
+        if item.policy.id == "marginalia-web-search-metadata"
+    )
+    now = datetime.now(UTC)
+    batch = MarginaliaSearchAdapter(
+        entry,
+        (target,),
+        (template,),
+        entitlement,
+        token_provider=lambda: _required_env("MARGINALIA_API_KEY"),
+        timeout_seconds=60,
+    ).collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=None,
+        collected_at=now,
+        retention_until=now + timedelta(days=90),
+    )
+    _validate_batch(batch)
+    print(
+        "SA-15 L06 live validation passed: "
+        f"organization={target.canonical_name!r} "
+        f"marginalia_observations={len(batch.observations)} "
+        f"marginalia_projections={len(batch.public_footprint_projections)} claims=0 bodies=0"
+    )
+
+
+def _controlled_target() -> PublicWebTarget:
+    name = os.environ.get("SA15_SEARCH_ORGANIZATION", "Internet Archive").strip()
+    base_url = os.environ.get("SA15_SEARCH_ORGANIZATION_URL", "https://archive.org/").strip()
+    if not name or not base_url:
+        raise RuntimeError("controlled search organization name and URL are required")
+    now = datetime.now(UTC)
+    return PublicWebTarget(
+        id="sa15-controlled-marginalia-search-organization",
+        organization_id=_ORG_ID,
+        canonical_name=name,
+        base_url=base_url,
+        sitemap_urls=(),
+        feed_urls=(),
+        seed_urls=(base_url,),
+        discover_security_txt=False,
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="sa15-controlled-public-search-validation",
+        authorization_reviewed_at=now,
+        terms_url=base_url,
+        max_pages=_MAX_RESULTS,
+        max_total_bytes=2_000_000,
+        max_resource_bytes=1_000_000,
+        max_redirects=0,
+    )
+
+
+def _validate_batch(batch: AdapterCollectionBatch) -> None:
+    observations = batch.observations
+    projections = batch.public_footprint_projections
+    if not 1 <= len(observations) <= _MAX_RESULTS or len(projections) != len(observations):
+        raise RuntimeError("Marginalia live validation returned invalid result counts")
+    if any(
+        observation.source_id != "marginalia-web-search-metadata"
+        for observation in observations
+    ):
+        raise RuntimeError("Marginalia live validation lost source provenance")
+    if any(projection.claims for projection in projections):
+        raise RuntimeError("Marginalia search metadata unexpectedly produced claims")
+    if any(
+        projection.resource.kind is not PublicResourceKind.SEARCH_RESULT
+        or projection.resource.retrieval_state is not ResourceRetrievalState.QUARANTINED
+        for projection in projections
+    ):
+        raise RuntimeError("Marginalia search results escaped discovery quarantine")
+    if batch.checkpoint_payload != {"pair_index": 0}:
+        raise RuntimeError("Marginalia live validation checkpoint did not converge")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required for controlled live validation")
+    return value
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/marginalia_search/__init__.py
+++ b/src/cip/adapters/sources/marginalia_search/__init__.py
@@ -1,4 +1,11 @@
 from cip.adapters.sources.marginalia_search.client import MarginaliaSearchClient
-from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
+from cip.adapters.sources.marginalia_search.registry import (
+    MarginaliaSearchEntitlement,
+    load_marginalia_search_entitlement,
+)
 
-__all__ = ["MarginaliaSearchClient", "MarginaliaSearchEntitlement"]
+__all__ = [
+    "MarginaliaSearchClient",
+    "MarginaliaSearchEntitlement",
+    "load_marginalia_search_entitlement",
+]

--- a/src/cip/adapters/sources/marginalia_search/registry.py
+++ b/src/cip/adapters/sources/marginalia_search/registry.py
@@ -1,8 +1,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
 
 MARGINALIA_API_HOST = "api2.marginalia-search.com"
+
+
+class _MarginaliaEntitlementModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    api_host: str = Field(default=MARGINALIA_API_HOST, min_length=1, max_length=253)
+    commercial_use_rights: bool = False
+    plan: str = Field(default="unprovisioned", min_length=1, max_length=100)
+    evidence_reference: str | None = Field(default=None, max_length=1_000)
+    api_key_secret_ref: str | None = Field(default=None, max_length=1_000)
+
+
+class _MarginaliaRegistryModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: int = Field(ge=1)
+    entitlement: _MarginaliaEntitlementModel
 
 
 @dataclass(frozen=True, slots=True)
@@ -10,6 +31,8 @@ class MarginaliaSearchEntitlement:
     api_host: str = MARGINALIA_API_HOST
     commercial_use_rights: bool = False
     api_key_secret_ref: str | None = None
+    plan: str = "unprovisioned"
+    evidence_reference: str | None = None
 
     def __post_init__(self) -> None:
         host = self.api_host.strip().casefold()
@@ -17,18 +40,53 @@ class MarginaliaSearchEntitlement:
             raise ValueError("Marginalia API host is not approved")
         object.__setattr__(self, "api_host", host)
 
-        if self.api_key_secret_ref is not None:
-            secret_ref = self.api_key_secret_ref.strip()
-            if not secret_ref:
-                raise ValueError("api_key_secret_ref must be non-empty when provided")
-            object.__setattr__(self, "api_key_secret_ref", secret_ref)
+        plan = self.plan.strip()
+        if not plan:
+            raise ValueError("Marginalia plan is required")
+        object.__setattr__(self, "plan", plan)
+
+        secret_ref = _normalize_optional(self.api_key_secret_ref)
+        evidence_reference = _normalize_optional(self.evidence_reference)
+        object.__setattr__(self, "api_key_secret_ref", secret_ref)
+        object.__setattr__(self, "evidence_reference", evidence_reference)
+
+        if self.commercial_use_rights and evidence_reference is None:
+            raise ValueError(
+                "Marginalia commercial-use rights require an evidence reference"
+            )
 
     def assert_live_collection_ready(self) -> None:
         if not self.commercial_use_rights:
             raise PermissionError(
                 "Marginalia production collection requires commercial-use rights"
             )
+        if self.evidence_reference is None:
+            raise PermissionError(
+                "Marginalia production collection requires entitlement evidence"
+            )
         if self.api_key_secret_ref is None:
             raise PermissionError(
                 "Marginalia production collection requires an API-key secret ref"
             )
+
+
+def load_marginalia_search_entitlement(path: Path) -> MarginaliaSearchEntitlement:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    parsed = _MarginaliaRegistryModel.model_validate(payload)
+    item = parsed.entitlement
+    return MarginaliaSearchEntitlement(
+        api_host=item.api_host,
+        commercial_use_rights=item.commercial_use_rights,
+        api_key_secret_ref=item.api_key_secret_ref,
+        plan=item.plan,
+        evidence_reference=item.evidence_reference,
+    )
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("optional Marginalia references must be non-empty when provided")
+    return normalized

--- a/src/cip/modules/collection_orchestration/application/adapter_composition.py
+++ b/src/cip/modules/collection_orchestration/application/adapter_composition.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from cip.adapters.sources.ashby.registry import AshbyBoard
 from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
@@ -9,6 +9,7 @@ from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystem
 from cip.adapters.sources.greenhouse.registry import GreenhouseBoard
 from cip.adapters.sources.incident_catalogs.sec_registry import SecIncidentTarget
 from cip.adapters.sources.lever.registry import LeverSite
+from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
 from cip.adapters.sources.mojeek_search.registry import MojeekSearchEntitlement
 from cip.adapters.sources.organization_identity.registry import OrganizationIdentityTarget
 from cip.adapters.sources.passive_infrastructure.rdap_registry import RdapTarget
@@ -86,6 +87,9 @@ class AdapterCompositionInputs:
     passive_infrastructure_targets: tuple[PassiveInfrastructureTarget, ...]
     rdap_targets: tuple[RdapTarget, ...]
     sec_incident_targets: tuple[SecIncidentTarget, ...]
+    marginalia_entitlement: MarginaliaSearchEntitlement = field(
+        default_factory=MarginaliaSearchEntitlement
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,6 +156,7 @@ def build_runtime_adapters(
             patentsview_patent_targets=inputs.patentsview_patent_targets,
             w3c_affiliation_targets=inputs.w3c_affiliation_targets,
             mojeek_entitlement=inputs.mojeek_entitlement,
+            marginalia_entitlement=inputs.marginalia_entitlement,
         ),
         secrets.search_archives,
         timeout_seconds=timeout_seconds,

--- a/src/cip/modules/collection_orchestration/application/marginalia_search_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/marginalia_search_adapter.py
@@ -37,7 +37,7 @@ _MAX_RESULTS = 20
 
 class MarginaliaSearchAdapter:
     source_id = "marginalia-web-search-metadata"
-    adapter_id = "marginalia-search-api2"
+    adapter_id = "marginalia-web-search"
     adapter_version = "1"
     data_category = DataCategory.PUBLIC_RESULT_METADATA
 

--- a/src/cip/modules/collection_orchestration/application/marginalia_search_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/marginalia_search_adapter.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from hashlib import sha256
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import httpx
+
+from cip.adapters.sources.marginalia_search.client import (
+    MarginaliaSearchClient,
+    MarginaliaSearchClientError,
+)
+from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
+from cip.adapters.sources.marginalia_search.schemas import MarginaliaSearchResult
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.ports import (
+    AdapterCollectionBatch,
+    AdapterExecutionError,
+)
+from cip.modules.public_footprint.domain.search import (
+    SearchQueryTemplate,
+    SearchResultLead,
+    map_search_result_lead,
+)
+from cip.modules.raw_observations.domain.entities import RawObservation
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_MAX_RESULTS = 20
+
+
+class MarginaliaSearchAdapter:
+    source_id = "marginalia-web-search-metadata"
+    adapter_id = "marginalia-search-api2"
+    adapter_version = "1"
+    data_category = DataCategory.PUBLIC_RESULT_METADATA
+
+    def __init__(
+        self,
+        entry: SourceRegistryEntry,
+        targets: tuple[PublicWebTarget, ...],
+        templates: tuple[SearchQueryTemplate, ...],
+        entitlement: MarginaliaSearchEntitlement,
+        *,
+        token_provider: Callable[[], str | None],
+        timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        if entry.policy.id != self.source_id:
+            raise ValueError("Marginalia adapter requires marginalia-web-search-metadata policy")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._entry = entry
+        self._pairs = tuple(
+            (target, template)
+            for target in targets
+            if target.enabled
+            for template in templates
+            if template.enabled
+        )
+        self._entitlement = entitlement
+        self._token_provider = token_provider
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    def collect(
+        self,
+        *,
+        collection_job_id: UUID,
+        checkpoint_payload: Mapping[str, object] | None,
+        collected_at: datetime,
+        retention_until: datetime,
+    ) -> AdapterCollectionBatch:
+        pair, next_index = _next_pair(self._pairs, checkpoint_payload)
+        if pair is None:
+            return _empty_batch()
+        target, template = pair
+        query = template.render(target.canonical_name)
+        target_url = self._entry.policy.base_url
+        _authorize(self._entry, target_url, template.purpose, collected_at)
+        try:
+            self._entitlement.assert_live_collection_ready()
+        except PermissionError as exc:
+            raise AdapterExecutionError(
+                str(exc),
+                error_code="provider_commercial_entitlement_missing",
+                retryable=False,
+            ) from exc
+        api_key = self._token_provider()
+        if api_key is None or not api_key.strip():
+            raise AdapterExecutionError(
+                "Marginalia provider secret is unavailable",
+                error_code="provider_not_connected",
+                retryable=False,
+            )
+        try:
+            result = MarginaliaSearchClient(
+                self._entitlement,
+                timeout_seconds=self._timeout_seconds,
+                transport=self._transport,
+            ).search(query=query, api_key=api_key.strip())
+        except MarginaliaSearchClientError as exc:
+            raise AdapterExecutionError(
+                str(exc),
+                error_code=exc.code,
+                retryable=exc.retryable,
+            ) from exc
+        except PermissionError as exc:
+            raise AdapterExecutionError(
+                str(exc),
+                error_code="provider_credential_rejected",
+                retryable=False,
+            ) from exc
+
+        results = tuple(
+            item for item in result.response.results[:_MAX_RESULTS] if _safe_result(item)
+        )
+        observations = tuple(
+            _observation(
+                item,
+                target=target,
+                template=template,
+                collection_job_id=collection_job_id,
+                collected_at=collected_at,
+                retention_until=retention_until,
+                source_url=target_url,
+            )
+            for item in results
+        )
+        projections = tuple(
+            map_search_result_lead(
+                SearchResultLead(
+                    organization_id=target.organization_id,
+                    source_id=self.source_id,
+                    source_record_key=_record_key(query, item.url),
+                    target_url=item.url,
+                    title=item.title,
+                    snippet=item.description[:1_000],
+                    rank=rank,
+                    observed_at=collected_at,
+                    query_template_id=template.id,
+                    query_template_version=template.version,
+                )
+            )
+            for rank, item in enumerate(results, start=1)
+        )
+        return AdapterCollectionBatch(
+            observations=observations,
+            public_footprint_projections=projections,
+            checkpoint_payload={"pair_index": next_index},
+            not_modified=not results,
+        )
+
+
+def _authorize(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    purpose: str,
+    now: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.PUBLIC_RESULT_METADATA,
+            target_url=target_url,
+            purpose=purpose,
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=True,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise AdapterExecutionError(
+            decision.reason.value,
+            error_code="source_policy_denied",
+            retryable=False,
+        )
+
+
+def _safe_result(result: MarginaliaSearchResult) -> bool:
+    parsed = urlsplit(result.url)
+    return parsed.scheme in {"http", "https"} and parsed.hostname is not None
+
+
+def _observation(
+    result: MarginaliaSearchResult,
+    *,
+    target: PublicWebTarget,
+    template: SearchQueryTemplate,
+    collection_job_id: UUID,
+    collected_at: datetime,
+    retention_until: datetime,
+    source_url: str,
+) -> RawObservation:
+    payload = result.model_dump_json(exclude_none=True).encode("utf-8")
+    query = template.render(target.canonical_name)
+    return RawObservation(
+        source_id=MarginaliaSearchAdapter.source_id,
+        adapter_id=MarginaliaSearchAdapter.adapter_id,
+        adapter_version=MarginaliaSearchAdapter.adapter_version,
+        collection_job_id=collection_job_id,
+        source_record_type="marginalia-search-result",
+        source_url=source_url,
+        payload_hash_sha256=sha256(payload).hexdigest(),
+        data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+        source_record_key=_record_key(query, result.url),
+        collected_at=collected_at,
+        retention_until=retention_until,
+        schema_fingerprint="marginalia-search:v1",
+    )
+
+
+def _record_key(query: str, result_url: str) -> str:
+    return sha256(f"{query}\0{result_url}".encode()).hexdigest()
+
+
+def _next_pair(
+    pairs: tuple[tuple[PublicWebTarget, SearchQueryTemplate], ...],
+    payload: Mapping[str, object] | None,
+) -> tuple[tuple[PublicWebTarget, SearchQueryTemplate] | None, int]:
+    if not pairs:
+        return None, 0
+    value = 0 if payload is None else payload.get("pair_index", 0)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise AdapterExecutionError(
+            "invalid Marginalia Search checkpoint",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
+    index = value % len(pairs)
+    return pairs[index], 0 if index + 1 >= len(pairs) else index + 1
+
+
+def _empty_batch() -> AdapterCollectionBatch:
+    return AdapterCollectionBatch(
+        observations=(),
+        public_footprint_projections=(),
+        checkpoint_payload={"pair_index": 0},
+        not_modified=True,
+    )

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -158,6 +158,7 @@ def _load_portfolio(settings: Settings) -> tuple[SourceCatalogEntry, ...]:
         settings.public_web_source_portfolio_path,
         settings.vulnerability_source_portfolio_path,
         settings.search_archive_source_portfolio_path,
+        settings.search_provider_source_portfolio_path,
         settings.incident_source_portfolio_path,
         settings.threat_telemetry_source_portfolio_path,
         settings.passive_exposure_source_portfolio_path,

--- a/src/cip/modules/collection_orchestration/application/runtime.py
+++ b/src/cip/modules/collection_orchestration/application/runtime.py
@@ -21,6 +21,9 @@ from cip.adapters.sources.github_code_search.registry import (
 from cip.adapters.sources.greenhouse.registry import load_greenhouse_boards
 from cip.adapters.sources.incident_catalogs.sec_registry import load_sec_incident_targets
 from cip.adapters.sources.lever.registry import load_lever_sites
+from cip.adapters.sources.marginalia_search.registry import (
+    load_marginalia_search_entitlement,
+)
 from cip.adapters.sources.mojeek_search.registry import load_mojeek_search_entitlement
 from cip.adapters.sources.organization_identity.registry import load_organization_identity_targets
 from cip.adapters.sources.passive_infrastructure.rdap_registry import load_rdap_targets
@@ -133,6 +136,7 @@ def _load_source_entries(settings: Settings) -> tuple[SourceRegistryEntry, ...]:
         settings.public_web_source_registry_path,
         settings.vulnerability_source_registry_path,
         settings.search_archive_source_registry_path,
+        settings.search_provider_source_registry_path,
         settings.incident_source_registry_path,
         settings.threat_telemetry_source_registry_path,
         settings.passive_exposure_source_registry_path,
@@ -206,6 +210,9 @@ def _load_adapter_inputs(
         ),
         mojeek_entitlement=load_mojeek_search_entitlement(
             settings.mojeek_search_entitlement_registry_path
+        ),
+        marginalia_entitlement=load_marginalia_search_entitlement(
+            settings.marginalia_search_entitlement_registry_path
         ),
         vulnerability_targets=load_vulnerability_query_targets(
             settings.vulnerability_query_target_registry_path

--- a/src/cip/modules/collection_orchestration/application/runtime_secret_providers.py
+++ b/src/cip/modules/collection_orchestration/application/runtime_secret_providers.py
@@ -38,6 +38,11 @@ def build_runtime_secret_providers(
                 source_id="mojeek-web-search-metadata",
                 secret_name="api_key",
             ),
+            marginalia_api_key_provider=connected_secret_supplier(
+                factory,
+                source_id="marginalia-web-search-metadata",
+                secret_name="api_key",
+            ),
         ),
         certspotter_token_provider=connected_secret_supplier(
             factory,

--- a/src/cip/modules/collection_orchestration/application/search_archive_registration.py
+++ b/src/cip/modules/collection_orchestration/application/search_archive_registration.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from cip.adapters.sources.crossref_publications.registry import CrossrefPublicationTarget
 from cip.adapters.sources.developer_ecosystem.registry import DeveloperEcosystemTarget
+from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
 from cip.adapters.sources.mojeek_search.registry import MojeekSearchEntitlement
 from cip.adapters.sources.patentsview_patents.registry import PatentsViewPatentTarget
 from cip.adapters.sources.public_web.registry import PublicWebTarget
@@ -24,6 +25,9 @@ from cip.modules.collection_orchestration.application.crossref_publication_adapt
 from cip.modules.collection_orchestration.application.github_code_search_adapter import (
     GitHubCodeSearchAdapter,
 )
+from cip.modules.collection_orchestration.application.marginalia_search_adapter import (
+    MarginaliaSearchAdapter,
+)
 from cip.modules.collection_orchestration.application.mojeek_search_adapter import (
     MojeekSearchAdapter,
 )
@@ -36,6 +40,10 @@ from cip.modules.public_footprint.domain.search import SearchQueryTemplate
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
 
+def _missing_secret() -> None:
+    return None
+
+
 @dataclass(frozen=True, slots=True)
 class SearchArchiveRegistrationInputs:
     public_web_targets: tuple[PublicWebTarget, ...]
@@ -46,6 +54,9 @@ class SearchArchiveRegistrationInputs:
     patentsview_patent_targets: tuple[PatentsViewPatentTarget, ...]
     w3c_affiliation_targets: tuple[W3cAffiliationTarget, ...]
     mojeek_entitlement: MojeekSearchEntitlement
+    marginalia_entitlement: MarginaliaSearchEntitlement = field(
+        default_factory=MarginaliaSearchEntitlement
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +65,7 @@ class SearchArchiveSecretProviders:
     github_code_search_token_provider: Callable[[], str | None]
     patentsview_api_key_provider: Callable[[], str | None]
     mojeek_api_key_provider: Callable[[], str | None]
+    marginalia_api_key_provider: Callable[[], str | None] = _missing_secret
 
 
 def register_search_archive_adapters(
@@ -87,6 +99,20 @@ def register_search_archive_adapters(
                 inputs.search_templates,
                 inputs.mojeek_entitlement,
                 token_provider=secrets.mojeek_api_key_provider,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+
+    marginalia_entry = entries_by_id.get(MarginaliaSearchAdapter.source_id)
+    if marginalia_entry is not None:
+        _register(
+            adapters,
+            MarginaliaSearchAdapter(
+                marginalia_entry,
+                inputs.public_web_targets,
+                inputs.search_templates,
+                inputs.marginalia_entitlement,
+                token_provider=secrets.marginalia_api_key_provider,
                 timeout_seconds=timeout_seconds,
             ),
         )

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -76,6 +76,9 @@ class Settings(BaseSettings):
     search_archive_source_portfolio_path: Path = Path(
         "policies/source_portfolio.search_archives.yml"
     )
+    search_provider_source_portfolio_path: Path = Path(
+        "policies/source_portfolio.search_providers_sa15.yml"
+    )
     incident_source_portfolio_path: Path = Path(
         "policies/source_portfolio.incidents.yml"
     )

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
     search_archive_source_registry_path: Path = Path(
         "policies/sources.search_archives.yml"
     )
+    search_provider_source_registry_path: Path = Path(
+        "policies/sources.search_providers_sa15.yml"
+    )
     incident_source_registry_path: Path = Path("policies/sources.incidents.yml")
     threat_telemetry_source_registry_path: Path = Path(
         "policies/sources.threat_telemetry.yml"
@@ -132,6 +135,9 @@ class Settings(BaseSettings):
     mojeek_search_entitlement_registry_path: Path = Path(
         "policies/mojeek_search_entitlement.yml"
     )
+    marginalia_search_entitlement_registry_path: Path = Path(
+        "policies/marginalia_search_entitlement.yml"
+    )
     vulnerability_query_target_registry_path: Path = Path(
         "policies/vulnerability_query_targets.yml"
     )
@@ -178,10 +184,9 @@ class Settings(BaseSettings):
     worker_poll_seconds: float = Field(default=2.0, gt=0, le=300)
     source_http_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
     api_host: str = "127.0.0.1"
-    api_port: int = Field(default=8000, ge=1, le=65_535)
-    api_reload: bool = False
+    api_port: int = Field(default=8000, ge=1, le=65535)
 
 
-@lru_cache(maxsize=1)
+@lru_cache
 def get_settings() -> Settings:
     return Settings()

--- a/src/cip/shared/config/settings.py
+++ b/src/cip/shared/config/settings.py
@@ -184,9 +184,10 @@ class Settings(BaseSettings):
     worker_poll_seconds: float = Field(default=2.0, gt=0, le=300)
     source_http_timeout_seconds: float = Field(default=30.0, gt=0, le=120)
     api_host: str = "127.0.0.1"
-    api_port: int = Field(default=8000, ge=1, le=65535)
+    api_port: int = Field(default=8000, ge=1, le=65_535)
+    api_reload: bool = False
 
 
-@lru_cache
+@lru_cache(maxsize=1)
 def get_settings() -> Settings:
     return Settings()

--- a/tests/unit/adapters/test_marginalia_search.py
+++ b/tests/unit/adapters/test_marginalia_search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import httpx
 import pytest
@@ -12,7 +13,20 @@ from cip.adapters.sources.marginalia_search.client import (
 from cip.adapters.sources.marginalia_search.registry import (
     MARGINALIA_API_HOST,
     MarginaliaSearchEntitlement,
+    load_marginalia_search_entitlement,
 )
+
+ENTITLEMENT_PATH = Path("policies/marginalia_search_entitlement.yml")
+
+
+def test_checked_in_marginalia_entitlement_is_fail_closed() -> None:
+    entitlement = load_marginalia_search_entitlement(ENTITLEMENT_PATH)
+
+    assert entitlement.api_host == MARGINALIA_API_HOST
+    assert entitlement.commercial_use_rights is False
+    assert entitlement.plan == "unprovisioned"
+    assert entitlement.evidence_reference is None
+    assert entitlement.api_key_secret_ref is None
 
 
 def test_marginalia_entitlement_fails_closed_without_commercial_rights() -> None:
@@ -22,8 +36,21 @@ def test_marginalia_entitlement_fails_closed_without_commercial_rights() -> None
         entitlement.assert_live_collection_ready()
 
 
+def test_marginalia_entitlement_requires_evidence_for_commercial_rights() -> None:
+    with pytest.raises(ValueError, match="evidence reference"):
+        MarginaliaSearchEntitlement(
+            commercial_use_rights=True,
+            api_key_secret_ref="secret://marginalia",
+            plan="commercial",
+        )
+
+
 def test_marginalia_entitlement_requires_secret_ref() -> None:
-    entitlement = MarginaliaSearchEntitlement(commercial_use_rights=True)
+    entitlement = MarginaliaSearchEntitlement(
+        commercial_use_rights=True,
+        plan="commercial",
+        evidence_reference="controlled-test-entitlement",
+    )
 
     with pytest.raises(PermissionError, match="API-key secret ref"):
         entitlement.assert_live_collection_ready()
@@ -152,4 +179,6 @@ def _ready_entitlement() -> MarginaliaSearchEntitlement:
         api_host=MARGINALIA_API_HOST,
         commercial_use_rights=True,
         api_key_secret_ref="secret://marginalia/commercial",
+        plan="commercial",
+        evidence_reference="controlled-test-entitlement",
     )

--- a/tests/unit/collection_orchestration/test_marginalia_search_adapter.py
+++ b/tests/unit/collection_orchestration/test_marginalia_search_adapter.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from cip.adapters.sources.marginalia_search.registry import MarginaliaSearchEntitlement
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.marginalia_search_adapter import (
+    MarginaliaSearchAdapter,
+)
+from cip.modules.collection_orchestration.application.ports import AdapterExecutionError
+from cip.modules.public_footprint.domain.search import SearchQueryTemplate
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    DataCategory,
+    SourceAuthorization,
+    SourcePolicy,
+    SourceStatus,
+    SourceType,
+)
+from cip.modules.source_governance.infrastructure.registry import (
+    SourceRegistryEntry,
+    load_source_registry,
+)
+
+NOW = datetime(2026, 8, 12, 17, 50, tzinfo=UTC)
+RETENTION = NOW + timedelta(days=90)
+ORG_ID = UUID("b05a6206-c42d-55b7-bcb9-727b0203bc50")
+POLICY_PATH = Path("policies/sources.search_providers_sa15.yml")
+
+
+def test_checked_in_marginalia_policy_denies_before_secret_and_network() -> None:
+    token_calls = 0
+
+    def token_provider() -> str:
+        nonlocal token_calls
+        token_calls += 1
+        return "commercial-test-key"
+
+    adapter = MarginaliaSearchAdapter(
+        _checked_in_entry(),
+        (_target(),),
+        (_template(),),
+        _ready_entitlement(),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(
+            lambda _: (_ for _ in ()).throw(
+                AssertionError("network must not run while source governance is missing")
+            )
+        ),
+    )
+
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "source_policy_denied"
+    assert exc_info.value.retryable is False
+    assert token_calls == 0
+
+
+def test_marginalia_disabled_target_uses_no_entitlement_secret_or_network() -> None:
+    token_calls = 0
+
+    def token_provider() -> str:
+        nonlocal token_calls
+        token_calls += 1
+        return "commercial-test-key"
+
+    batch = _collect(
+        MarginaliaSearchAdapter(
+            _authorized_entry(),
+            (_target(enabled=False),),
+            (_template(),),
+            MarginaliaSearchEntitlement(),
+            token_provider=token_provider,
+            transport=httpx.MockTransport(
+                lambda _: (_ for _ in ()).throw(
+                    AssertionError("network must not run without enabled target")
+                )
+            ),
+        )
+    )
+    assert batch.not_modified is True
+    assert batch.observations == ()
+    assert token_calls == 0
+
+
+def test_marginalia_missing_entitlement_stops_before_secret_and_network() -> None:
+    token_calls = 0
+
+    def token_provider() -> str:
+        nonlocal token_calls
+        token_calls += 1
+        return "commercial-test-key"
+
+    adapter = MarginaliaSearchAdapter(
+        _authorized_entry(),
+        (_target(),),
+        (_template(),),
+        MarginaliaSearchEntitlement(api_key_secret_ref="secret://marginalia"),
+        token_provider=token_provider,
+        transport=httpx.MockTransport(
+            lambda _: (_ for _ in ()).throw(
+                AssertionError("network must not run without commercial entitlement")
+            )
+        ),
+    )
+
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "provider_commercial_entitlement_missing"
+    assert exc_info.value.retryable is False
+    assert token_calls == 0
+
+
+def test_marginalia_missing_runtime_secret_stops_before_network() -> None:
+    adapter = MarginaliaSearchAdapter(
+        _authorized_entry(),
+        (_target(),),
+        (_template(),),
+        _ready_entitlement(),
+        token_provider=lambda: None,
+        transport=httpx.MockTransport(
+            lambda _: (_ for _ in ()).throw(
+                AssertionError("network must not run without runtime provider secret")
+            )
+        ),
+    )
+
+    with pytest.raises(AdapterExecutionError) as exc_info:
+        _collect(adapter)
+    assert exc_info.value.error_code == "provider_not_connected"
+    assert exc_info.value.retryable is False
+
+
+def test_marginalia_maps_bounded_safe_result_metadata_only() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={
+                "query": "Example Corp cybersecurity",
+                "license": "commercial",
+                "results": [
+                    {
+                        "url": "https://example.com/security",
+                        "title": "Example security",
+                        "description": "Public search snippet",
+                    },
+                    {
+                        "url": "javascript:alert(1)",
+                        "title": "Unsafe",
+                        "description": "discard me",
+                    },
+                ],
+            },
+            request=request,
+        )
+
+    batch = _collect(
+        MarginaliaSearchAdapter(
+            _authorized_entry(),
+            (_target(),),
+            (_template(),),
+            _ready_entitlement(),
+            token_provider=lambda: "commercial-test-key",
+            transport=httpx.MockTransport(handler),
+        )
+    )
+
+    assert len(requests) == 1
+    request = requests[0]
+    assert request.url.host == "api2.marginalia-search.com"
+    assert request.url.path == "/search"
+    assert request.headers["API-Key"] == "commercial-test-key"
+    assert request.url.params["query"] == "Example Corp cybersecurity"
+    assert len(batch.observations) == 1
+    assert len(batch.public_footprint_projections) == 1
+    observation = batch.observations[0]
+    projection = batch.public_footprint_projections[0]
+    assert observation.source_id == "marginalia-web-search-metadata"
+    assert "commercial-test-key" not in observation.source_url
+    assert projection.claims == ()
+    assert projection.resource.canonical_url == "https://example.com/security"
+    assert projection.resource.retrieval_state.value == "quarantined"
+    assert projection.version.excerpt == "Public search snippet"
+    assert batch.checkpoint_payload == {"pair_index": 0}
+
+
+def test_marginalia_invalid_checkpoint_and_429_fail_closed() -> None:
+    adapter = MarginaliaSearchAdapter(
+        _authorized_entry(),
+        (_target(),),
+        (_template(),),
+        _ready_entitlement(),
+        token_provider=lambda: "commercial-test-key",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, request=request)),
+    )
+    with pytest.raises(AdapterExecutionError) as checkpoint_info:
+        _collect(adapter, checkpoint_payload={"pair_index": True})
+    assert checkpoint_info.value.error_code == "invalid_checkpoint"
+
+    rate_limited = MarginaliaSearchAdapter(
+        _authorized_entry(),
+        (_target(),),
+        (_template(),),
+        _ready_entitlement(),
+        token_provider=lambda: "commercial-test-key",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(429, request=request)
+        ),
+    )
+    with pytest.raises(AdapterExecutionError) as rate_info:
+        _collect(rate_limited)
+    assert rate_info.value.error_code == "http_429"
+    assert rate_info.value.retryable is True
+
+
+def _checked_in_entry() -> SourceRegistryEntry:
+    return next(
+        entry
+        for entry in load_source_registry(POLICY_PATH)
+        if entry.policy.id == "marginalia-web-search-metadata"
+    )
+
+
+def _authorized_entry() -> SourceRegistryEntry:
+    return SourceRegistryEntry(
+        policy=SourcePolicy(
+            id="marginalia-web-search-metadata",
+            name="Marginalia Search API metadata",
+            base_url="https://api2.marginalia-search.com/search",
+            status=SourceStatus.ENABLED,
+            source_type=SourceType.SEARCH_PROVIDER,
+            owner="Marginalia Search",
+            terms_url="https://about.marginalia-search.com/article/api/",
+            licence="controlled test-only commercial authorization",
+            allowed_data_categories=frozenset({DataCategory.PUBLIC_RESULT_METADATA}),
+            retention_days=90,
+            raw_content_storage=False,
+            human_review_required=False,
+        ),
+        authorization=SourceAuthorization(
+            status=AuthorizationStatus.APPROVED,
+            document_reference="controlled-test-only-authorization",
+            reviewed_at=NOW,
+            approved_hosts=frozenset({"api2.marginalia-search.com"}),
+            approved_path_prefixes=("/search",),
+            approved_purposes=frozenset({"corporate-public-footprint"}),
+            automated_collection_allowed=True,
+            raw_storage_allowed=False,
+        ),
+        economics={},
+        notes="test-only authorization; not production activation truth",
+    )
+
+
+def _target(*, enabled: bool = True) -> PublicWebTarget:
+    return PublicWebTarget(
+        id="example-corp",
+        organization_id=ORG_ID,
+        canonical_name="Example Corp",
+        base_url="https://example.com/",
+        sitemap_urls=("https://example.com/sitemap.xml",),
+        allowed_path_prefixes=("/",),
+        enabled=enabled,
+        authorization_reference="controlled-test-target",
+        authorization_reviewed_at=NOW,
+    )
+
+
+def _template() -> SearchQueryTemplate:
+    return SearchQueryTemplate(
+        id="security-context",
+        version=1,
+        query_pattern="{organization} cybersecurity",
+        purpose="corporate-public-footprint",
+        enabled=True,
+    )
+
+
+def _ready_entitlement() -> MarginaliaSearchEntitlement:
+    return MarginaliaSearchEntitlement(
+        commercial_use_rights=True,
+        api_key_secret_ref="secret://marginalia/commercial",
+        plan="commercial",
+        evidence_reference="controlled-test-entitlement",
+    )
+
+
+def _collect(
+    adapter: MarginaliaSearchAdapter,
+    *,
+    checkpoint_payload: dict[str, object] | None = None,
+):
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint_payload,
+        collected_at=NOW,
+        retention_until=RETENTION,
+    )

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -7,6 +7,41 @@ def test_mojeek_checked_in_storage_entitlement_remains_fail_closed() -> None:
     assert "evidence_reference: null" in policy
 
 
+def test_marginalia_checked_in_entitlement_and_governance_remain_fail_closed() -> None:
+    with open(
+        "policies/marginalia_search_entitlement.yml", encoding="utf-8"
+    ) as entitlement_file:
+        entitlement = entitlement_file.read()
+    with open(
+        "policies/sources.search_providers_sa15.yml", encoding="utf-8"
+    ) as governance_file:
+        governance = governance_file.read()
+    with open(
+        "policies/source_activation.search_providers_sa15.yml", encoding="utf-8"
+    ) as activation_file:
+        activation = activation_file.read()
+
+    assert "commercial_use_rights: false" in entitlement
+    assert "plan: unprovisioned" in entitlement
+    assert "evidence_reference: null" in entitlement
+    assert "api_key_secret_ref: null" in entitlement
+
+    marginalia_governance = governance.split(
+        "  - id: marginalia-web-search-metadata", 1
+    )[1]
+    assert "status: draft" in marginalia_governance
+    assert "status: missing" in marginalia_governance
+    assert "approved_hosts: []" in marginalia_governance
+    assert "automated_collection_allowed: false" in marginalia_governance
+
+    marginalia_activation = activation.split(
+        "  - source_id: marginalia-web-search-metadata", 1
+    )[1].split("  - source_id: google-search-governed-route", 1)[0]
+    assert "disposition: blocked" in marginalia_activation
+    assert "stages: [catalogued, reviewed, mapped, adapter_present]" in marginalia_activation
+    assert "live_tested" not in marginalia_activation
+
+
 def test_patentsview_has_no_checked_in_production_target() -> None:
     with open("policies/patentsview_patent_targets.yml", encoding="utf-8") as policy_file:
         policy = policy_file.read()
@@ -14,15 +49,27 @@ def test_patentsview_has_no_checked_in_production_target() -> None:
     assert "targets: []" in policy
 
 
-def test_brave_and_mojeek_live_runners_have_valid_controlled_discovery_seed() -> None:
+def test_search_provider_live_runners_have_valid_controlled_discovery_seed() -> None:
     for script_name in (
         "scripts/live_validate_sa15_brave.py",
         "scripts/live_validate_sa15_mojeek.py",
+        "scripts/live_validate_sa15_marginalia.py",
     ):
         with open(script_name, encoding="utf-8") as script_file:
             script = script_file.read()
         assert "seed_urls=(base_url,)" in script
         assert "discover_security_txt=False" in script
+
+
+def test_marginalia_live_runner_defers_secret_read_to_fail_closed_adapter() -> None:
+    with open(
+        "scripts/live_validate_sa15_marginalia.py", encoding="utf-8"
+    ) as script_file:
+        script = script_file.read()
+
+    assert 'token_provider=lambda: _required_env("MARGINALIA_API_KEY")' in script
+    assert "MarginaliaSearchAdapter" in script
+    assert "load_marginalia_search_entitlement" in script
 
 
 def test_patentsview_legacy_live_runner_fails_before_reading_any_credential() -> None:
@@ -61,7 +108,7 @@ def test_patentsview_legacy_governance_and_activation_are_revoked() -> None:
     assert "- live_tested" not in patentsview_activation
 
 
-def test_manual_live_workflow_exposes_only_current_credentialed_provider_runners() -> None:
+def test_manual_live_workflow_exposes_only_prepared_credentialed_provider_runners() -> None:
     with open(
         ".github/workflows/sa15-provider-live-validation.yml", encoding="utf-8"
     ) as workflow_file:
@@ -70,11 +117,13 @@ def test_manual_live_workflow_exposes_only_current_credentialed_provider_runners
     for script_name in (
         "live_validate_sa15_brave.py",
         "live_validate_sa15_mojeek.py",
+        "live_validate_sa15_marginalia.py",
     ):
         assert f"python scripts/{script_name}" in workflow
     for secret_name in (
         "BRAVE_SEARCH_API_TOKEN",
         "MOJEEK_API_KEY",
+        "MARGINALIA_API_KEY",
     ):
         assert f"secrets.{secret_name}" in workflow
     assert "live_validate_sa15_patentsview.py" not in workflow

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -42,8 +42,13 @@ def test_marginalia_checked_in_entitlement_and_governance_remain_fail_closed() -
         "  - source_id: marginalia-web-search-metadata", 1
     )[1].split("  - source_id: google-search-governed-route", 1)[0]
     assert "disposition: blocked" in marginalia_activation
-    assert "stages: [catalogued, reviewed, mapped, adapter_present]" in marginalia_activation
-    assert "live_tested" not in marginalia_activation
+    stages_line = next(
+        line.strip()
+        for line in marginalia_activation.splitlines()
+        if line.strip().startswith("stages:")
+    )
+    assert stages_line == "stages: [catalogued, reviewed, mapped, adapter_present]"
+    assert "live_tested" not in stages_line
 
     marginalia_portfolio = portfolio.split(
         "  - source_id: marginalia-web-search-metadata", 1

--- a/tests/unit/source_activation/test_sa15_provider_live_readiness.py
+++ b/tests/unit/source_activation/test_sa15_provider_live_readiness.py
@@ -20,6 +20,10 @@ def test_marginalia_checked_in_entitlement_and_governance_remain_fail_closed() -
         "policies/source_activation.search_providers_sa15.yml", encoding="utf-8"
     ) as activation_file:
         activation = activation_file.read()
+    with open(
+        "policies/source_portfolio.search_providers_sa15.yml", encoding="utf-8"
+    ) as portfolio_file:
+        portfolio = portfolio_file.read()
 
     assert "commercial_use_rights: false" in entitlement
     assert "plan: unprovisioned" in entitlement
@@ -40,6 +44,14 @@ def test_marginalia_checked_in_entitlement_and_governance_remain_fail_closed() -
     assert "disposition: blocked" in marginalia_activation
     assert "stages: [catalogued, reviewed, mapped, adapter_present]" in marginalia_activation
     assert "live_tested" not in marginalia_activation
+
+    marginalia_portfolio = portfolio.split(
+        "  - source_id: marginalia-web-search-metadata", 1
+    )[1].split("  - source_id: google-search-governed-route", 1)[0]
+    assert "status: candidate" in marginalia_portfolio
+    assert "executable: false" in marginalia_portfolio
+    assert "runtime_adapter_present: true" in marginalia_portfolio
+    assert "adapter_id: marginalia-web-search" in marginalia_portfolio
 
 
 def test_patentsview_has_no_checked_in_production_target() -> None:


### PR DESCRIPTION
## Scope

Close the remaining **internal** L06 runtime-readiness gap without promoting Marginalia to production authorization or `live_tested`.

- add the real `MarginaliaSearchAdapter` in collection orchestration;
- preserve source-governance -> commercial-entitlement -> secret -> network gate order;
- version/load the Marginalia commercial entitlement policy;
- load `sources.search_providers_sa15.yml` in the global runtime and compose the adapter;
- use Provider Onboarding as the runtime secret supplier;
- add a controlled live runner and manual workflow option for a future legitimate commercial credentialed run;
- add deterministic fail-closed/runtime mapping tests;
- keep checked-in governance `draft` / authorization `missing`, entitlement unprovisioned, Source Activation blocked and `live_tested` absent.

Truth boundary: this PR is **not** Marginalia provider live proof. It must not enable real network collection until legitimate commercial-use evidence, approved API2 scope and Provider Onboarding credentials are configured. Mocks/CI alone do not promote the provider.