### PR TITLE
SA16-L02: add bounded recursive static public-web crawler

### DIFF
--- a/.github/workflows/sa16-l02-live-validation.yml
+++ b/.github/workflows/sa16-l02-live-validation.yml
@@ -1,0 +1,35 @@
+name: SA-16 L02 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa16-l02-live-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
+jobs:
+  live-recursive-static-public-web:
+    if: github.event.pull_request.head.ref == 'agent/sa16-l02-recursive-static-crawler'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact pull-request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled recursive static production live validation
+        run: python scripts/live_validate_sa16_l02.py

--- a/docs/source_activation/SA_16_L02_RECURSIVE_STATIC_CRAWLER.md
+++ b/docs/source_activation/SA_16_L02_RECURSIVE_STATIC_CRAWLER.md
@@ -1,0 +1,86 @@
+# SA-16 L02 — Bounded recursive static public-web crawler
+
+## Status
+
+`IMPLEMENTATION_IN_PROGRESS`.
+
+L02 extends the automatic governed target delivered by SA16-L01 into bounded same-origin static link traversal. It does not introduce browser rendering, authenticated navigation, JavaScript execution, sitemap-index recursion or incremental recrawl; those remain later SA16 increments.
+
+## Production path
+
+```text
+Organization.website_url
+-> SA16-L01 automatic governed PublicWebTarget
+-> homepage / explicit discovery candidates
+-> PublicWebClient
+-> static HTML link extraction
+-> deterministic BFS frontier
+-> same-origin + approved-path + max-depth admission
+-> PublicWebClient again for every child URL
+-> RawObservation + PublicResourceVersion + checkpoint
+```
+
+No recursive child fetch bypasses `PublicWebClient`. Each child therefore re-enters the existing robots, crawl-scope, redirect, response-type and byte-budget controls.
+
+## Implementation
+
+- `PublicWebTarget.max_depth` is now first-class.
+- Checked-in/legacy targets default to `max_depth=0`, preserving their previous non-recursive behavior unless explicitly enabled.
+- `AutomaticPublicWebPolicy` defaults to a conservative one-link-hop `max_depth=1` and provisions that value into automatic company targets.
+- `PublicWebClient.fetch_page()` receives the actual candidate depth rather than hard-coding depth zero.
+- Static HTML anchors are canonicalized relative to the fetched parent URL, fragments are removed by canonical URL identity, query parameters are deterministically normalized and duplicates are discarded.
+- `rel=nofollow` anchors are not enqueued.
+- non-HTTP(S) links are rejected by canonical URL validation.
+- off-origin and out-of-approved-path links are discarded before enqueue and are still re-evaluated by source governance/client policy before any network request.
+- traversal is deterministic breadth-first order.
+- the existing `max_pages`, `max_total_bytes`, `max_resource_bytes`, `max_redirects` and robots rules remain authoritative.
+- linked resources use `DiscoveryMethod.LINK` and retain the parent fetched URL in `PublicResourceVersion.source_locator`.
+
+## Replay and checkpoint boundary
+
+L02 deliberately keeps the durable checkpoint format focused on resource/version state rather than persisting an arbitrary URL frontier. A collection run deterministically rebuilds its bounded BFS frontier from the governed seeds and the fetched HTML. This means retry/replay cannot expand beyond the same target depth/page/path/origin budgets, while unchanged page hashes reuse the existing checkpointed version ids.
+
+Incremental frontier persistence, freshness prioritization, tombstone sweeps and recrawl scheduling are later SA16 work and are not claimed by L02.
+
+## Deterministic tests
+
+Tests cover:
+
+- canonicalization and deduplication of static anchor links;
+- `rel=nofollow` exclusion;
+- bounded link extraction order;
+- same-origin confinement;
+- depth enforcement;
+- no duplicate child fetch;
+- automatic-target recursive default versus legacy non-recursive default;
+- checkpoint replay rebuilding the frontier while producing no new observations/versions for unchanged content.
+
+## Controlled real-network validation
+
+`scripts/live_validate_sa16_l02.py` uses the real Python Software Foundation public website through the production provisioner, `PublicWebClient` and collector. The live gate requires:
+
+- the generated homepage seed to be checkpointed;
+- at least one real same-origin child page discovered with `DiscoveryMethod.LINK` and fetched by the production collector;
+- the child to retain its parent discovery source locator;
+- all observations/projections to keep `automatic-public-company-web` provenance;
+- no URL to escape the approved `https://www.python.org/` origin;
+- total projected pages to remain within the configured page budget;
+- exact pull-request head checkout;
+- normal repository CI on the same final head.
+
+A mocked response, skipped workflow, synthetic merge ref or successful L01 run does not satisfy L02 live proof.
+
+## Exit gate
+
+L02 is complete only when the final PR head has:
+
+1. frontend audit/typecheck/build green;
+2. dependency consistency and Python audit green;
+3. Ruff green;
+4. strict Mypy green;
+5. architecture/release contracts green;
+6. reversible migrations green;
+7. complete backend tests/coverage green;
+8. the real SA-16 L02 production-path live workflow green on that exact head;
+9. zero unresolved review threads;
+10. merge content proven identical to the validated final tree.

--- a/docs/source_activation/SA_16_L02_RECURSIVE_STATIC_CRAWLER.md
+++ b/docs/source_activation/SA_16_L02_RECURSIVE_STATIC_CRAWLER.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-`IMPLEMENTATION_IN_PROGRESS`.
+`IMPLEMENTED_FINAL_VALIDATION_PENDING`.
 
