### PR TITLE
SA16-L01: revalidate automatic crawl target on current main

### DIFF
--- a/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
+++ b/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-`REVALIDATION_IN_PROGRESS` on the current `main` content tree.
+`IMPLEMENTED_VALIDATED_MERGED` for the SA16-L01 production capability.
 
-SA16-L01 is implemented and was originally live-tested before PR #128 merged, but the PR was squash-merged after `main` had advanced. The implementation-head proof remains genuine; this closeout deliberately re-runs both normal CI and the dedicated real-network SA-16 L01 workflow on the current repository content so the final status does not rely on an older branch tree.
+SA16-L01 was implemented in PR #128 and is already merged. Because that PR was squash-merged after `main` had advanced, this closeout also revalidates the capability from the current repository baseline rather than relying only on the older implementation branch tree.
 
 Historical final implementation/documentation head:
 
@@ -17,7 +17,18 @@ That exact head passed:
 
 PR #128 was then squash-merged as `74542d9ade125f4a07afd0f77a6c61f0bb907e94`.
 
-This document is now being revalidated from the current `main` baseline. L01 will be recorded `IMPLEMENTED_VALIDATED_MERGED` only after the final closeout head itself passes normal CI and the dedicated real production-path workflow.
+### Current-main revalidation
+
+The first current-main closeout head was:
+
+`1872ad71706f25eaf9951713f056fc9c93a49cae`
+
+That exact head passed:
+
+- normal CI #1989 (`31633779550`): **PASS**;
+- SA-16 L01 Live Validation run #59 (`31633779677`): **PASS** against the real Python.org production path.
+
+This documentation commit is the final PR #138 candidate. Because changing documentation changes the content tree, PR #138 may merge only after **this final head itself** independently repeats both normal CI and the SA-16 L01 live workflow, with zero unresolved review threads. No earlier run is substituted for that final gate.
 
 ## Objective
 
@@ -89,7 +100,7 @@ The workflow fails unless the generated homepage is checkpointed, real non-empty
 
 ## Completion rule
 
-L01 is finally closed only when the same final content head passes:
+The PR #138 final content head must pass:
 
 1. dependency consistency and audits;
 2. Ruff;

--- a/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
+++ b/docs/source_activation/SA_16_L01_AUTOMATIC_CRAWL_TARGET.md
@@ -2,20 +2,28 @@
 
 ## Status
 
-`LIVE_TESTED` on the implementation candidate and awaiting the mandatory exact-head revalidation of this proof/documentation commit before merge.
+`REVALIDATION_IN_PROGRESS` on the current `main` content tree.
 
-The first real production-path proof succeeded on implementation head `1fed10fe0fdcc1959b06cc6bd57b1678dcc03d51`:
+SA16-L01 is implemented and was originally live-tested before PR #128 merged, but the PR was squash-merged after `main` had advanced. The implementation-head proof remains genuine; this closeout deliberately re-runs both normal CI and the dedicated real-network SA-16 L01 workflow on the current repository content so the final status does not rely on an older branch tree.
 
-- SA-16 L01 Live Validation run `31588271537`: **PASS**;
-- normal CI run `31588271512` / CI #1921: **PASS**.
+Historical final implementation/documentation head:
 
-Because recording this proof changes the PR head, repository rules require both gates to pass again on the new final SHA. Until that second pass completes, the PR remains draft and must not be merged.
+`f99579909a10595acadc55d092e0aeee7ca42d6c`
+
+That exact head passed:
+
+- normal CI #1923 (`31588625902`): **PASS**;
+- SA-16 L01 Live Validation run #2 (`31588625975`): **PASS**.
+
+PR #128 was then squash-merged as `74542d9ade125f4a07afd0f77a6c61f0bb907e94`.
+
+This document is now being revalidated from the current `main` baseline. L01 will be recorded `IMPLEMENTED_VALIDATED_MERGED` only after the final closeout head itself passes normal CI and the dedicated real production-path workflow.
 
 ## Objective
 
 Remove the developer-edited-YAML dependency between a resolved organization website and the first governed public-web collection.
 
-The implemented runtime chain is:
+The production chain is:
 
 ```text
 Organization.website_url
@@ -27,79 +35,44 @@ Organization.website_url
 -> RawObservation + PublicResource provenance
 ```
 
-L01 does not implement recursive link traversal, sitemap-index recursion, generalized browser rendering, or incremental recrawl. Those remain subsequent SA-16 increments.
+L01 does not implement recursive link traversal, sitemap-index recursion, generalized browser rendering, or incremental recrawl. Those belong to subsequent SA-16 increments.
 
-## Architecture decisions
+## Implemented behavior
 
-### Reuse the canonical public-web target
+`PublicWebTarget` remains the single target model. L01 adds explicit homepage `seed_urls` and a separate governed `source_id`, so an organization-specific target does not require a new source-policy YAML record for every company.
 
-`PublicWebTarget` remains the single target definition. L01 extends it with:
+`provision_public_web_target()` generates an exact runtime source policy and authorization from a deployment-approved canonical organization domain. Authorization remains limited to the canonical host, approved path prefixes, `corporate-public-footprint`, bounded automated collection and no raw-content storage.
 
