### PR TITLE
SA15: align credentialed provider readiness docs after L06

### DIFF
--- a/docs/source_activation/SA_15_L02_L04_SEARCH_PROVIDER_LIVE_READINESS.md
+++ b/docs/source_activation/SA_15_L02_L04_SEARCH_PROVIDER_LIVE_READINESS.md
@@ -1,19 +1,19 @@
 # SA-15 L02-L04 — Credentialed search-provider live readiness
 
-## Current truth after the SA15 internal-completion pass
+## Current truth after the SA15 internal-completion and L06 runtime-readiness passes
 
-Normal CI, mocks, deterministic adapter tests, missing-secret skips and runner presence are not provider live proof.
+Normal CI, mocks, deterministic adapter tests, missing-secret skips, entitlement gates, runtime registration and runner presence are not provider live proof.
 
 ### L02 — Mojeek
 
-`MojeekSearchAdapter` and its production live runner remain implemented. The runner now constructs a valid governed `PublicWebTarget` with an explicit seed, so the target model no longer blocks execution before the provider call.
+`MojeekSearchAdapter` and its production live runner are implemented. The runner constructs a valid governed `PublicWebTarget` with an explicit seed, so the target model no longer blocks execution before the provider call.
 
 The source remains **not `live_tested`**. Real execution still requires both:
 
 - a legitimate `MOJEEK_API_KEY`;
 - reviewed durable-storage rights recorded in `policies/mojeek_search_entitlement.yml` with evidence.
 
-The checked-in entitlement remains fail-closed. No provider call may be used as persistent-ingestion proof until those rights are actually available.
+The checked-in entitlement remains fail-closed. The controlled runner checks the storage entitlement before reading `MOJEEK_API_KEY`; no provider call may be used as persistent-ingestion proof until those rights are actually available.
 
 ### L03 — PatentsView
 
@@ -32,25 +32,35 @@ The historical adapter code is retained as implementation history only. It must 
 
 ### L04 — Brave Search
 
-`BraveSearchAdapter` and its live runner remain implemented. The runner now supplies an explicit governed seed and can reach the provider stage when a legitimate token exists.
+`BraveSearchAdapter` and its live runner are implemented. The runner supplies an explicit governed seed and can reach the provider stage when a legitimate token exists.
 
-Brave remains **not `live_tested`** because no real `BRAVE_SEARCH_API_TOKEN` has been provisioned/run through the workflow. A real provider response and complete exact-SHA CI are still required before activation promotion.
+Brave remains **not `live_tested`** because no real `BRAVE_SEARCH_API_TOKEN` has been provisioned/run through the workflow. A real non-empty provider response and complete exact-SHA CI/live validation are still required before activation promotion.
+
+### L06 — Marginalia workflow presence after PR #136
+
+Marginalia is now exposed by the same manual credentialed-provider workflow because its internal runtime adapter and controlled runner are present. This does **not** make it equivalent to the L02/L04 currently authorized/executable candidates.
+
+Its checked-in Source Governance remains `draft` with authorization `missing`, its Source Portfolio entry remains `candidate` / `executable: false`, Source Activation remains `blocked`, and its commercial entitlement remains unprovisioned. The Marginalia runner therefore exists only as the controlled future execution path to use after legitimate commercial-use evidence, exact approved API2 scope and Provider Onboarding credentials are configured.
 
 ## Credentialed workflow
 
-`.github/workflows/sa15-provider-live-validation.yml` now exposes only the currently legitimate runnable credentialed candidates:
+`.github/workflows/sa15-provider-live-validation.yml` exposes three manually selectable controlled runners:
 
-- `brave`;
-- `mojeek`.
+- `brave` — implementation ready; legitimate subscription token still required;
+- `mojeek` — implementation ready; legitimate key plus durable-storage entitlement still required;
+- `marginalia` — runtime ready but deliberately fail-closed; commercial-use authorization/evidence, Provider Onboarding credential and approved API2 scope still required.
 
-PatentsView is intentionally absent until the current ODP contract is implemented.
+PatentsView is intentionally absent until the current USPTO ODP contract is implemented.
+
+Merely appearing as a workflow option is not an activation stage and is not provider live proof. A skipped or blocked run does not satisfy `live_tested`.
 
 ## Activation matrix
 
 | Source | Production implementation | Current route authorized/executable | External prerequisite | `live_tested` |
 |---|---:|---:|---|---:|
-| Brave Search | yes | yes | legitimate subscription token + real run | no |
-| Mojeek | yes | yes, entitlement-gated | legitimate key + durable-storage rights + real run | no |
+| Brave Search | yes | yes | legitimate subscription token + controlled real run | no |
+| Mojeek | yes | yes, entitlement-gated | legitimate key + durable-storage rights/evidence + controlled real run | no |
+| Marginalia | yes, runtime-ready | **no; candidate/blocked** | commercial key + commercial-use evidence + approved API2 scope/onboarding + controlled real run | no |
 | PatentsView legacy PatentSearch | historical adapter retained | **no; paused/revoked** | replace with current USPTO ODP contract | no |
 
-No row may be promoted by association with another provider's successful workflow.
+No row may be promoted by association with another provider's successful workflow, by adapter presence, by CI alone or by a skipped provider workflow.


### PR DESCRIPTION
Documentation-only truth closeout after PR #136.

- keeps Brave and Mojeek explicitly not `live_tested` pending their real external credentials/entitlements and provider runs;
- records Marginalia as a manual workflow option without promoting it: governance remains draft/missing, portfolio candidate/non-executable, activation blocked;
- keeps PatentsView absent from the credentialed workflow pending the current USPTO ODP contract;
- states explicitly that workflow presence, CI, mocks, skipped or blocked runs are not provider live proof.

No runtime, activation, authorization, entitlement or credential state is changed.