-L02 extends the automatic governed target delivered by SA16-L01 into bounded same-origin static link traversal. It does not introduce browser rendering, authenticated navigation, JavaScript execution, sitemap-index recursion or incremental recrawl; those remain later SA16 increments.
+L02 extends the automatic governed target delivered by SA16-L01 into bounded same-origin static link traversal. The implementation candidate immediately preceding this closeout document passed both complete repository CI and a real exact-head Python.org recursive crawl. Because this documentation change creates a new content head, **this final PR head must independently repeat both gates before merge**. No earlier successful run is substituted for the final gate.
+
+L02 does not introduce browser rendering, authenticated navigation, JavaScript execution, sitemap-index recursion or incremental recrawl; those remain later SA16 increments.
 
 ## Production path
 
@@ -76,13 +78,33 @@ Tests cover:
 - exact pull-request head checkout;
 - normal repository CI on the same final head.
 
-The first implementation candidate `30ecc5254b9628fe39cacdb56afaa48c0ad40bdc` produced a genuine intermediate real-network result of **2 observations / 2 projections / 1 linked child**, but it is not final proof because normal CI exposed the compatibility regression described above. The corrected final head must repeat both gates.
+### Rejected intermediate candidate
+
+`30ecc5254b9628fe39cacdb56afaa48c0ad40bdc` produced a genuine real-network result of **2 observations / 2 projections / 1 linked child**, but normal CI exposed the legacy feed compatibility regression described above. It is not accepted as final proof.
+
+### Corrected validated implementation candidate
+
+`1b4a98008f672f225cf295fea46f9171cb79c307` passed both gates after the compatibility fix:
+
+- **SA-16 L02 Live Validation #9** (`31636984136`): PASS on the exact PR head, with **2 observations, 2 projections, 1 linked child, 2 checkpointed pages, max_link_depth=1**;
+- **CI #2002** (`31636984113`): PASS;
+- dependency consistency: PASS;
+- Python dependency audit: no known vulnerabilities;
+- Ruff: PASS;
+- strict Mypy: PASS on **697 source files**;
+- architecture/release contracts: **36 passed**;
+- reversible migrations: PASS;
+- backend suite: **1500 passed**;
+- branch-aware coverage: **90.10%**;
+- frontend audit/typecheck/build: PASS.
+
+This proves the corrected implementation itself, but the **documentation head produced by this closeout must now repeat CI + SA-16 L02 live validation on its own exact SHA** before PR #139 may merge.
 
 A mocked response, skipped workflow, synthetic merge ref, intermediate successful live run or successful L01 run does not satisfy L02 final live proof.
 
 ## Exit gate
 
-L02 is complete only when the final PR head has:
+PR #139 may merge only when its final content head has:
 
 1. frontend audit/typecheck/build green;
 2. dependency consistency and Python audit green;
@@ -93,4 +115,6 @@ L02 is complete only when the final PR head has:
 7. complete backend tests/coverage green;
 8. the real SA-16 L02 production-path live workflow green on that exact head;
 9. zero unresolved review threads;
-10. merge content proven identical to the validated final tree.
+10. squash-merge content proven identical to the validated final Git tree.
+
+Once those conditions hold and the tree-identical squash is on `main`, L02 is complete without another content-changing documentation edit.

--- a/docs/source_activation/SA_16_L02_RECURSIVE_STATIC_CRAWLER.md
+++ b/docs/source_activation/SA_16_L02_RECURSIVE_STATIC_CRAWLER.md
@@ -15,7 +15,7 @@ Organization.website_url
 -> PublicWebClient
 -> static HTML link extraction
 -> deterministic BFS frontier