-- `seed_urls` for explicit first-party entry pages such as the canonical homepage;
-- `source_id` so a unique organization target identity is not confused with the governed acquisition-source identity.
-
-Existing checked-in targets remain backward compatible: when `source_id` is omitted, it defaults to the existing target `id`.
-
-### Generated governance, not per-company source YAML
-
-The previous collector required `SourceRegistryEntry.policy.id == PublicWebTarget.id`. That made an automatic organization target effectively require a new source-policy record for every company.
-
-L01 separates those identities. `provision_public_web_target()` generates an exact runtime `SourcePolicy` and `SourceAuthorization` from a deployment-approved organization/domain policy. The generated authorization is limited to:
-
-- the canonical website host;
-- approved path prefixes;
-- the `corporate-public-footprint` purpose;
-- bounded automated collection;
-- no raw-content storage.
-
-Policy evaluation still happens before the robots request and before every discovered resource request.
-
-### Deterministic target identity
-
-The target id is derived from the canonical organization UUID:
+The generated target uses deterministic identity:
 
 ```text
 public-web-<organization UUID hex>
 ```
 
-The source identity for this capability is:
+and governed source identity:
 
 ```text
 automatic-public-company-web
 ```
 
-Raw observations and public-resource projections retain the governed source identity while the organization id and target id preserve target lineage.
+Initial discovery includes the canonical homepage and `/.well-known/security.txt`; it deliberately does not guess arbitrary sitemap/feed locations.
 
-## Initial discovery behavior
+## Safety and provenance invariants
 
-L01 provisions:
-
-- canonical homepage as an explicit `DIRECT` seed;
-- `/.well-known/security.txt` discovery;
-- exact crawl-scope budgets;
-- first-crawl timestamp;
-- refresh interval metadata.
-
-It intentionally does not guess that `/sitemap.xml` exists. Automatic robots/sitemap/feed discovery and recursive traversal are owned by the following SA-16 crawler increments.
+- source governance is evaluated before robots and resource requests;
+- off-origin acquisition fails closed;
+- raw-content storage remains disabled;
+- observations/resources retain the governed source id while target/organization identity remains explicit;
+- no page-view-triggered or unrestricted crawler is introduced by L01;
+- no provider/live status is inferred from mocks, skipped workflows or adapter presence.
 
 ## Deterministic validation
 
-Unit coverage proves:
+Unit coverage proves the canonical website requirement, deterministic target identity, source/target separation, same-origin homepage/security.txt behavior, generated host/path authorization, off-host denial, raw-storage denial, expired-authorization denial and legacy target compatibility.
 
-- a canonical website is mandatory;
-- target identity is deterministic;
-- source and target identities remain distinct;
-- homepage and security.txt remain same-origin;
-- generated governance permits the approved host and denies another host before collection;
-- raw storage remains disabled;
-- expired authorization fails closed;
-- legacy target source-id behavior remains compatible.
+## Real live validation contract
 
-Unit tests remain network-free.
-
-## Controlled live validation
-
-The dedicated production-path runner uses the public Python Software Foundation website as the neutral approved validation target:
+The dedicated production-path runner uses the public Python Software Foundation website:
 
 ```text
 Organization(Python Software Foundation, https://www.python.org/)
@@ -112,43 +85,20 @@ Organization(Python Software Foundation, https://www.python.org/)
 -> non-empty RawObservation / PublicResource projection
 ```
 
-### First successful proof
-
-On implementation head `1fed10fe0fdcc1959b06cc6bd57b1678dcc03d51`, the dedicated real-network workflow reported:
-
-```text
-SA-16 L01 live validation passed:
-organization='Python Software Foundation'
-target=public-web-15712d0d905450b48a26e25d9ea1f509
-source=automatic-public-company-web
-observations=1
-projections=1
-homepage=https://www.python.org/
-```
-
-The live gate therefore proved that the production client and production collector can consume a target generated from a real organization website, fetch real public data, retain exact source provenance and stay inside the approved origin.
-
-The live gate fails unless:
-
-1. the generated homepage is checkpointed;
-2. at least one real observation and projection are produced;
-3. every observation and projection uses `automatic-public-company-web` provenance;
-4. no canonical resource escapes `https://www.python.org/`;
-5. the production collector, not a mock transport, performs the network requests.
+The workflow fails unless the generated homepage is checkpointed, real non-empty data is produced, source provenance is `automatic-public-company-web`, no resource escapes the approved origin, and the production client/collector perform the network requests.
 
 ## Completion rule
 
-L01 is merge-valid only after:
+L01 is finally closed only when the same final content head passes:
 
-1. deterministic tests pass;
-2. Ruff passes;
-3. strict Mypy passes;
-4. architecture/release contracts pass;
-5. migration gates remain green;
-6. complete backend coverage remains at or above repository thresholds;
-7. frontend quality remains green;
-8. the SA-16 L01 real-network workflow passes using the production client and collector;
-9. the live proof is recorded in this document;
-10. this documentation/live-state commit itself passes both normal CI and the live workflow on the exact final SHA.
+1. dependency consistency and audits;
+2. Ruff;
+3. strict Mypy;
+4. architecture/release contracts;
+5. reversible migrations;
+6. complete backend tests/coverage;
+7. frontend audit/typecheck/build;
+8. the SA-16 L01 real-network workflow;
+9. zero unresolved review threads.
 
-A skipped live job, mocked HTTP response, documentation-only claim, or earlier SHA does not satisfy this gate.
+A skipped live job, mocked HTTP response, documentation-only claim, older SHA or synthetic merge-ref result does not satisfy this gate.


### PR DESCRIPTION
Documentation/status closeout for the already-merged SA16-L01 implementation.

The historical L01 head passed both normal CI and the real Python.org production-path live workflow, but PR #128 was squash-merged after main had advanced. This PR intentionally rebases the L01 validation branch onto current main and re-runs the exact production-path gate so L01 can be closed against the current repository content rather than an older branch tree.

No L01 runtime behavior is changed by this PR. The branch remains fail-closed under the existing generated SourcePolicy/SourceAuthorization and no raw content storage. Merge only after exact-head normal CI + SA-16 L01 live validation + zero unresolved review threads.