--> same-origin + approved-path + max-depth admission
+-> same-origin + approved-path + max-link-depth admission
 -> PublicWebClient again for every child URL
 -> RawObservation + PublicResourceVersion + checkpoint
 ```
@@ -24,10 +24,11 @@ No recursive child fetch bypasses `PublicWebClient`. Each child therefore re-ent
 
 ## Implementation
 
-- `PublicWebTarget.max_depth` is now first-class.
-- Checked-in/legacy targets default to `max_depth=0`, preserving their previous non-recursive behavior unless explicitly enabled.
-- `AutomaticPublicWebPolicy` defaults to a conservative one-link-hop `max_depth=1` and provisions that value into automatic company targets.
-- `PublicWebClient.fetch_page()` receives the actual candidate depth rather than hard-coding depth zero.
+- `PublicWebTarget.max_link_depth` explicitly controls only HTML-anchor recursion.
+- Checked-in/legacy targets default to `max_link_depth=0`, preserving their previous non-recursive HTML behavior.
+- The underlying `CrawlScope` retains at least structural depth `1`, preserving the pre-L02 contract used by existing RSS/Atom and sitemap discovery. Link recursion and structural feed/sitemap discovery are therefore no longer conflated.
+- `AutomaticPublicWebPolicy` defaults to a conservative one-link-hop `max_link_depth=1` and provisions that value into automatic company targets.
+- `PublicWebClient.fetch_page()` receives the actual candidate depth rather than hard-coding depth zero, so depth admission is enforced by the existing crawl-scope gate before network I/O.
 - Static HTML anchors are canonicalized relative to the fetched parent URL, fragments are removed by canonical URL identity, query parameters are deterministically normalized and duplicates are discarded.
 - `rel=nofollow` anchors are not enqueued.
 - non-HTTP(S) links are rejected by canonical URL validation.
@@ -36,9 +37,15 @@ No recursive child fetch bypasses `PublicWebClient`. Each child therefore re-ent
 - the existing `max_pages`, `max_total_bytes`, `max_resource_bytes`, `max_redirects` and robots rules remain authoritative.
 - linked resources use `DiscoveryMethod.LINK` and retain the parent fetched URL in `PublicResourceVersion.source_locator`.
 
+## Compatibility correction found during validation
+
+The first L02 candidate set `PublicWebTarget` depth to zero by default. Normal CI correctly exposed that RSS/Atom parsing historically evaluates discovered entries at structural depth `1`; five existing feed tests failed even though the first real recursive Python.org live run succeeded.
+
+That candidate was rejected. L02 now separates `max_link_depth` from the structural crawl-scope depth instead of weakening or rewriting the existing feed tests. Legacy feeds/sitemaps keep their historical admission behavior while HTML-link recursion remains opt-in for legacy targets.
+
 ## Replay and checkpoint boundary
 
-L02 deliberately keeps the durable checkpoint format focused on resource/version state rather than persisting an arbitrary URL frontier. A collection run deterministically rebuilds its bounded BFS frontier from the governed seeds and the fetched HTML. This means retry/replay cannot expand beyond the same target depth/page/path/origin budgets, while unchanged page hashes reuse the existing checkpointed version ids.
+L02 deliberately keeps the durable checkpoint format focused on resource/version state rather than persisting an arbitrary URL frontier. A collection run deterministically rebuilds its bounded BFS frontier from the governed seeds and the fetched HTML. This means retry/replay cannot expand beyond the same target link-depth/page/path/origin budgets, while unchanged page hashes reuse the existing checkpointed version ids.
 
 Incremental frontier persistence, freshness prioritization, tombstone sweeps and recrawl scheduling are later SA16 work and are not claimed by L02.
 
@@ -50,9 +57,10 @@ Tests cover:
 - `rel=nofollow` exclusion;
 - bounded link extraction order;
 - same-origin confinement;
-- depth enforcement;
+- link-depth enforcement;
 - no duplicate child fetch;
-- automatic-target recursive default versus legacy non-recursive default;
+- automatic-target recursive default versus legacy HTML non-recursive default;
+- preservation of the historical structural depth needed by existing feed/sitemap discovery;
 - checkpoint replay rebuilding the frontier while producing no new observations/versions for unchanged content.
 
 ## Controlled real-network validation
@@ -68,7 +76,9 @@ Tests cover:
 - exact pull-request head checkout;
 - normal repository CI on the same final head.
 
-A mocked response, skipped workflow, synthetic merge ref or successful L01 run does not satisfy L02 live proof.
+The first implementation candidate `30ecc5254b9628fe39cacdb56afaa48c0ad40bdc` produced a genuine intermediate real-network result of **2 observations / 2 projections / 1 linked child**, but it is not final proof because normal CI exposed the compatibility regression described above. The corrected final head must repeat both gates.
+
+A mocked response, skipped workflow, synthetic merge ref, intermediate successful live run or successful L01 run does not satisfy L02 final live proof.
 
 ## Exit gate
 

--- a/scripts/live_validate_sa16_l02.py
+++ b/scripts/live_validate_sa16_l02.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.provisioning import (
+    AUTOMATIC_PUBLIC_WEB_SOURCE_ID,
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.public_footprint.domain import DiscoveryMethod
+
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+_TARGET_URL = "https://www.python.org/"
+_MAX_PAGES = 6
+
+
+def main() -> None:
+    now = datetime.now(UTC)
+    organization = Organization(
+        id=_ORG_ID,
+        canonical_name="Python Software Foundation",
+        website_url=_TARGET_URL,
+        created_at=now,
+        updated_at=now,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l02-controlled-python-org-recursive-target",
+            reviewed_at=now,
+            allowed_path_prefixes=("/",),
+            refresh_interval_seconds=86_400,
+            max_depth=1,
+            max_pages=_MAX_PAGES,
+            max_total_bytes=4_000_000,
+            max_resource_bytes=1_000_000,
+            max_redirects=1,
+        ),
+        first_crawl_at=now,
+    )
+    with httpx.Client(timeout=30.0) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            provisioned.source_entry,
+            provisioned.target,
+            collection_job_id=uuid4(),
+            collected_at=now,
+            retention_until=now + timedelta(days=365),
+        )
+
+    homepage = provisioned.target.seed_urls[0]
+    linked = [
+        projection
+        for projection in batch.projections
+        if projection.resource.discovery_method is DiscoveryMethod.LINK
+    ]
+    if homepage not in batch.checkpoint.pages:
+        raise RuntimeError("SA16-L02 live crawl did not checkpoint the homepage seed")
+    if not linked:
+        raise RuntimeError("SA16-L02 live crawl did not fetch a same-origin linked child page")
+    if len(batch.projections) > _MAX_PAGES:
+        raise RuntimeError("SA16-L02 live crawl exceeded the page budget")
+    if any(item.source_id != AUTOMATIC_PUBLIC_WEB_SOURCE_ID for item in batch.observations):
+        raise RuntimeError("SA16-L02 observations lost governed source provenance")
+    if any(
+        projection.resource.source_id != AUTOMATIC_PUBLIC_WEB_SOURCE_ID
+        for projection in batch.projections
+    ):
+        raise RuntimeError("SA16-L02 projections lost governed source provenance")
+    if any(
+        not projection.resource.canonical_url.startswith(_TARGET_URL)
+        for projection in batch.projections
+    ):
+        raise RuntimeError("SA16-L02 recursive crawl escaped the approved origin")
+    if any(
+        projection.resource.source_url == homepage
+        for projection in linked
+    ):
+        raise RuntimeError("SA16-L02 linked child lost its discovery source locator")
+
+    print(
+        "SA-16 L02 live validation passed: "
+        f"organization={organization.canonical_name!r} target={provisioned.target.id} "
+        f"source={AUTOMATIC_PUBLIC_WEB_SOURCE_ID} observations={len(batch.observations)} "
+        f"projections={len(batch.projections)} linked_children={len(linked)} "
+        f"checkpoint_pages={len(batch.checkpoint.pages)} max_depth={provisioned.target.max_depth}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/live_validate_sa16_l02.py
+++ b/scripts/live_validate_sa16_l02.py
@@ -78,10 +78,7 @@ def main() -> None:
         for projection in batch.projections
     ):
         raise RuntimeError("SA16-L02 recursive crawl escaped the approved origin")
-    if any(
-        projection.resource.source_url == homepage
-        for projection in linked
-    ):
+    if any(projection.version.source_locator is None for projection in linked):
         raise RuntimeError("SA16-L02 linked child lost its discovery source locator")
 
     print(

--- a/scripts/live_validate_sa16_l02.py
+++ b/scripts/live_validate_sa16_l02.py
@@ -36,7 +36,7 @@ def main() -> None:
             reviewed_at=now,
             allowed_path_prefixes=("/",),
             refresh_interval_seconds=86_400,
-            max_depth=1,
+            max_link_depth=1,
             max_pages=_MAX_PAGES,
             max_total_bytes=4_000_000,
             max_resource_bytes=1_000_000,
@@ -86,7 +86,8 @@ def main() -> None:
         f"organization={organization.canonical_name!r} target={provisioned.target.id} "
         f"source={AUTOMATIC_PUBLIC_WEB_SOURCE_ID} observations={len(batch.observations)} "
         f"projections={len(batch.projections)} linked_children={len(linked)} "
-        f"checkpoint_pages={len(batch.checkpoint.pages)} max_depth={provisioned.target.max_depth}"
+        f"checkpoint_pages={len(batch.checkpoint.pages)} "
+        f"max_link_depth={provisioned.target.max_link_depth}"
     )
 
 

--- a/src/cip/adapters/sources/public_web/client.py
+++ b/src/cip/adapters/sources/public_web/client.py
@@ -186,6 +186,7 @@ class PublicWebClient:
         robots: RobotsRules,
         *,
         usage: CrawlUsage,
+        depth: int = 0,
     ) -> PublicWebFetchResult:
         requested = CanonicalUrl(url).value
         current = requested
@@ -193,7 +194,7 @@ class PublicWebClient:
         while True:
             decision = target.crawl_scope.evaluate_target(
                 current,
-                depth=0,
+                depth=depth,
                 redirects=redirects,
                 usage=usage,
             )

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -240,7 +240,7 @@ def _discover_recursive_links(
     remaining = target.max_pages - len(candidates)
     if (
         fetched.mime_type != "text/html"
-        or child_depth > target.max_depth
+        or child_depth > target.max_link_depth
         or remaining <= 0
     ):
         return

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -10,6 +10,7 @@ from cip.adapters.sources.public_web.client import (
     RobotsRules,
 )
 from cip.adapters.sources.public_web.feed_parsing import parse_public_feed
+from cip.adapters.sources.public_web.link_discovery import extract_public_html_links
 from cip.adapters.sources.public_web.mapper import (
     MappedPublicPage,
     PreviousPageState,
@@ -25,6 +26,7 @@ from cip.modules.public_footprint.domain import (
     PublicResourceKind,
 )
 from cip.modules.public_footprint.domain.scope import CrawlUsage
+from cip.modules.public_footprint.domain.url_identity import same_origin
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import (
     CollectionRequest,
@@ -66,6 +68,7 @@ class PublicWebDiscoveryCandidate:
     discovery_method: DiscoveryMethod
     source_locator: str | None = None
     security_txt: bool = False
+    depth: int = 0
 
 
 def collect_public_web_target(
@@ -85,7 +88,7 @@ def collect_public_web_target(
         raise PublicWebCollectionDeniedError("target_authorization_inactive")
     _authorize(entry, target.robots_url, now=collected)
     robots = client.fetch_robots(target)
-    candidates, discovery_bytes = _discover_candidates(
+    initial_candidates, discovery_bytes = _discover_candidates(
         client,
         entry,
         target,
@@ -93,14 +96,27 @@ def collect_public_web_target(
         now=collected,
         initial_bytes=robots.bytes_fetched,
     )
+    candidates = list(initial_candidates)
+    seen = {candidate.url for candidate in candidates}
     usage = CrawlUsage(bytes_fetched=discovery_bytes)
     previous_pages = checkpoint.pages if checkpoint is not None else {}
     next_pages = dict(previous_pages)
     observations: list[RawObservation] = []
     projections: list[PublicFootprintProjection] = []
-    for candidate in candidates:
+    index = 0
+    while index < len(candidates):
+        candidate = candidates[index]
+        index += 1
+        if usage.pages_fetched >= target.max_pages:
+            break
         _authorize(entry, candidate.url, now=collected)
-        fetched = client.fetch_page(target, candidate.url, robots, usage=usage)
+        fetched = client.fetch_page(
+            target,
+            candidate.url,
+            robots,
+            usage=usage,
+            depth=candidate.depth,
+        )
         usage = CrawlUsage(
             pages_fetched=usage.pages_fetched + 1,
             bytes_fetched=usage.bytes_fetched + len(fetched.body),
@@ -126,6 +142,13 @@ def collect_public_web_target(
             version_id=checkpoint_version_id,
             canonical_url=fetched.fetched_url,
             resource_kind=mapped.projection.resource.kind,
+        )
+        _discover_recursive_links(
+            target,
+            candidate,
+            fetched,
+            candidates,
+            seen,
         )
     return PublicWebCollectionBatch(
         observations=tuple(observations),
@@ -206,6 +229,50 @@ def _discover_candidates(
     return tuple(candidates), total_bytes
 
 
+def _discover_recursive_links(
+    target: PublicWebTarget,
+    candidate: PublicWebDiscoveryCandidate,
+    fetched: PublicWebFetchResult,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+) -> None:
+    child_depth = candidate.depth + 1
+    remaining = target.max_pages - len(candidates)
+    if (
+        fetched.mime_type != "text/html"
+        or child_depth > target.max_depth
+        or remaining <= 0
+    ):
+        return
+    links = extract_public_html_links(
+        fetched.body,
+        base_url=fetched.fetched_url,
+        max_links=remaining,
+    )
+    for link in links:
+        if not same_origin(target.base_url, link):
+            continue
+        decision = target.crawl_scope.evaluate_target(
+            link,
+            depth=child_depth,
+            redirects=0,
+            usage=CrawlUsage(),
+        )
+        if not decision.allowed:
+            continue
+        _append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=link,
+                discovery_method=DiscoveryMethod.LINK,
+                source_locator=fetched.fetched_url,
+                depth=child_depth,
+            ),
+            max_pages=target.max_pages,
+        )
+
+
 def _append_candidate(
     candidates: list[PublicWebDiscoveryCandidate],
     seen: set[str],
@@ -232,9 +299,7 @@ def _map_candidate(
     previous_state = _previous_state(previous)
     if candidate.security_txt:
         if fetched.mime_type != "text/plain":
-            raise PublicWebCollectionDeniedError(
-                "security.txt must be served as text/plain"
-            )
+            raise PublicWebCollectionDeniedError("security.txt must be served as text/plain")
         document = parse_security_txt(fetched.body, target)
         return map_security_txt(
             target,

--- a/src/cip/adapters/sources/public_web/link_discovery.py
+++ b/src/cip/adapters/sources/public_web/link_discovery.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from urllib.parse import urljoin
+
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+
+
+class _AnchorParser(HTMLParser):
+    def __init__(self, *, max_links: int) -> None:
+        super().__init__(convert_charrefs=True)
+        self._max_links = max_links
+        self.links: list[str] = []
+
+    def handle_starttag(
+        self,
+        tag: str,
+        attrs: list[tuple[str, str | None]],
+    ) -> None:
+        if tag.casefold() != "a" or len(self.links) >= self._max_links:
+            return
+        values = {name.casefold(): value for name, value in attrs}
+        href = values.get("href")
+        if href is None or not href.strip():
+            return
+        rel = values.get("rel") or ""
+        if "nofollow" in {part.casefold() for part in rel.split()}:
+            return
+        self.links.append(href)
+
+
+def extract_public_html_links(
+    body: bytes,
+    *,
+    base_url: str,
+    max_links: int,
+) -> tuple[str, ...]:
+    if max_links < 1:
+        return ()
+    parser = _AnchorParser(max_links=max_links)
+    parser.feed(body.decode("utf-8", errors="replace"))
+    parser.close()
+    discovered: list[str] = []
+    seen: set[str] = set()
+    for href in parser.links:
+        try:
+            canonical = CanonicalUrl(urljoin(base_url, href)).value
+        except (TypeError, ValueError):
+            continue
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        discovered.append(canonical)
+        if len(discovered) >= max_links:
+            break
+    return tuple(discovered)

--- a/src/cip/adapters/sources/public_web/provisioning.py
+++ b/src/cip/adapters/sources/public_web/provisioning.py
@@ -37,6 +37,7 @@ class AutomaticPublicWebPolicy:
     expires_at: datetime | None = None
     allowed_path_prefixes: tuple[str, ...] = ("/",)
     refresh_interval_seconds: int = 86_400
+    max_depth: int = 1
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -58,6 +59,8 @@ class AutomaticPublicWebPolicy:
             raise ValueError("allowed_path_prefixes must contain absolute paths")
         if self.refresh_interval_seconds < 60:
             raise ValueError("refresh_interval_seconds must be at least 60")
+        if not 0 <= self.max_depth <= 20:
+            raise ValueError("max_depth must be between 0 and 20")
         object.__setattr__(self, "authorization_reference", reference)
         object.__setattr__(self, "reviewed_at", reviewed)
         object.__setattr__(self, "expires_at", expires)
@@ -97,6 +100,7 @@ def provision_public_web_target(
         authorization_reference=policy.authorization_reference,
         authorization_reviewed_at=policy.reviewed_at,
         authorization_expires_at=policy.expires_at,
+        max_depth=policy.max_depth,
         max_pages=policy.max_pages,
         max_total_bytes=policy.max_total_bytes,
         max_resource_bytes=policy.max_resource_bytes,

--- a/src/cip/adapters/sources/public_web/provisioning.py
+++ b/src/cip/adapters/sources/public_web/provisioning.py
@@ -37,7 +37,7 @@ class AutomaticPublicWebPolicy:
     expires_at: datetime | None = None
     allowed_path_prefixes: tuple[str, ...] = ("/",)
     refresh_interval_seconds: int = 86_400
-    max_depth: int = 1
+    max_link_depth: int = 1
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -59,8 +59,8 @@ class AutomaticPublicWebPolicy:
             raise ValueError("allowed_path_prefixes must contain absolute paths")
         if self.refresh_interval_seconds < 60:
             raise ValueError("refresh_interval_seconds must be at least 60")
-        if not 0 <= self.max_depth <= 20:
-            raise ValueError("max_depth must be between 0 and 20")
+        if not 0 <= self.max_link_depth <= 20:
+            raise ValueError("max_link_depth must be between 0 and 20")
         object.__setattr__(self, "authorization_reference", reference)
         object.__setattr__(self, "reviewed_at", reviewed)
         object.__setattr__(self, "expires_at", expires)
@@ -100,7 +100,7 @@ def provision_public_web_target(
         authorization_reference=policy.authorization_reference,
         authorization_reviewed_at=policy.reviewed_at,
         authorization_expires_at=policy.expires_at,
-        max_depth=policy.max_depth,
+        max_link_depth=policy.max_link_depth,
         max_pages=policy.max_pages,
         max_total_bytes=policy.max_total_bytes,
         max_resource_bytes=policy.max_resource_bytes,

--- a/src/cip/adapters/sources/public_web/registry.py
+++ b/src/cip/adapters/sources/public_web/registry.py
@@ -40,6 +40,7 @@ class PublicWebTarget:
     seed_urls: tuple[str, ...] = ()
     discover_security_txt: bool = False
     source_id: str | None = None
+    max_depth: int = 0
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -78,7 +79,7 @@ class PublicWebTarget:
         scope = CrawlScope(
             allowed_hosts=frozenset({base.host}),
             allowed_path_prefixes=prefixes,
-            max_depth=1,
+            max_depth=self.max_depth,
             max_pages=self.max_pages,
             max_total_bytes=self.max_total_bytes,
             max_resource_bytes=self.max_resource_bytes,
@@ -114,7 +115,7 @@ class PublicWebTarget:
         return CrawlScope(
             allowed_hosts=frozenset({self.host}),
             allowed_path_prefixes=self.allowed_path_prefixes,
-            max_depth=1,
+            max_depth=self.max_depth,
             max_pages=self.max_pages,
             max_total_bytes=self.max_total_bytes,
             max_resource_bytes=self.max_resource_bytes,
@@ -191,6 +192,13 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
             "expires_at",
         ),
         terms_url=_optional_string(payload, "terms_url"),
+        max_depth=_optional_bounded_int(
+            limits,
+            "max_depth",
+            default=0,
+            minimum=0,
+            maximum=20,
+        ),
         max_pages=_bounded_int(limits, "max_pages", minimum=1, maximum=1_000),
         max_total_bytes=_bounded_int(
             limits,
@@ -307,6 +315,24 @@ def _bounded_int(
     maximum: int,
 ) -> int:
     value = payload.get(key)
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not minimum <= value <= maximum
+    ):
+        raise ValueError(f"{key} must be between {minimum} and {maximum}")
+    return value
+
+
+def _optional_bounded_int(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    value = payload.get(key, default)
     if (
         not isinstance(value, int)
         or isinstance(value, bool)

--- a/src/cip/adapters/sources/public_web/registry.py
+++ b/src/cip/adapters/sources/public_web/registry.py
@@ -40,7 +40,7 @@ class PublicWebTarget:
     seed_urls: tuple[str, ...] = ()
     discover_security_txt: bool = False
     source_id: str | None = None
-    max_depth: int = 0
+    max_link_depth: int = 0
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -51,6 +51,8 @@ class PublicWebTarget:
         name = self.canonical_name.strip()
         if not identifier or not name:
             raise ValueError("public web target id and canonical_name are required")
+        if not 0 <= self.max_link_depth <= 20:
+            raise ValueError("max_link_depth must be between 0 and 20")
         base = CanonicalUrl(self.base_url)
         _validate_public_hostname(base.host)
         seeds = _same_origin_urls(base, self.seed_urls, label="seed")
@@ -79,7 +81,7 @@ class PublicWebTarget:
         scope = CrawlScope(
             allowed_hosts=frozenset({base.host}),
             allowed_path_prefixes=prefixes,
-            max_depth=self.max_depth,
+            max_depth=max(1, self.max_link_depth),
             max_pages=self.max_pages,
             max_total_bytes=self.max_total_bytes,
             max_resource_bytes=self.max_resource_bytes,
@@ -115,7 +117,7 @@ class PublicWebTarget:
         return CrawlScope(
             allowed_hosts=frozenset({self.host}),
             allowed_path_prefixes=self.allowed_path_prefixes,
-            max_depth=self.max_depth,
+            max_depth=max(1, self.max_link_depth),
             max_pages=self.max_pages,
             max_total_bytes=self.max_total_bytes,
             max_resource_bytes=self.max_resource_bytes,
@@ -192,9 +194,9 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
             "expires_at",
         ),
         terms_url=_optional_string(payload, "terms_url"),
-        max_depth=_optional_bounded_int(
+        max_link_depth=_optional_bounded_int(
             limits,
-            "max_depth",
+            "max_link_depth",
             default=0,
             minimum=0,
             maximum=20,

--- a/tests/unit/adapters/public_web/test_link_discovery.py
+++ b/tests/unit/adapters/public_web/test_link_discovery.py
@@ -1,0 +1,33 @@
+from cip.adapters.sources.public_web.link_discovery import extract_public_html_links
+
+
+def test_extract_public_html_links_normalizes_deduplicates_and_skips_nofollow() -> None:
+    body = b"""
+    <html><body>
+      <a href="/about#team">About</a>
+      <a href="https://example.com/about">Duplicate</a>
+      <a href="/ignored" rel="nofollow external">Ignored</a>
+      <a href="mailto:security@example.com">Mail</a>
+      <a href="javascript:void(0)">JS</a>
+      <a href="?b=2&a=1">Query</a>
+    </body></html>
+    """
+
+    assert extract_public_html_links(
+        body,
+        base_url="https://example.com/",
+        max_links=10,
+    ) == (
+        "https://example.com/about",
+        "https://example.com/?a=1&b=2",
+    )
+
+
+def test_extract_public_html_links_respects_document_order_and_limit() -> None:
+    body = b'<a href="/one">1</a><a href="/two">2</a><a href="/three">3</a>'
+
+    assert extract_public_html_links(
+        body,
+        base_url="https://example.com/",
+        max_links=2,
+    ) == ("https://example.com/one", "https://example.com/two")

--- a/tests/unit/adapters/public_web/test_provisioning.py
+++ b/tests/unit/adapters/public_web/test_provisioning.py
@@ -61,6 +61,8 @@ def test_provisioning_creates_deterministic_governed_homepage_target() -> None:
     assert target.feed_urls == ()
     assert target.discover_security_txt is True
     assert target.security_txt_url == "https://www.python.org/.well-known/security.txt"
+    assert target.max_depth == 1
+    assert target.crawl_scope.max_depth == 1
     assert target.executable_at(_NOW) is True
     assert provisioned.first_crawl_at == _NOW + timedelta(minutes=5)
     assert provisioned.refresh_interval_seconds == 86_400
@@ -124,7 +126,12 @@ def test_expired_target_fails_closed() -> None:
     assert provisioned.target.executable_at(_NOW + timedelta(hours=2)) is False
 
 
-def test_legacy_target_defaults_source_id_to_target_id() -> None:
+def test_recursive_depth_must_stay_bounded() -> None:
+    with pytest.raises(ValueError, match="max_depth"):
+        _policy(max_depth=21)
+
+
+def test_legacy_target_defaults_source_id_and_recursion_off() -> None:
     target = PublicWebTarget(
         id="legacy-source",
         organization_id=_ORG_ID,
@@ -139,3 +146,4 @@ def test_legacy_target_defaults_source_id_to_target_id() -> None:
     )
 
     assert target.source_id == "legacy-source"
+    assert target.max_depth == 0

--- a/tests/unit/adapters/public_web/test_provisioning.py
+++ b/tests/unit/adapters/public_web/test_provisioning.py
@@ -61,7 +61,7 @@ def test_provisioning_creates_deterministic_governed_homepage_target() -> None:
     assert target.feed_urls == ()
     assert target.discover_security_txt is True
     assert target.security_txt_url == "https://www.python.org/.well-known/security.txt"
-    assert target.max_depth == 1
+    assert target.max_link_depth == 1
     assert target.crawl_scope.max_depth == 1
     assert target.executable_at(_NOW) is True
     assert provisioned.first_crawl_at == _NOW + timedelta(minutes=5)
@@ -126,12 +126,12 @@ def test_expired_target_fails_closed() -> None:
     assert provisioned.target.executable_at(_NOW + timedelta(hours=2)) is False
 
 
-def test_recursive_depth_must_stay_bounded() -> None:
-    with pytest.raises(ValueError, match="max_depth"):
-        _policy(max_depth=21)
+def test_recursive_link_depth_must_stay_bounded() -> None:
+    with pytest.raises(ValueError, match="max_link_depth"):
+        _policy(max_link_depth=21)
 
 
-def test_legacy_target_defaults_source_id_and_recursion_off() -> None:
+def test_legacy_target_keeps_structural_discovery_but_link_recursion_off() -> None:
     target = PublicWebTarget(
         id="legacy-source",
         organization_id=_ORG_ID,
@@ -146,4 +146,5 @@ def test_legacy_target_defaults_source_id_and_recursion_off() -> None:
     )
 
     assert target.source_id == "legacy-source"
-    assert target.max_depth == 0
+    assert target.max_link_depth == 0
+    assert target.crawl_scope.max_depth == 1

--- a/tests/unit/adapters/public_web/test_recursive_collection.py
+++ b/tests/unit/adapters/public_web/test_recursive_collection.py
@@ -19,7 +19,7 @@ _NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
 _ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
 
 
-def _provisioned(*, max_depth: int = 1, max_pages: int = 5):
+def _provisioned(*, max_link_depth: int = 1, max_pages: int = 5):
     organization = Organization(
         id=_ORG_ID,
         canonical_name="Example Research",
@@ -32,7 +32,7 @@ def _provisioned(*, max_depth: int = 1, max_pages: int = 5):
         AutomaticPublicWebPolicy(
             authorization_reference="sa16-l02-test",
             reviewed_at=_NOW,
-            max_depth=max_depth,
+            max_link_depth=max_link_depth,
             max_pages=max_pages,
             max_total_bytes=100_000,
             max_resource_bytes=20_000,
@@ -80,7 +80,7 @@ def _transport(requested: list[str]) -> httpx.MockTransport:
 
 
 def test_recursive_collection_is_same_origin_bounded_and_depth_aware() -> None:
-    target, entry = _provisioned(max_depth=1, max_pages=5)
+    target, entry = _provisioned(max_link_depth=1, max_pages=5)
     requested: list[str] = []
 
     with httpx.Client(transport=_transport(requested)) as http_client:
@@ -108,7 +108,7 @@ def test_recursive_collection_is_same_origin_bounded_and_depth_aware() -> None:
 
 
 def test_recursive_collection_rebuilds_frontier_and_replays_checkpoint_safely() -> None:
-    target, entry = _provisioned(max_depth=2, max_pages=3)
+    target, entry = _provisioned(max_link_depth=2, max_pages=3)
     first_requested: list[str] = []
     with httpx.Client(transport=_transport(first_requested)) as http_client:
         first = collect_public_web_target(

--- a/tests/unit/adapters/public_web/test_recursive_collection.py
+++ b/tests/unit/adapters/public_web/test_recursive_collection.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.provisioning import (
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.public_footprint.domain import DiscoveryMethod
+
+_NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+
+
+def _provisioned(*, max_depth: int = 1, max_pages: int = 5):
+    organization = Organization(
+        id=_ORG_ID,
+        canonical_name="Example Research",
+        website_url="https://example.com/",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l02-test",
+            reviewed_at=_NOW,
+            max_depth=max_depth,
+            max_pages=max_pages,
+            max_total_bytes=100_000,
+            max_resource_bytes=20_000,
+            max_redirects=0,
+        ),
+        first_crawl_at=_NOW,
+    )
+    return replace(provisioned.target, discover_security_txt=False), provisioned.source_entry
+
+
+def _transport(requested: list[str]) -> httpx.MockTransport:
+    pages = {
+        "https://example.com/": b"""
+            <html><head><title>Root</title></head><body>
+              <a href="/child">Child</a>
+              <a href="https://outside.example/path">Outside</a>
+              <a href="/child#duplicate">Duplicate</a>
+            </body></html>
+        """,
+        "https://example.com/child": b"""
+            <html><head><title>Child</title></head><body>
+              <a href="/grandchild">Grandchild</a>
+              <a href="/">Root</a>
+            </body></html>
+        """,
+        "https://example.com/grandchild": b"<html><title>Grandchild</title></html>",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        requested.append(url)
+        if url == "https://example.com/robots.txt":
+            return httpx.Response(404, request=request)
+        body = pages.get(url)
+        if body is None:
+            raise AssertionError(f"unexpected network request: {url}")
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html"},
+            content=body,
+            request=request,
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def test_recursive_collection_is_same_origin_bounded_and_depth_aware() -> None:
+    target, entry = _provisioned(max_depth=1, max_pages=5)
+    requested: list[str] = []
+
+    with httpx.Client(transport=_transport(requested)) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=_NOW,
+            retention_until=_NOW + timedelta(days=30),
+        )
+
+    resource_by_url = {
+        projection.resource.canonical_url: projection.resource for projection in batch.projections
+    }
+    assert set(resource_by_url) == {
+        "https://example.com/",
+        "https://example.com/child",
+    }
+    assert resource_by_url["https://example.com/"].discovery_method is DiscoveryMethod.DIRECT
+    assert resource_by_url["https://example.com/child"].discovery_method is DiscoveryMethod.LINK
+    assert "https://outside.example/path" not in requested
+    assert "https://example.com/grandchild" not in requested
+    assert requested.count("https://example.com/child") == 1
+
+
+def test_recursive_collection_rebuilds_frontier_and_replays_checkpoint_safely() -> None:
+    target, entry = _provisioned(max_depth=2, max_pages=3)
+    first_requested: list[str] = []
+    with httpx.Client(transport=_transport(first_requested)) as http_client:
+        first = collect_public_web_target(
+            PublicWebClient(http_client),
+            entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=_NOW,
+            retention_until=_NOW + timedelta(days=30),
+        )
+
+    assert set(first.checkpoint.pages) == {
+        "https://example.com/",
+        "https://example.com/child",
+        "https://example.com/grandchild",
+    }
+
+    second_requested: list[str] = []
+    with httpx.Client(transport=_transport(second_requested)) as http_client:
+        second = collect_public_web_target(
+            PublicWebClient(http_client),
+            entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=_NOW + timedelta(hours=1),
+            retention_until=_NOW + timedelta(days=30),
+            checkpoint=first.checkpoint,
+        )
+
+    assert second.not_modified is True
+    assert second.observations == ()
+    assert second.checkpoint.pages == first.checkpoint.pages
+    assert "https://example.com/grandchild" in second_requested


### PR DESCRIPTION
Implement SA16-L02 on top of the validated L01 automatic governed target.

Current scope:
- configurable bounded crawl depth for automatic targets, with legacy checked-in targets remaining non-recursive by default;
- static HTML link discovery with canonicalization, deduplication and rel=nofollow handling;
- deterministic breadth-first same-origin/path traversal;
- every child URL re-enters the existing governed PublicWebClient path (robots, crawl scope, redirects, response budgets);
- actual depth passed into CrawlScope instead of the previous hard-coded depth=0;
- cumulative page/byte budgets and existing checkpoint/version replay preserved;
- deterministic tests for depth, same-origin confinement, deduplication and unchanged replay.

Still to add before ready: controlled real-network L02 runner/workflow, closeout documentation, full exact-head CI/live proof and review-thread audit. This PR does not add browser automation; generalized Playwright remains a later SA16 increment.