### PR TITLE
SA16-L03: add governed sitemap and feed discovery

### DIFF
--- a/.github/workflows/sa16-l03-live-validation.yml
+++ b/.github/workflows/sa16-l03-live-validation.yml
@@ -1,0 +1,35 @@
+name: SA-16 L03 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa16-l03-live-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
+jobs:
+  live-structured-public-web-discovery:
+    if: github.event.pull_request.head.ref == 'agent/sa16-l03-structured-discovery'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact pull-request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled sitemap and feed production live validation
+        run: python scripts/live_validate_sa16_l03.py

--- a/docs/source_activation/SA_16_L03_STRUCTURED_DISCOVERY.md
+++ b/docs/source_activation/SA_16_L03_STRUCTURED_DISCOVERY.md
@@ -1,0 +1,60 @@
+# SA-16 L03 — Governed sitemap and feed discovery
+
+## Status
+
+`IMPLEMENTATION_VALIDATION_IN_PROGRESS`.
+
+L03 extends the merged L01/L02 public-web path with structured static discovery. It does not add browser rendering, authenticated sessions, JavaScript extraction, incremental recrawl, freshness scheduling or crawl-health metrics.
+
+## Capability
+
+```text
+robots.txt Sitemap declarations
+-> bounded sitemap queue
+-> sitemapindex recursion
+-> urlset page candidates
+
+HTML <link rel="alternate" type="application/rss+xml|application/atom+xml">
+-> bounded feed queue
+-> RSS/Atom entries
+-> page candidates
+
+all discovered URLs
+-> Source Governance
+-> same-origin/path scope
+-> robots
+-> size/byte/page budgets
+-> existing PublicWebClient
+-> existing provenance/checkpoint mapping
+```
+
+Automatic targets enable structured discovery with conservative limits. Legacy targets keep `discover_sitemaps=false` and `discover_feeds=false` unless explicitly configured.
+
+## Safety invariants
+
+- no blind sitemap/feed URL guessing;
+- robots sitemap declarations are accepted only on the governed target origin and approved path scope;
+- sitemap-index children are same-origin/path filtered and bounded by `max_sitemap_depth` and `max_sitemaps`;
+- HTML feed discovery accepts only declared alternate RSS/Atom MIME types;
+- discovered feeds are same-origin/path filtered and bounded by `max_feeds`;
+- every dynamic sitemap/feed is source-authorized before network I/O;
+- structured discovery bytes count against the target total-byte budget;
+- page candidates still count against `max_pages`;
+- structured discovery metadata remains provenance, not an automatic commercial claim.
+
+## Deterministic validation
+
+Tests cover declared feed extraction, sitemap-index filtering/deduplication/bounds, robots-declared sitemap traversal, nested sitemap traversal, dynamic feed fetch, source locators and off-origin rejection.
+
+## Real live validation
+
+The dedicated exact-head workflow uses two public first-party/neutral Python ecosystem surfaces:
+
+1. `https://docs.python.org/` — the production client reads `robots.txt`, discovers its declared sitemap and requires at least one real page candidate with `DiscoveryMethod.SITEMAP` and sitemap source locator.
+2. `https://blog.python.org/` — the production client reads the homepage, discovers an HTML-declared RSS/Atom feed and requires at least one real page candidate with `DiscoveryMethod.FEED` and feed source locator.
+
+Both cases remain same-origin and bounded. A skipped workflow, mock, configured static feed/sitemap, or another lot's live proof does not satisfy L03.
+
+## Exit gate
+
+L03 is complete only when one final PR head has normal repository CI green, the SA-16 L03 real-network workflow green, zero unresolved review threads, and the squash-merged Git tree is identical to that validated head tree.

--- a/docs/source_activation/SA_16_L03_STRUCTURED_DISCOVERY.md
+++ b/docs/source_activation/SA_16_L03_STRUCTURED_DISCOVERY.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-`IMPLEMENTATION_VALIDATION_IN_PROGRESS`.
+`FINAL_EXACT_HEAD_REVALIDATION_PENDING`.
 
 L03 extends the merged L01/L02 public-web path with structured static discovery. It does not add browser rendering, authenticated sessions, JavaScript extraction, incremental recrawl, freshness scheduling or crawl-health metrics.
+
+The implementation candidate `e7fb55741b18d43f64aa6fd809c6b9163b99ae99` passed normal repository CI run #2019 and the dedicated real-network SA-16 L03 live run #12. Because this documentation update creates a new PR head, those runs are recorded as candidate evidence only. L03 remains open until the new exact head independently passes both gates, has zero unresolved review threads, and its squash-merged Git tree is identical to the validated head tree.
 
 ## Capability
 
@@ -19,7 +21,7 @@ HTML <link rel="alternate" type="application/rss+xml|application/atom+xml">
 -> RSS/Atom entries
 -> page candidates
 
-all discovered URLs
+all dynamically discovered URLs
 -> Source Governance
 -> same-origin/path scope
 -> robots
@@ -29,6 +31,8 @@ all discovered URLs
 ```
 
 Automatic targets enable structured discovery with conservative limits. Legacy targets keep `discover_sitemaps=false` and `discover_feeds=false` unless explicitly configured.
+
+Explicitly configured sitemap/feed URLs retain the pre-L03 contract: they are still checked against robots and network-response safety controls, while the new same-origin/path discovery scope is applied to dynamically discovered structured URLs. This preserves existing configured targets without weakening the dynamic-discovery fail-closed path.
 
 ## Safety invariants
 
@@ -40,18 +44,23 @@ Automatic targets enable structured discovery with conservative limits. Legacy t
 - every dynamic sitemap/feed is source-authorized before network I/O;
 - structured discovery bytes count against the target total-byte budget;
 - page candidates still count against `max_pages`;
-- structured discovery metadata remains provenance, not an automatic commercial claim.
+- structured discovery metadata remains provenance, not an automatic commercial claim;
+- page versions discovered from a sitemap or feed retain the structured discovery URL in `source_locator` while keeping the fetched page URL as the version `source_url`.
 
 ## Deterministic validation
 
-Tests cover declared feed extraction, sitemap-index filtering/deduplication/bounds, robots-declared sitemap traversal, nested sitemap traversal, dynamic feed fetch, source locators and off-origin rejection.
+Tests cover declared feed extraction, sitemap-index filtering/deduplication/bounds, robots-declared sitemap traversal, nested sitemap traversal, dynamic feed fetch, explicit configured sitemap/feed compatibility, source locators and off-origin rejection.
+
+The validated candidate passed the repository's Ruff, strict Mypy, architecture/release-contract, reversible-migration, frontend, full test and coverage gates in CI #2019. These results must be repeated on the final documentation head before merge.
 
 ## Real live validation
 
 The dedicated exact-head workflow uses two public first-party/neutral Python ecosystem surfaces:
 
-1. `https://docs.python.org/` — the production client reads `robots.txt`, discovers its declared sitemap and requires at least one real page candidate with `DiscoveryMethod.SITEMAP` and sitemap source locator.
-2. `https://blog.python.org/` — the production client reads the homepage, discovers an HTML-declared RSS/Atom feed and requires at least one real page candidate with `DiscoveryMethod.FEED` and feed source locator.
+1. `https://docs.python.org/` — the production client reads `robots.txt`, discovers its declared sitemap and requires real page candidates with `DiscoveryMethod.SITEMAP` and sitemap source locators.
+2. `https://blog.python.org/` — the production client reads the homepage, discovers an HTML-declared RSS/Atom feed and requires real page candidates with `DiscoveryMethod.FEED` and feed source locators.
+
+On candidate `e7fb55741b18d43f64aa6fd809c6b9163b99ae99`, live run #12 checked out that exact SHA and completed with `robots_sitemap_pages=4` and `html_feed_pages=4`.
 
 Both cases remain same-origin and bounded. A skipped workflow, mock, configured static feed/sitemap, or another lot's live proof does not satisfy L03.
 

--- a/scripts/live_validate_sa16_l03.py
+++ b/scripts/live_validate_sa16_l03.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.provisioning import (
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.public_footprint.domain import DiscoveryMethod
+from cip.modules.public_footprint.domain.url_identity import same_origin
+
+_DOCS_ORG_ID = UUID("65aa3ec1-1c46-5f64-9192-591abae9ca0a")
+_BLOG_ORG_ID = UUID("3679ab63-e441-5445-bdb2-5ec2f760f752")
+
+
+def main() -> None:
+    now = datetime.now(UTC)
+    sitemap_count = _run_sitemap_case(now)
+    feed_count = _run_feed_case(now)
+    print(
+        "SA-16 L03 live validation passed: "
+        f"robots_sitemap_pages={sitemap_count} html_feed_pages={feed_count}"
+    )
+
+
+def _run_sitemap_case(now: datetime) -> int:
+    origin = "https://docs.python.org/"
+    organization = Organization(
+        id=_DOCS_ORG_ID,
+        canonical_name="Python Documentation",
+        website_url=origin,
+        created_at=now,
+        updated_at=now,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l03-python-docs-sitemap",
+            reviewed_at=now,
+            max_link_depth=0,
+            discover_sitemaps=True,
+            discover_feeds=False,
+            max_sitemap_depth=2,
+            max_sitemaps=8,
+            max_feeds=1,
+            max_pages=5,
+            max_total_bytes=5_000_000,
+            max_resource_bytes=1_000_000,
+            max_redirects=1,
+        ),
+        first_crawl_at=now,
+    )
+    target = replace(provisioned.target, discover_security_txt=False)
+    with httpx.Client(timeout=30.0) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            provisioned.source_entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=now,
+            retention_until=now + timedelta(days=365),
+        )
+    sitemap_pages = [
+        projection
+        for projection in batch.projections
+        if projection.resource.discovery_method is DiscoveryMethod.SITEMAP
+    ]
+    if not sitemap_pages:
+        raise RuntimeError("SA16-L03 did not traverse a robots-declared Python docs sitemap")
+    if any(not same_origin(origin, item.resource.canonical_url) for item in batch.projections):
+        raise RuntimeError("SA16-L03 sitemap traversal escaped the approved origin")
+    if any(item.version.source_locator is None for item in sitemap_pages):
+        raise RuntimeError("SA16-L03 sitemap page lost its sitemap source locator")
+    return len(sitemap_pages)
+
+
+def _run_feed_case(now: datetime) -> int:
+    origin = "https://blog.python.org/"
+    organization = Organization(
+        id=_BLOG_ORG_ID,
+        canonical_name="Python Insider",
+        website_url=origin,
+        created_at=now,
+        updated_at=now,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l03-python-insider-feed",
+            reviewed_at=now,
+            max_link_depth=0,
+            discover_sitemaps=False,
+            discover_feeds=True,
+            max_sitemap_depth=0,
+            max_sitemaps=1,
+            max_feeds=3,
+            max_pages=5,
+            max_total_bytes=4_000_000,
+            max_resource_bytes=1_000_000,
+            max_redirects=1,
+        ),
+        first_crawl_at=now,
+    )
+    target = replace(provisioned.target, discover_security_txt=False)
+    with httpx.Client(timeout=30.0) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            provisioned.source_entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=now,
+            retention_until=now + timedelta(days=365),
+        )
+    feed_pages = [
+        projection
+        for projection in batch.projections
+        if projection.resource.discovery_method is DiscoveryMethod.FEED
+    ]
+    if not feed_pages:
+        raise RuntimeError("SA16-L03 did not traverse an HTML-declared Python Insider feed")
+    if any(not same_origin(origin, item.resource.canonical_url) for item in batch.projections):
+        raise RuntimeError("SA16-L03 feed traversal escaped the approved origin")
+    if any(item.version.source_locator is None for item in feed_pages):
+        raise RuntimeError("SA16-L03 feed page lost its feed source locator")
+    return len(feed_pages)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/public_web/client.py
+++ b/src/cip/adapters/sources/public_web/client.py
@@ -113,9 +113,16 @@ class PublicWebClient:
     ) -> PublicWebFetchResult:
         canonical = CanonicalUrl(sitemap_url).value
         explicit = canonical in target.sitemap_urls
-        if not explicit and not (discovered and target.discover_sitemaps):
-            raise PublicWebPolicyDeniedError("sitemap URL is not configured or discoverable")
-        _require_structured_url_in_scope(target, canonical)
+        if not explicit:
+            if not discovered:
+                raise PublicWebPolicyDeniedError(
+                    "sitemap URL is not explicitly configured"
+                )
+            if not target.discover_sitemaps:
+                raise PublicWebPolicyDeniedError(
+                    "sitemap URL is not configured or discoverable"
+                )
+            _require_structured_url_in_scope(target, canonical)
         if not robots.allows(canonical):
             raise PublicWebPolicyDeniedError("robots.txt denied sitemap collection")
         response = self._client.get(
@@ -157,9 +164,14 @@ class PublicWebClient:
     ) -> PublicWebFetchResult:
         canonical = CanonicalUrl(feed_url).value
         explicit = canonical in target.feed_urls
-        if not explicit and not (discovered and target.discover_feeds):
-            raise PublicWebPolicyDeniedError("feed URL is not configured or discoverable")
-        _require_structured_url_in_scope(target, canonical)
+        if not explicit:
+            if not discovered:
+                raise PublicWebPolicyDeniedError("feed URL is not explicitly configured")
+            if not target.discover_feeds:
+                raise PublicWebPolicyDeniedError(
+                    "feed URL is not configured or discoverable"
+                )
+            _require_structured_url_in_scope(target, canonical)
         if not robots.allows(canonical):
             raise PublicWebPolicyDeniedError("robots.txt denied feed collection")
         response = self._client.get(

--- a/src/cip/adapters/sources/public_web/client.py
+++ b/src/cip/adapters/sources/public_web/client.py
@@ -9,7 +9,7 @@ import httpx
 from cip import __version__
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.public_footprint.domain.scope import CrawlUsage
-from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl, same_origin
 
 _USER_AGENT = f"CyberIntelligencePlatform/{__version__} (+public-evidence-collector)"
 _REDIRECT_STATUSES = {
@@ -54,6 +54,7 @@ class RobotsRules:
     source_url: str
     missing: bool
     bytes_fetched: int
+    sitemap_urls: tuple[str, ...] = ()
 
     def allows(self, url: str) -> bool:
         return self.missing or self.parser.can_fetch(_USER_AGENT, url)
@@ -90,14 +91,16 @@ class PublicWebClient:
         if mime_type not in {"text/plain", "application/octet-stream"}:
             raise PublicWebResponseError("robots.txt returned an unexpected content type")
         body = _bounded_body(response, max_bytes=self.ROBOTS_MAX_BYTES)
+        lines = body.decode("utf-8", errors="replace").splitlines()
         parser = RobotFileParser()
         parser.set_url(target.robots_url)
-        parser.parse(body.decode("utf-8", errors="replace").splitlines())
+        parser.parse(lines)
         return RobotsRules(
             parser,
             target.robots_url,
             missing=False,
             bytes_fetched=len(body),
+            sitemap_urls=_robots_sitemaps(lines, target, max_sitemaps=target.max_sitemaps),
         )
 
     def fetch_sitemap(
@@ -105,10 +108,14 @@ class PublicWebClient:
         target: PublicWebTarget,
         sitemap_url: str,
         robots: RobotsRules,
+        *,
+        discovered: bool = False,
     ) -> PublicWebFetchResult:
         canonical = CanonicalUrl(sitemap_url).value
-        if canonical not in target.sitemap_urls:
-            raise PublicWebPolicyDeniedError("sitemap URL is not explicitly configured")
+        explicit = canonical in target.sitemap_urls
+        if not explicit and not (discovered and target.discover_sitemaps):
+            raise PublicWebPolicyDeniedError("sitemap URL is not configured or discoverable")
+        _require_structured_url_in_scope(target, canonical)
         if not robots.allows(canonical):
             raise PublicWebPolicyDeniedError("robots.txt denied sitemap collection")
         response = self._client.get(
@@ -145,10 +152,14 @@ class PublicWebClient:
         target: PublicWebTarget,
         feed_url: str,
         robots: RobotsRules,
+        *,
+        discovered: bool = False,
     ) -> PublicWebFetchResult:
         canonical = CanonicalUrl(feed_url).value
-        if canonical not in target.feed_urls:
-            raise PublicWebPolicyDeniedError("feed URL is not explicitly configured")
+        explicit = canonical in target.feed_urls
+        if not explicit and not (discovered and target.discover_feeds):
+            raise PublicWebPolicyDeniedError("feed URL is not configured or discoverable")
+        _require_structured_url_in_scope(target, canonical)
         if not robots.allows(canonical):
             raise PublicWebPolicyDeniedError("robots.txt denied feed collection")
         response = self._client.get(
@@ -248,6 +259,48 @@ class PublicWebClient:
                 redirects=redirects,
                 status_code=response.status_code,
             )
+
+
+def _robots_sitemaps(
+    lines: list[str],
+    target: PublicWebTarget,
+    *,
+    max_sitemaps: int,
+) -> tuple[str, ...]:
+    if not target.discover_sitemaps:
+        return ()
+    discovered: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        key, separator, value = line.partition(":")
+        if not separator or key.strip().casefold() != "sitemap":
+            continue
+        try:
+            canonical = CanonicalUrl(value.strip()).value
+        except ValueError:
+            continue
+        if not same_origin(target.base_url, canonical) or canonical in seen:
+            continue
+        try:
+            _require_structured_url_in_scope(target, canonical)
+        except PublicWebPolicyDeniedError:
+            continue
+        seen.add(canonical)
+        discovered.append(canonical)
+        if len(discovered) >= max_sitemaps:
+            break
+    return tuple(discovered)
+
+
+def _require_structured_url_in_scope(target: PublicWebTarget, url: str) -> None:
+    decision = target.crawl_scope.evaluate_target(
+        url,
+        depth=0,
+        redirects=0,
+        usage=CrawlUsage(),
+    )
+    if not decision.allowed:
+        raise PublicWebPolicyDeniedError(decision.reason.value)
 
 
 def _header(response: httpx.Response, name: str) -> str | None:

--- a/src/cip/adapters/sources/public_web/collection_policy.py
+++ b/src/cip/adapters/sources/public_web/collection_policy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.source_governance.domain.models import (
+    CollectionRequest,
+    DataCategory,
+    SourceRuntimeState,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+class PublicWebCollectionDeniedError(RuntimeError):
+    """Source or target governance denied public-web collection."""
+
+
+def authorize_public_web_url(
+    entry: SourceRegistryEntry,
+    target_url: str,
+    *,
+    now: datetime,
+) -> None:
+    decision = entry.policy.evaluate(
+        CollectionRequest(
+            data_category=DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,
+            target_url=target_url,
+            purpose="corporate-public-footprint",
+            automated=True,
+            store_raw_content=False,
+            human_review_completed=False,
+        ),
+        entry.authorization,
+        SourceRuntimeState(remaining_requests=1),
+        now=now,
+    )
+    if not decision.allowed:
+        raise PublicWebCollectionDeniedError(decision.reason.value)
+
+
+def checked_total_bytes(target: PublicWebTarget, value: int) -> int:
+    if value > target.max_total_bytes:
+        raise PublicWebCollectionDeniedError("total_byte_budget_exceeded")
+    return value

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -10,13 +10,16 @@ from cip.adapters.sources.public_web.client import (
     RobotsRules,
 )
 from cip.adapters.sources.public_web.feed_parsing import parse_public_feed
-from cip.adapters.sources.public_web.link_discovery import extract_public_html_links
+from cip.adapters.sources.public_web.link_discovery import (
+    extract_public_feed_links,
+    extract_public_html_links,
+)
 from cip.adapters.sources.public_web.mapper import (
     MappedPublicPage,
     PreviousPageState,
     map_public_page,
 )
-from cip.adapters.sources.public_web.parsing import parse_sitemap
+from cip.adapters.sources.public_web.parsing import parse_sitemap_document
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.public_web.security_txt import parse_security_txt
 from cip.adapters.sources.public_web.security_txt_mapper import map_security_txt
@@ -88,7 +91,7 @@ def collect_public_web_target(
         raise PublicWebCollectionDeniedError("target_authorization_inactive")
     _authorize(entry, target.robots_url, now=collected)
     robots = client.fetch_robots(target)
-    initial_candidates, discovery_bytes = _discover_candidates(
+    initial_candidates, discovery_bytes, seen_feeds = _discover_candidates(
         client,
         entry,
         target,
@@ -143,6 +146,18 @@ def collect_public_web_target(
             canonical_url=fetched.fetched_url,
             resource_kind=mapped.projection.resource.kind,
         )
+        usage = _discover_html_feeds(
+            client,
+            entry,
+            target,
+            robots,
+            fetched,
+            candidates,
+            seen,
+            seen_feeds,
+            usage=usage,
+            now=collected,
+        )
         _discover_recursive_links(
             target,
             candidate,
@@ -166,7 +181,7 @@ def _discover_candidates(
     *,
     now: datetime,
     initial_bytes: int,
-) -> tuple[tuple[PublicWebDiscoveryCandidate, ...], int]:
+) -> tuple[tuple[PublicWebDiscoveryCandidate, ...], int, set[str]]:
     candidates: list[PublicWebDiscoveryCandidate] = []
     seen: set[str] = set()
     total_bytes = _checked_total_bytes(target, initial_bytes)
@@ -191,42 +206,174 @@ def _discover_candidates(
             ),
             max_pages=target.max_pages,
         )
-    for sitemap_url in target.sitemap_urls:
+    total_bytes = _discover_sitemap_candidates(
+        client,
+        entry,
+        target,
+        robots,
+        candidates,
+        seen,
+        now=now,
+        total_bytes=total_bytes,
+    )
+    seen_feeds = set(target.feed_urls)
+    for feed_url in target.feed_urls:
         if len(candidates) >= target.max_pages:
             break
+        total_bytes = _consume_feed(
+            client,
+            entry,
+            target,
+            robots,
+            feed_url,
+            candidates,
+            seen,
+            now=now,
+            total_bytes=total_bytes,
+            discovered=False,
+        )
+    return tuple(candidates), total_bytes, seen_feeds
+
+
+def _discover_sitemap_candidates(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    *,
+    now: datetime,
+    total_bytes: int,
+) -> int:
+    queue: list[tuple[str, int, bool]] = [
+        (url, 0, False) for url in target.sitemap_urls
+    ]
+    if target.discover_sitemaps:
+        queue.extend((url, 0, True) for url in robots.sitemap_urls)
+    seen_sitemaps: set[str] = set()
+    index = 0
+    while index < len(queue) and len(seen_sitemaps) < target.max_sitemaps:
+        sitemap_url, depth, discovered = queue[index]
+        index += 1
+        if sitemap_url in seen_sitemaps:
+            continue
+        seen_sitemaps.add(sitemap_url)
         _authorize(entry, sitemap_url, now=now)
-        sitemap = client.fetch_sitemap(target, sitemap_url, robots)
+        sitemap = client.fetch_sitemap(
+            target,
+            sitemap_url,
+            robots,
+            discovered=discovered,
+        )
         total_bytes = _checked_total_bytes(target, total_bytes + len(sitemap.body))
-        remaining = target.max_pages - len(candidates)
-        for sitemap_entry in parse_sitemap(sitemap.body, target, max_entries=remaining):
+        remaining_pages = max(1, target.max_pages - len(candidates))
+        remaining_sitemaps = max(1, target.max_sitemaps - len(seen_sitemaps))
+        document = parse_sitemap_document(
+            sitemap.body,
+            target,
+            max_entries=remaining_pages,
+            max_child_sitemaps=remaining_sitemaps,
+        )
+        for sitemap_entry in document.entries:
             _append_candidate(
                 candidates,
                 seen,
                 PublicWebDiscoveryCandidate(
                     url=sitemap_entry.url,
                     discovery_method=DiscoveryMethod.SITEMAP,
+                    source_locator=sitemap_url,
                 ),
                 max_pages=target.max_pages,
             )
-    for feed_url in target.feed_urls:
-        if len(candidates) >= target.max_pages:
+        if depth >= target.max_sitemap_depth:
+            continue
+        for child_url in document.child_sitemaps:
+            if child_url in seen_sitemaps or len(queue) >= target.max_sitemaps:
+                continue
+            queue.append((child_url, depth + 1, True))
+    return total_bytes
+
+
+def _discover_html_feeds(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    fetched: PublicWebFetchResult,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    seen_feeds: set[str],
+    *,
+    usage: CrawlUsage,
+    now: datetime,
+) -> CrawlUsage:
+    remaining_feeds = target.max_feeds - len(seen_feeds)
+    if (
+        not target.discover_feeds
+        or fetched.mime_type != "text/html"
+        or remaining_feeds <= 0
+        or len(candidates) >= target.max_pages
+    ):
+        return usage
+    feed_urls = extract_public_feed_links(
+        fetched.body,
+        base_url=fetched.fetched_url,
+        max_feeds=remaining_feeds,
+    )
+    total_bytes = usage.bytes_fetched
+    for feed_url in feed_urls:
+        if feed_url in seen_feeds or not same_origin(target.base_url, feed_url):
+            continue
+        seen_feeds.add(feed_url)
+        total_bytes = _consume_feed(
+            client,
+            entry,
+            target,
+            robots,
+            feed_url,
+            candidates,
+            seen,
+            now=now,
+            total_bytes=total_bytes,
+            discovered=True,
+        )
+        if len(seen_feeds) >= target.max_feeds or len(candidates) >= target.max_pages:
             break
-        _authorize(entry, feed_url, now=now)
-        feed = client.fetch_feed(target, feed_url, robots)
-        total_bytes = _checked_total_bytes(target, total_bytes + len(feed.body))
-        remaining = target.max_pages - len(candidates)
-        for feed_entry in parse_public_feed(feed.body, target, max_entries=remaining):
-            _append_candidate(
-                candidates,
-                seen,
-                PublicWebDiscoveryCandidate(
-                    url=feed_entry.url,
-                    discovery_method=DiscoveryMethod.FEED,
-                    source_locator=feed_url,
-                ),
-                max_pages=target.max_pages,
-            )
-    return tuple(candidates), total_bytes
+    return CrawlUsage(pages_fetched=usage.pages_fetched, bytes_fetched=total_bytes)
+
+
+def _consume_feed(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    feed_url: str,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    *,
+    now: datetime,
+    total_bytes: int,
+    discovered: bool,
+) -> int:
+    _authorize(entry, feed_url, now=now)
+    feed = client.fetch_feed(target, feed_url, robots, discovered=discovered)
+    total_bytes = _checked_total_bytes(target, total_bytes + len(feed.body))
+    remaining = target.max_pages - len(candidates)
+    if remaining <= 0:
+        return total_bytes
+    for feed_entry in parse_public_feed(feed.body, target, max_entries=remaining):
+        _append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=feed_entry.url,
+                discovery_method=DiscoveryMethod.FEED,
+                source_locator=feed_url,
+            ),
+            max_pages=target.max_pages,
+        )
+    return total_bytes
 
 
 def _discover_recursive_links(

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -4,44 +4,30 @@ from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from cip.adapters.sources.public_web.client import (
-    PublicWebClient,
-    PublicWebFetchResult,
-    RobotsRules,
+from cip.adapters.sources.public_web.client import PublicWebClient, PublicWebFetchResult
+from cip.adapters.sources.public_web.collection_policy import (
+    PublicWebCollectionDeniedError,
+    authorize_public_web_url,
 )
-from cip.adapters.sources.public_web.feed_parsing import parse_public_feed
-from cip.adapters.sources.public_web.link_discovery import (
-    extract_public_feed_links,
-    extract_public_html_links,
+from cip.adapters.sources.public_web.discovery import (
+    PublicWebDiscoveryCandidate,
+    discover_html_feeds,
+    discover_initial_candidates,
+    discover_recursive_links,
 )
 from cip.adapters.sources.public_web.mapper import (
     MappedPublicPage,
     PreviousPageState,
     map_public_page,
 )
-from cip.adapters.sources.public_web.parsing import parse_sitemap_document
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.public_web.security_txt import parse_security_txt
 from cip.adapters.sources.public_web.security_txt_mapper import map_security_txt
-from cip.modules.public_footprint.domain import (
-    DiscoveryMethod,
-    PublicFootprintProjection,
-    PublicResourceKind,
-)
+from cip.modules.public_footprint.domain import PublicFootprintProjection, PublicResourceKind
 from cip.modules.public_footprint.domain.scope import CrawlUsage
-from cip.modules.public_footprint.domain.url_identity import same_origin
 from cip.modules.raw_observations.domain.entities import RawObservation
-from cip.modules.source_governance.domain.models import (
-    CollectionRequest,
-    DataCategory,
-    SourceRuntimeState,
-)
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 from cip.shared.kernel.time import require_aware_utc
-
-
-class PublicWebCollectionDeniedError(RuntimeError):
-    """Source or target governance denied public-web collection."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,15 +51,6 @@ class PublicWebCollectionBatch:
     not_modified: bool
 
 
-@dataclass(frozen=True, slots=True)
-class PublicWebDiscoveryCandidate:
-    url: str
-    discovery_method: DiscoveryMethod
-    source_locator: str | None = None
-    security_txt: bool = False
-    depth: int = 0
-
-
 def collect_public_web_target(
     client: PublicWebClient,
     entry: SourceRegistryEntry,
@@ -89,9 +66,9 @@ def collect_public_web_target(
         raise ValueError("public web source policy and target source_id must match")
     if not target.executable_at(collected):
         raise PublicWebCollectionDeniedError("target_authorization_inactive")
-    _authorize(entry, target.robots_url, now=collected)
+    authorize_public_web_url(entry, target.robots_url, now=collected)
     robots = client.fetch_robots(target)
-    initial_candidates, discovery_bytes, seen_feeds = _discover_candidates(
+    initial_candidates, discovery_bytes, seen_feeds = discover_initial_candidates(
         client,
         entry,
         target,
@@ -112,7 +89,7 @@ def collect_public_web_target(
         index += 1
         if usage.pages_fetched >= target.max_pages:
             break
-        _authorize(entry, candidate.url, now=collected)
+        authorize_public_web_url(entry, candidate.url, now=collected)
         fetched = client.fetch_page(
             target,
             candidate.url,
@@ -139,14 +116,13 @@ def collect_public_web_target(
         if mapped.observation is not None:
             observations.append(mapped.observation)
         projections.append(mapped.projection)
-        checkpoint_version_id = _checkpoint_version_id(previous, mapped, fetched)
         next_pages[candidate.url] = PageCheckpoint(
             content_hash_sha256=mapped.content_hash_sha256,
-            version_id=checkpoint_version_id,
+            version_id=_checkpoint_version_id(previous, mapped, fetched),
             canonical_url=fetched.fetched_url,
             resource_kind=mapped.projection.resource.kind,
         )
-        usage = _discover_html_feeds(
+        usage = discover_html_feeds(
             client,
             entry,
             target,
@@ -158,279 +134,13 @@ def collect_public_web_target(
             usage=usage,
             now=collected,
         )
-        _discover_recursive_links(
-            target,
-            candidate,
-            fetched,
-            candidates,
-            seen,
-        )
+        discover_recursive_links(target, candidate, fetched, candidates, seen)
     return PublicWebCollectionBatch(
         observations=tuple(observations),
         projections=tuple(projections),
         checkpoint=PublicWebCheckpoint(next_pages),
         not_modified=not observations,
     )
-
-
-def _discover_candidates(
-    client: PublicWebClient,
-    entry: SourceRegistryEntry,
-    target: PublicWebTarget,
-    robots: RobotsRules,
-    *,
-    now: datetime,
-    initial_bytes: int,
-) -> tuple[tuple[PublicWebDiscoveryCandidate, ...], int, set[str]]:
-    candidates: list[PublicWebDiscoveryCandidate] = []
-    seen: set[str] = set()
-    total_bytes = _checked_total_bytes(target, initial_bytes)
-    for seed_url in target.seed_urls:
-        _append_candidate(
-            candidates,
-            seen,
-            PublicWebDiscoveryCandidate(
-                url=seed_url,
-                discovery_method=DiscoveryMethod.DIRECT,
-            ),
-            max_pages=target.max_pages,
-        )
-    if target.discover_security_txt:
-        _append_candidate(
-            candidates,
-            seen,
-            PublicWebDiscoveryCandidate(
-                url=target.security_txt_url,
-                discovery_method=DiscoveryMethod.DIRECT,
-                security_txt=True,
-            ),
-            max_pages=target.max_pages,
-        )
-    total_bytes = _discover_sitemap_candidates(
-        client,
-        entry,
-        target,
-        robots,
-        candidates,
-        seen,
-        now=now,
-        total_bytes=total_bytes,
-    )
-    seen_feeds = set(target.feed_urls)
-    for feed_url in target.feed_urls:
-        if len(candidates) >= target.max_pages:
-            break
-        total_bytes = _consume_feed(
-            client,
-            entry,
-            target,
-            robots,
-            feed_url,
-            candidates,
-            seen,
-            now=now,
-            total_bytes=total_bytes,
-            discovered=False,
-        )
-    return tuple(candidates), total_bytes, seen_feeds
-
-
-def _discover_sitemap_candidates(
-    client: PublicWebClient,
-    entry: SourceRegistryEntry,
-    target: PublicWebTarget,
-    robots: RobotsRules,
-    candidates: list[PublicWebDiscoveryCandidate],
-    seen: set[str],
-    *,
-    now: datetime,
-    total_bytes: int,
-) -> int:
-    queue: list[tuple[str, int, bool]] = [
-        (url, 0, False) for url in target.sitemap_urls
-    ]
-    if target.discover_sitemaps:
-        queue.extend((url, 0, True) for url in robots.sitemap_urls)
-    seen_sitemaps: set[str] = set()
-    index = 0
-    while index < len(queue) and len(seen_sitemaps) < target.max_sitemaps:
-        sitemap_url, depth, discovered = queue[index]
-        index += 1
-        if sitemap_url in seen_sitemaps:
-            continue
-        seen_sitemaps.add(sitemap_url)
-        _authorize(entry, sitemap_url, now=now)
-        sitemap = client.fetch_sitemap(
-            target,
-            sitemap_url,
-            robots,
-            discovered=discovered,
-        )
-        total_bytes = _checked_total_bytes(target, total_bytes + len(sitemap.body))
-        remaining_pages = max(1, target.max_pages - len(candidates))
-        remaining_sitemaps = max(1, target.max_sitemaps - len(seen_sitemaps))
-        document = parse_sitemap_document(
-            sitemap.body,
-            target,
-            max_entries=remaining_pages,
-            max_child_sitemaps=remaining_sitemaps,
-        )
-        for sitemap_entry in document.entries:
-            _append_candidate(
-                candidates,
-                seen,
-                PublicWebDiscoveryCandidate(
-                    url=sitemap_entry.url,
-                    discovery_method=DiscoveryMethod.SITEMAP,
-                    source_locator=sitemap_url,
-                ),
-                max_pages=target.max_pages,
-            )
-        if depth >= target.max_sitemap_depth:
-            continue
-        for child_url in document.child_sitemaps:
-            if child_url in seen_sitemaps or len(queue) >= target.max_sitemaps:
-                continue
-            queue.append((child_url, depth + 1, True))
-    return total_bytes
-
-
-def _discover_html_feeds(
-    client: PublicWebClient,
-    entry: SourceRegistryEntry,
-    target: PublicWebTarget,
-    robots: RobotsRules,
-    fetched: PublicWebFetchResult,
-    candidates: list[PublicWebDiscoveryCandidate],
-    seen: set[str],
-    seen_feeds: set[str],
-    *,
-    usage: CrawlUsage,
-    now: datetime,
-) -> CrawlUsage:
-    remaining_feeds = target.max_feeds - len(seen_feeds)
-    if (
-        not target.discover_feeds
-        or fetched.mime_type != "text/html"
-        or remaining_feeds <= 0
-        or len(candidates) >= target.max_pages
-    ):
-        return usage
-    feed_urls = extract_public_feed_links(
-        fetched.body,
-        base_url=fetched.fetched_url,
-        max_feeds=remaining_feeds,
-    )
-    total_bytes = usage.bytes_fetched
-    for feed_url in feed_urls:
-        if feed_url in seen_feeds or not same_origin(target.base_url, feed_url):
-            continue
-        seen_feeds.add(feed_url)
-        total_bytes = _consume_feed(
-            client,
-            entry,
-            target,
-            robots,
-            feed_url,
-            candidates,
-            seen,
-            now=now,
-            total_bytes=total_bytes,
-            discovered=True,
-        )
-        if len(seen_feeds) >= target.max_feeds or len(candidates) >= target.max_pages:
-            break
-    return CrawlUsage(pages_fetched=usage.pages_fetched, bytes_fetched=total_bytes)
-
-
-def _consume_feed(
-    client: PublicWebClient,
-    entry: SourceRegistryEntry,
-    target: PublicWebTarget,
-    robots: RobotsRules,
-    feed_url: str,
-    candidates: list[PublicWebDiscoveryCandidate],
-    seen: set[str],
-    *,
-    now: datetime,
-    total_bytes: int,
-    discovered: bool,
-) -> int:
-    _authorize(entry, feed_url, now=now)
-    feed = client.fetch_feed(target, feed_url, robots, discovered=discovered)
-    total_bytes = _checked_total_bytes(target, total_bytes + len(feed.body))
-    remaining = target.max_pages - len(candidates)
-    if remaining <= 0:
-        return total_bytes
-    for feed_entry in parse_public_feed(feed.body, target, max_entries=remaining):
-        _append_candidate(
-            candidates,
-            seen,
-            PublicWebDiscoveryCandidate(
-                url=feed_entry.url,
-                discovery_method=DiscoveryMethod.FEED,
-                source_locator=feed_url,
-            ),
-            max_pages=target.max_pages,
-        )
-    return total_bytes
-
-
-def _discover_recursive_links(
-    target: PublicWebTarget,
-    candidate: PublicWebDiscoveryCandidate,
-    fetched: PublicWebFetchResult,
-    candidates: list[PublicWebDiscoveryCandidate],
-    seen: set[str],
-) -> None:
-    child_depth = candidate.depth + 1
-    remaining = target.max_pages - len(candidates)
-    if (
-        fetched.mime_type != "text/html"
-        or child_depth > target.max_link_depth
-        or remaining <= 0
-    ):
-        return
-    links = extract_public_html_links(
-        fetched.body,
-        base_url=fetched.fetched_url,
-        max_links=remaining,
-    )
-    for link in links:
-        if not same_origin(target.base_url, link):
-            continue
-        decision = target.crawl_scope.evaluate_target(
-            link,
-            depth=child_depth,
-            redirects=0,
-            usage=CrawlUsage(),
-        )
-        if not decision.allowed:
-            continue
-        _append_candidate(
-            candidates,
-            seen,
-            PublicWebDiscoveryCandidate(
-                url=link,
-                discovery_method=DiscoveryMethod.LINK,
-                source_locator=fetched.fetched_url,
-                depth=child_depth,
-            ),
-            max_pages=target.max_pages,
-        )
-
-
-def _append_candidate(
-    candidates: list[PublicWebDiscoveryCandidate],
-    seen: set[str],
-    candidate: PublicWebDiscoveryCandidate,
-    *,
-    max_pages: int,
-) -> None:
-    if len(candidates) >= max_pages or candidate.url in seen:
-        return
-    seen.add(candidate.url)
-    candidates.append(candidate)
 
 
 def _map_candidate(
@@ -494,27 +204,3 @@ def _checkpoint_version_id(
     if unchanged and previous is not None:
         return previous.version_id
     return mapped.projection.version.id
-
-
-def _checked_total_bytes(target: PublicWebTarget, value: int) -> int:
-    if value > target.max_total_bytes:
-        raise PublicWebCollectionDeniedError("total_byte_budget_exceeded")
-    return value
-
-
-def _authorize(entry: SourceRegistryEntry, target_url: str, *, now: datetime) -> None:
-    decision = entry.policy.evaluate(
-        CollectionRequest(
-            data_category=DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,
-            target_url=target_url,
-            purpose="corporate-public-footprint",
-            automated=True,
-            store_raw_content=False,
-            human_review_completed=False,
-        ),
-        entry.authorization,
-        SourceRuntimeState(remaining_requests=1),
-        now=now,
-    )
-    if not decision.allowed:
-        raise PublicWebCollectionDeniedError(decision.reason.value)

--- a/src/cip/adapters/sources/public_web/discovery.py
+++ b/src/cip/adapters/sources/public_web/discovery.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from cip.adapters.sources.public_web.client import (
+    PublicWebClient,
+    PublicWebFetchResult,
+    RobotsRules,
+)
+from cip.adapters.sources.public_web.collection_policy import (
+    authorize_public_web_url,
+    checked_total_bytes,
+)
+from cip.adapters.sources.public_web.feed_parsing import parse_public_feed
+from cip.adapters.sources.public_web.link_discovery import (
+    extract_public_feed_links,
+    extract_public_html_links,
+)
+from cip.adapters.sources.public_web.parsing import parse_sitemap_document
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.public_footprint.domain import DiscoveryMethod
+from cip.modules.public_footprint.domain.scope import CrawlUsage
+from cip.modules.public_footprint.domain.url_identity import same_origin
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+
+@dataclass(frozen=True, slots=True)
+class PublicWebDiscoveryCandidate:
+    url: str
+    discovery_method: DiscoveryMethod
+    source_locator: str | None = None
+    security_txt: bool = False
+    depth: int = 0
+
+
+def discover_initial_candidates(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    *,
+    now: datetime,
+    initial_bytes: int,
+) -> tuple[tuple[PublicWebDiscoveryCandidate, ...], int, set[str]]:
+    candidates: list[PublicWebDiscoveryCandidate] = []
+    seen: set[str] = set()
+    total_bytes = checked_total_bytes(target, initial_bytes)
+    for seed_url in target.seed_urls:
+        append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=seed_url,
+                discovery_method=DiscoveryMethod.DIRECT,
+            ),
+            max_pages=target.max_pages,
+        )
+    if target.discover_security_txt:
+        append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=target.security_txt_url,
+                discovery_method=DiscoveryMethod.DIRECT,
+                security_txt=True,
+            ),
+            max_pages=target.max_pages,
+        )
+    total_bytes = _discover_sitemap_candidates(
+        client,
+        entry,
+        target,
+        robots,
+        candidates,
+        seen,
+        now=now,
+        total_bytes=total_bytes,
+    )
+    seen_feeds = set(target.feed_urls)
+    for feed_url in target.feed_urls:
+        if len(candidates) >= target.max_pages:
+            break
+        total_bytes = _consume_feed(
+            client,
+            entry,
+            target,
+            robots,
+            feed_url,
+            candidates,
+            seen,
+            now=now,
+            total_bytes=total_bytes,
+            discovered=False,
+        )
+    return tuple(candidates), total_bytes, seen_feeds
+
+
+def discover_html_feeds(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    fetched: PublicWebFetchResult,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    seen_feeds: set[str],
+    *,
+    usage: CrawlUsage,
+    now: datetime,
+) -> CrawlUsage:
+    remaining_feeds = target.max_feeds - len(seen_feeds)
+    if (
+        not target.discover_feeds
+        or fetched.mime_type != "text/html"
+        or remaining_feeds <= 0
+        or len(candidates) >= target.max_pages
+    ):
+        return usage
+    feed_urls = extract_public_feed_links(
+        fetched.body,
+        base_url=fetched.fetched_url,
+        max_feeds=remaining_feeds,
+    )
+    total_bytes = usage.bytes_fetched
+    for feed_url in feed_urls:
+        if feed_url in seen_feeds or not same_origin(target.base_url, feed_url):
+            continue
+        seen_feeds.add(feed_url)
+        total_bytes = _consume_feed(
+            client,
+            entry,
+            target,
+            robots,
+            feed_url,
+            candidates,
+            seen,
+            now=now,
+            total_bytes=total_bytes,
+            discovered=True,
+        )
+        if len(seen_feeds) >= target.max_feeds or len(candidates) >= target.max_pages:
+            break
+    return CrawlUsage(pages_fetched=usage.pages_fetched, bytes_fetched=total_bytes)
+
+
+def discover_recursive_links(
+    target: PublicWebTarget,
+    candidate: PublicWebDiscoveryCandidate,
+    fetched: PublicWebFetchResult,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+) -> None:
+    child_depth = candidate.depth + 1
+    remaining = target.max_pages - len(candidates)
+    if (
+        fetched.mime_type != "text/html"
+        or child_depth > target.max_link_depth
+        or remaining <= 0
+    ):
+        return
+    links = extract_public_html_links(
+        fetched.body,
+        base_url=fetched.fetched_url,
+        max_links=remaining,
+    )
+    for link in links:
+        if not same_origin(target.base_url, link):
+            continue
+        decision = target.crawl_scope.evaluate_target(
+            link,
+            depth=child_depth,
+            redirects=0,
+            usage=CrawlUsage(),
+        )
+        if not decision.allowed:
+            continue
+        append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=link,
+                discovery_method=DiscoveryMethod.LINK,
+                source_locator=fetched.fetched_url,
+                depth=child_depth,
+            ),
+            max_pages=target.max_pages,
+        )
+
+
+def append_candidate(
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    candidate: PublicWebDiscoveryCandidate,
+    *,
+    max_pages: int,
+) -> None:
+    if len(candidates) >= max_pages or candidate.url in seen:
+        return
+    seen.add(candidate.url)
+    candidates.append(candidate)
+
+
+def _discover_sitemap_candidates(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    *,
+    now: datetime,
+    total_bytes: int,
+) -> int:
+    queue: list[tuple[str, int, bool]] = [(url, 0, False) for url in target.sitemap_urls]
+    if target.discover_sitemaps:
+        queue.extend((url, 0, True) for url in robots.sitemap_urls)
+    seen_sitemaps: set[str] = set()
+    index = 0
+    while index < len(queue) and len(seen_sitemaps) < target.max_sitemaps:
+        if len(candidates) >= target.max_pages:
+            break
+        sitemap_url, depth, discovered = queue[index]
+        index += 1
+        if sitemap_url in seen_sitemaps:
+            continue
+        seen_sitemaps.add(sitemap_url)
+        authorize_public_web_url(entry, sitemap_url, now=now)
+        sitemap = client.fetch_sitemap(
+            target,
+            sitemap_url,
+            robots,
+            discovered=discovered,
+        )
+        total_bytes = checked_total_bytes(target, total_bytes + len(sitemap.body))
+        remaining_pages = target.max_pages - len(candidates)
+        remaining_sitemaps = target.max_sitemaps - len(seen_sitemaps)
+        document = parse_sitemap_document(
+            sitemap.body,
+            target,
+            max_entries=max(1, remaining_pages),
+            max_child_sitemaps=max(1, remaining_sitemaps),
+        )
+        for sitemap_entry in document.entries:
+            append_candidate(
+                candidates,
+                seen,
+                PublicWebDiscoveryCandidate(
+                    url=sitemap_entry.url,
+                    discovery_method=DiscoveryMethod.SITEMAP,
+                    source_locator=sitemap_url,
+                ),
+                max_pages=target.max_pages,
+            )
+        if depth >= target.max_sitemap_depth or remaining_sitemaps <= 0:
+            continue
+        for child_url in document.child_sitemaps:
+            if child_url in seen_sitemaps or len(queue) >= target.max_sitemaps:
+                continue
+            queue.append((child_url, depth + 1, True))
+    return total_bytes
+
+
+def _consume_feed(
+    client: PublicWebClient,
+    entry: SourceRegistryEntry,
+    target: PublicWebTarget,
+    robots: RobotsRules,
+    feed_url: str,
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+    *,
+    now: datetime,
+    total_bytes: int,
+    discovered: bool,
+) -> int:
+    authorize_public_web_url(entry, feed_url, now=now)
+    feed = client.fetch_feed(target, feed_url, robots, discovered=discovered)
+    total_bytes = checked_total_bytes(target, total_bytes + len(feed.body))
+    remaining = target.max_pages - len(candidates)
+    if remaining <= 0:
+        return total_bytes
+    for feed_entry in parse_public_feed(feed.body, target, max_entries=remaining):
+        append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=feed_entry.url,
+                discovery_method=DiscoveryMethod.FEED,
+                source_locator=feed_url,
+            ),
+            max_pages=target.max_pages,
+        )
+    return total_bytes

--- a/src/cip/adapters/sources/public_web/link_discovery.py
+++ b/src/cip/adapters/sources/public_web/link_discovery.py
@@ -5,28 +5,41 @@ from urllib.parse import urljoin
 
 from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
 
+_FEED_TYPES = {
+    "application/atom+xml",
+    "application/rss+xml",
+}
 
-class _AnchorParser(HTMLParser):
-    def __init__(self, *, max_links: int) -> None:
+
+class _DiscoveryParser(HTMLParser):
+    def __init__(self, *, max_links: int, max_feeds: int) -> None:
         super().__init__(convert_charrefs=True)
         self._max_links = max_links
+        self._max_feeds = max_feeds
         self.links: list[str] = []
+        self.feeds: list[str] = []
 
     def handle_starttag(
         self,
         tag: str,
         attrs: list[tuple[str, str | None]],
     ) -> None:
-        if tag.casefold() != "a" or len(self.links) >= self._max_links:
-            return
+        normalized = tag.casefold()
         values = {name.casefold(): value for name, value in attrs}
         href = values.get("href")
         if href is None or not href.strip():
             return
-        rel = values.get("rel") or ""
-        if "nofollow" in {part.casefold() for part in rel.split()}:
+        if normalized == "a" and len(self.links) < self._max_links:
+            rel = values.get("rel") or ""
+            if "nofollow" not in {part.casefold() for part in rel.split()}:
+                self.links.append(href)
             return
-        self.links.append(href)
+        if normalized != "link" or len(self.feeds) >= self._max_feeds:
+            return
+        rel_tokens = {part.casefold() for part in (values.get("rel") or "").split()}
+        media_type = (values.get("type") or "").split(";", 1)[0].strip().casefold()
+        if "alternate" in rel_tokens and media_type in _FEED_TYPES:
+            self.feeds.append(href)
 
 
 def extract_public_html_links(
@@ -35,22 +48,48 @@ def extract_public_html_links(
     base_url: str,
     max_links: int,
 ) -> tuple[str, ...]:
-    if max_links < 1:
-        return ()
-    parser = _AnchorParser(max_links=max_links)
+    parser = _parse(body, max_links=max_links, max_feeds=0)
+    return _canonicalize(parser.links, base_url=base_url, limit=max_links)
+
+
+def extract_public_feed_links(
+    body: bytes,
+    *,
+    base_url: str,
+    max_feeds: int,
+) -> tuple[str, ...]:
+    parser = _parse(body, max_links=0, max_feeds=max_feeds)
+    return _canonicalize(parser.feeds, base_url=base_url, limit=max_feeds)
+
+
+def _parse(body: bytes, *, max_links: int, max_feeds: int) -> _DiscoveryParser:
+    if max_links < 0 or max_feeds < 0:
+        raise ValueError("discovery limits must not be negative")
+    parser = _DiscoveryParser(max_links=max_links, max_feeds=max_feeds)
     parser.feed(body.decode("utf-8", errors="replace"))
     parser.close()
+    return parser
+
+
+def _canonicalize(
+    values: list[str],
+    *,
+    base_url: str,
+    limit: int,
+) -> tuple[str, ...]:
+    if limit < 1:
+        return ()
     discovered: list[str] = []
     seen: set[str] = set()
-    for href in parser.links:
+    for value in values:
         try:
-            canonical = CanonicalUrl(urljoin(base_url, href)).value
+            canonical = CanonicalUrl(urljoin(base_url, value)).value
         except (TypeError, ValueError):
             continue
         if canonical in seen:
             continue
         seen.add(canonical)
         discovered.append(canonical)
-        if len(discovered) >= max_links:
+        if len(discovered) >= limit:
             break
     return tuple(discovered)

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -111,6 +111,7 @@ def map_public_page(
         indexable_text=indexable_text,
         extracted=extracted,
         tombstoned=tombstoned,
+        discovery_source_url=discovery_source_url,
     )
     claims = (
         ()
@@ -190,6 +191,7 @@ def _version(
     indexable_text: str,
     extracted: ExtractedPublicContent | None,
     tombstoned: bool,
+    discovery_source_url: str | None,
 ) -> PublicResourceVersion:
     excerpt = (
         f"HTTP {result.status_code} tombstone"
@@ -211,7 +213,7 @@ def _version(
             else None
         ),
         excerpt=excerpt,
-        source_locator=result.fetched_url,
+        source_locator=discovery_source_url or result.fetched_url,
         supersedes_version_id=_predecessor_id(
             previous,
             result.fetched_url,

--- a/src/cip/adapters/sources/public_web/parsing.py
+++ b/src/cip/adapters/sources/public_web/parsing.py
@@ -30,6 +30,12 @@ class SitemapEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class SitemapDocument:
+    entries: tuple[SitemapEntry, ...]
+    child_sitemaps: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class ExtractedHtml:
     title: str | None
     language: str | None
@@ -50,6 +56,24 @@ def parse_sitemap(
     *,
     max_entries: int | None = None,
 ) -> tuple[SitemapEntry, ...]:
+    document = parse_sitemap_document(
+        body,
+        target,
+        max_entries=max_entries,
+        max_child_sitemaps=target.max_sitemaps,
+    )
+    if document.child_sitemaps:
+        raise PublicWebParseError("sitemap index requires recursive traversal")
+    return document.entries
+
+
+def parse_sitemap_document(
+    body: bytes,
+    target: PublicWebTarget,
+    *,
+    max_entries: int | None = None,
+    max_child_sitemaps: int | None = None,
+) -> SitemapDocument:
     upper = body.upper()
     if any(marker in upper for marker in _FORBIDDEN_XML_MARKERS):
         raise PublicWebParseError("sitemap DTD and entities are not allowed")
@@ -57,11 +81,32 @@ def parse_sitemap(
         root = ElementTree.fromstring(body)
     except ElementTree.ParseError as exc:
         raise PublicWebParseError("invalid sitemap XML") from exc
-    if _local_name(root.tag) != "urlset":
-        raise PublicWebParseError("only sitemap urlset documents are supported")
-    limit = max_entries or target.max_pages
-    if not 1 <= limit <= target.max_pages:
+    root_name = _local_name(root.tag)
+    if root_name not in {"urlset", "sitemapindex"}:
+        raise PublicWebParseError("unsupported sitemap document root")
+    entry_limit = max_entries or target.max_pages
+    sitemap_limit = max_child_sitemaps or target.max_sitemaps
+    if not 1 <= entry_limit <= target.max_pages:
         raise ValueError("sitemap entry limit must fit the target page budget")
+    if not 1 <= sitemap_limit <= target.max_sitemaps:
+        raise ValueError("child sitemap limit must fit the target sitemap budget")
+    if root_name == "urlset":
+        return SitemapDocument(
+            entries=_parse_urlset(root, target, limit=entry_limit),
+            child_sitemaps=(),
+        )
+    return SitemapDocument(
+        entries=(),
+        child_sitemaps=_parse_sitemap_index(root, target, limit=sitemap_limit),
+    )
+
+
+def _parse_urlset(
+    root: ElementTree.Element,
+    target: PublicWebTarget,
+    *,
+    limit: int,
+) -> tuple[SitemapEntry, ...]:
     entries: list[SitemapEntry] = []
     seen: set[str] = set()
     for node in root:
@@ -92,6 +137,39 @@ def parse_sitemap(
         if len(entries) == limit:
             break
     return tuple(entries)
+
+
+def _parse_sitemap_index(
+    root: ElementTree.Element,
+    target: PublicWebTarget,
+    *,
+    limit: int,
+) -> tuple[str, ...]:
+    sitemaps: list[str] = []
+    seen: set[str] = set()
+    for node in root:
+        if _local_name(node.tag) != "sitemap":
+            continue
+        location = _child_text(node, "loc")
+        if location is None:
+            continue
+        try:
+            canonical = CanonicalUrl(location).value
+        except ValueError:
+            continue
+        decision = target.crawl_scope.evaluate_target(
+            canonical,
+            depth=0,
+            redirects=0,
+            usage=CrawlUsage(),
+        )
+        if not decision.allowed or canonical in seen:
+            continue
+        seen.add(canonical)
+        sitemaps.append(canonical)
+        if len(sitemaps) == limit:
+            break
+    return tuple(sitemaps)
 
 
 def extract_html(body: bytes, *, max_text_chars: int = 20_000) -> ExtractedHtml:

--- a/src/cip/adapters/sources/public_web/provisioning.py
+++ b/src/cip/adapters/sources/public_web/provisioning.py
@@ -38,6 +38,11 @@ class AutomaticPublicWebPolicy:
     allowed_path_prefixes: tuple[str, ...] = ("/",)
     refresh_interval_seconds: int = 86_400
     max_link_depth: int = 1
+    discover_sitemaps: bool = True
+    discover_feeds: bool = True
+    max_sitemap_depth: int = 2
+    max_sitemaps: int = 10
+    max_feeds: int = 5
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -61,6 +66,12 @@ class AutomaticPublicWebPolicy:
             raise ValueError("refresh_interval_seconds must be at least 60")
         if not 0 <= self.max_link_depth <= 20:
             raise ValueError("max_link_depth must be between 0 and 20")
+        if not 0 <= self.max_sitemap_depth <= 10:
+            raise ValueError("max_sitemap_depth must be between 0 and 10")
+        if not 1 <= self.max_sitemaps <= 100:
+            raise ValueError("max_sitemaps must be between 1 and 100")
+        if not 1 <= self.max_feeds <= 50:
+            raise ValueError("max_feeds must be between 1 and 50")
         object.__setattr__(self, "authorization_reference", reference)
         object.__setattr__(self, "reviewed_at", reviewed)
         object.__setattr__(self, "expires_at", expires)
@@ -95,12 +106,17 @@ def provision_public_web_target(
         sitemap_urls=(),
         feed_urls=(),
         discover_security_txt=True,
+        discover_sitemaps=policy.discover_sitemaps,
+        discover_feeds=policy.discover_feeds,
         allowed_path_prefixes=policy.allowed_path_prefixes,
         enabled=True,
         authorization_reference=policy.authorization_reference,
         authorization_reviewed_at=policy.reviewed_at,
         authorization_expires_at=policy.expires_at,
         max_link_depth=policy.max_link_depth,
+        max_sitemap_depth=policy.max_sitemap_depth,
+        max_sitemaps=policy.max_sitemaps,
+        max_feeds=policy.max_feeds,
         max_pages=policy.max_pages,
         max_total_bytes=policy.max_total_bytes,
         max_resource_bytes=policy.max_resource_bytes,

--- a/src/cip/adapters/sources/public_web/registry.py
+++ b/src/cip/adapters/sources/public_web/registry.py
@@ -7,8 +7,21 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-import yaml
-
+from cip.adapters.sources.public_web.registry_values import (
+    bounded_int,
+    load_yaml_mapping,
+    optional_bool,
+    optional_bounded_int,
+    optional_datetime,
+    optional_string,
+    optional_text,
+    optional_time,
+    positive_int,
+    required_bool,
+    required_mapping,
+    required_string,
+    string_tuple,
+)
 from cip.modules.public_footprint.domain.scope import CrawlScope
 from cip.modules.public_footprint.domain.url_identity import CanonicalUrl, same_origin
 from cip.shared.kernel.time import require_aware_utc
@@ -77,20 +90,20 @@ class PublicWebTarget:
             and not self.discover_sitemaps
         ):
             raise ValueError("public web target requires an explicit discovery path")
-        reviewed_at = _optional_time(
+        reviewed_at = optional_time(
             self.authorization_reviewed_at,
             field_name="authorization_reviewed_at",
         )
-        expires_at = _optional_time(
+        expires_at = optional_time(
             self.authorization_expires_at,
             field_name="authorization_expires_at",
         )
         if reviewed_at is not None and expires_at is not None and expires_at <= reviewed_at:
             raise ValueError("authorization expiry must follow its review time")
-        reference = _optional_text(self.authorization_reference)
+        reference = optional_text(self.authorization_reference)
         if self.enabled and (reference is None or reviewed_at is None):
             raise ValueError("enabled public web target requires reviewed authorization")
-        source_id = _optional_text(self.source_id) or identifier
+        source_id = optional_text(self.source_id) or identifier
         terms_url = CanonicalUrl(self.terms_url).value if self.terms_url else None
         prefixes = self.allowed_path_prefixes
         if self.discover_security_txt and _SECURITY_TXT_PATH not in prefixes:
@@ -155,8 +168,8 @@ class PublicWebTarget:
 
 
 def load_public_web_targets(path: Path) -> tuple[PublicWebTarget, ...]:
-    payload = _load_yaml_mapping(path)
-    if _positive_int(payload, "version") != 1:
+    payload = load_yaml_mapping(path)
+    if positive_int(payload, "version") != 1:
         raise ValueError("unsupported public web target registry version")
     raw_targets = payload.get("targets")
     if not isinstance(raw_targets, list):
@@ -180,81 +193,46 @@ def load_public_web_targets(path: Path) -> tuple[PublicWebTarget, ...]:
 
 
 def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
-    authorization = _required_mapping(payload, "authorization")
-    limits = _required_mapping(payload, "limits")
+    authorization = required_mapping(payload, "authorization")
+    limits = required_mapping(payload, "limits")
     return PublicWebTarget(
-        id=_required_string(payload, "id"),
-        organization_id=UUID(_required_string(payload, "organization_id")),
-        canonical_name=_required_string(payload, "canonical_name"),
-        base_url=_required_string(payload, "base_url"),
-        seed_urls=_string_tuple(payload, "seed_urls", minimum=0),
-        sitemap_urls=_string_tuple(payload, "sitemap_urls", minimum=0),
-        feed_urls=_string_tuple(payload, "feed_urls", minimum=0),
-        discover_security_txt=_optional_bool(payload, "discover_security_txt", default=False),
-        discover_sitemaps=_optional_bool(payload, "discover_sitemaps", default=False),
-        discover_feeds=_optional_bool(payload, "discover_feeds", default=False),
-        source_id=_optional_string(payload, "source_id"),
-        allowed_path_prefixes=_string_tuple(
-            payload,
-            "allowed_path_prefixes",
-            minimum=1,
+        id=required_string(payload, "id"),
+        organization_id=UUID(required_string(payload, "organization_id")),
+        canonical_name=required_string(payload, "canonical_name"),
+        base_url=required_string(payload, "base_url"),
+        seed_urls=string_tuple(payload, "seed_urls", minimum=0),
+        sitemap_urls=string_tuple(payload, "sitemap_urls", minimum=0),
+        feed_urls=string_tuple(payload, "feed_urls", minimum=0),
+        discover_security_txt=optional_bool(payload, "discover_security_txt", default=False),
+        discover_sitemaps=optional_bool(payload, "discover_sitemaps", default=False),
+        discover_feeds=optional_bool(payload, "discover_feeds", default=False),
+        source_id=optional_string(payload, "source_id"),
+        allowed_path_prefixes=string_tuple(payload, "allowed_path_prefixes", minimum=1),
+        enabled=required_bool(payload, "enabled"),
+        authorization_reference=optional_string(authorization, "document_reference"),
+        authorization_reviewed_at=optional_datetime(authorization, "reviewed_at"),
+        authorization_expires_at=optional_datetime(authorization, "expires_at"),
+        terms_url=optional_string(payload, "terms_url"),
+        max_link_depth=optional_bounded_int(
+            limits, "max_link_depth", default=0, minimum=0, maximum=20
         ),
-        enabled=_required_bool(payload, "enabled"),
-        authorization_reference=_optional_string(
-            authorization,
-            "document_reference",
+        max_sitemap_depth=optional_bounded_int(
+            limits, "max_sitemap_depth", default=0, minimum=0, maximum=10
         ),
-        authorization_reviewed_at=_optional_datetime(
-            authorization,
-            "reviewed_at",
+        max_sitemaps=optional_bounded_int(
+            limits, "max_sitemaps", default=10, minimum=1, maximum=100
         ),
-        authorization_expires_at=_optional_datetime(
-            authorization,
-            "expires_at",
+        max_feeds=optional_bounded_int(
+            limits, "max_feeds", default=5, minimum=1, maximum=50
         ),
-        terms_url=_optional_string(payload, "terms_url"),
-        max_link_depth=_optional_bounded_int(
-            limits,
-            "max_link_depth",
-            default=0,
-            minimum=0,
-            maximum=20,
+        max_pages=bounded_int(limits, "max_pages", minimum=1, maximum=1_000),
+        max_total_bytes=bounded_int(
+            limits, "max_total_bytes", minimum=1, maximum=100_000_000
         ),
-        max_sitemap_depth=_optional_bounded_int(
-            limits,
-            "max_sitemap_depth",
-            default=0,
-            minimum=0,
-            maximum=10,
+        max_resource_bytes=bounded_int(
+            limits, "max_resource_bytes", minimum=1, maximum=20_000_000
         ),
-        max_sitemaps=_optional_bounded_int(
-            limits,
-            "max_sitemaps",
-            default=10,
-            minimum=1,
-            maximum=100,
-        ),
-        max_feeds=_optional_bounded_int(
-            limits,
-            "max_feeds",
-            default=5,
-            minimum=1,
-            maximum=50,
-        ),
-        max_pages=_bounded_int(limits, "max_pages", minimum=1, maximum=1_000),
-        max_total_bytes=_bounded_int(
-            limits,
-            "max_total_bytes",
-            minimum=1,
-            maximum=100_000_000,
-        ),
-        max_resource_bytes=_bounded_int(
-            limits,
-            "max_resource_bytes",
-            minimum=1,
-            maximum=20_000_000,
-        ),
-        max_redirects=_bounded_int(limits, "max_redirects", minimum=0, maximum=10),
+        max_redirects=bounded_int(limits, "max_redirects", minimum=0, maximum=10),
     )
 
 
@@ -284,133 +262,3 @@ def _validate_public_hostname(host: str) -> None:
         raise ValueError("public web target host must not be an IP literal")
     if "." not in normalized:
         raise ValueError("public web target host must be a public DNS name")
-
-
-def _load_yaml_mapping(path: Path) -> dict[str, Any]:
-    if not path.is_file():
-        raise FileNotFoundError(path)
-    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(loaded, dict):
-        raise ValueError("public web target registry root must be a mapping")
-    return loaded
-
-
-def _required_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
-    value = payload.get(key)
-    if not isinstance(value, dict):
-        raise ValueError(f"{key} must be a mapping")
-    return value
-
-
-def _required_string(payload: dict[str, Any], key: str) -> str:
-    value = payload.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{key} must be a non-empty string")
-    return value
-
-
-def _optional_string(payload: dict[str, Any], key: str) -> str | None:
-    value = payload.get(key)
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise ValueError(f"{key} must be a string or null")
-    return _optional_text(value)
-
-
-def _required_bool(payload: dict[str, Any], key: str) -> bool:
-    value = payload.get(key)
-    if not isinstance(value, bool):
-        raise ValueError(f"{key} must be a boolean")
-    return value
-
-
-def _optional_bool(payload: dict[str, Any], key: str, *, default: bool) -> bool:
-    value = payload.get(key, default)
-    if not isinstance(value, bool):
-        raise ValueError(f"{key} must be a boolean")
-    return value
-
-
-def _string_tuple(
-    payload: dict[str, Any],
-    key: str,
-    *,
-    minimum: int,
-) -> tuple[str, ...]:
-    value = payload.get(key, [])
-    if not isinstance(value, list) or len(value) < minimum:
-        raise ValueError(f"{key} must contain at least {minimum} item(s)")
-    result: list[str] = []
-    for item in value:
-        if not isinstance(item, str) or not item.strip():
-            raise ValueError(f"{key} items must be non-empty strings")
-        result.append(item)
-    return tuple(result)
-
-
-def _bounded_int(
-    payload: dict[str, Any],
-    key: str,
-    *,
-    minimum: int,
-    maximum: int,
-) -> int:
-    value = payload.get(key)
-    if (
-        not isinstance(value, int)
-        or isinstance(value, bool)
-        or not minimum <= value <= maximum
-    ):
-        raise ValueError(f"{key} must be between {minimum} and {maximum}")
-    return value
-
-
-def _optional_bounded_int(
-    payload: dict[str, Any],
-    key: str,
-    *,
-    default: int,
-    minimum: int,
-    maximum: int,
-) -> int:
-    value = payload.get(key, default)
-    if (
-        not isinstance(value, int)
-        or isinstance(value, bool)
-        or not minimum <= value <= maximum
-    ):
-        raise ValueError(f"{key} must be between {minimum} and {maximum}")
-    return value
-
-
-def _positive_int(payload: dict[str, Any], key: str) -> int:
-    return _bounded_int(payload, key, minimum=1, maximum=2_147_483_647)
-
-
-def _optional_datetime(payload: dict[str, Any], key: str) -> datetime | None:
-    value = payload.get(key)
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return require_aware_utc(value, field_name=key)
-    if not isinstance(value, str):
-        raise ValueError(f"{key} must be an ISO datetime or null")
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError as exc:
-        raise ValueError(f"{key} must be an ISO datetime or null") from exc
-    return require_aware_utc(parsed, field_name=key)
-
-
-def _optional_time(value: datetime | None, *, field_name: str) -> datetime | None:
-    if value is None:
-        return None
-    return require_aware_utc(value, field_name=field_name)
-
-
-def _optional_text(value: str | None) -> str | None:
-    if value is None:
-        return None
-    normalized = value.strip()
-    return normalized or None

--- a/src/cip/adapters/sources/public_web/registry.py
+++ b/src/cip/adapters/sources/public_web/registry.py
@@ -39,8 +39,13 @@ class PublicWebTarget:
     feed_urls: tuple[str, ...] = ()
     seed_urls: tuple[str, ...] = ()
     discover_security_txt: bool = False
+    discover_sitemaps: bool = False
+    discover_feeds: bool = False
     source_id: str | None = None
     max_link_depth: int = 0
+    max_sitemap_depth: int = 0
+    max_sitemaps: int = 10
+    max_feeds: int = 5
     max_pages: int = 100
     max_total_bytes: int = 10_000_000
     max_resource_bytes: int = 1_000_000
@@ -53,12 +58,24 @@ class PublicWebTarget:
             raise ValueError("public web target id and canonical_name are required")
         if not 0 <= self.max_link_depth <= 20:
             raise ValueError("max_link_depth must be between 0 and 20")
+        if not 0 <= self.max_sitemap_depth <= 10:
+            raise ValueError("max_sitemap_depth must be between 0 and 10")
+        if not 1 <= self.max_sitemaps <= 100:
+            raise ValueError("max_sitemaps must be between 1 and 100")
+        if not 1 <= self.max_feeds <= 50:
+            raise ValueError("max_feeds must be between 1 and 50")
         base = CanonicalUrl(self.base_url)
         _validate_public_hostname(base.host)
         seeds = _same_origin_urls(base, self.seed_urls, label="seed")
         sitemaps = _same_origin_urls(base, self.sitemap_urls, label="sitemap")
         feeds = _same_origin_urls(base, self.feed_urls, label="feed")
-        if not seeds and not sitemaps and not feeds and not self.discover_security_txt:
+        if (
+            not seeds
+            and not sitemaps
+            and not feeds
+            and not self.discover_security_txt
+            and not self.discover_sitemaps
+        ):
             raise ValueError("public web target requires an explicit discovery path")
         reviewed_at = _optional_time(
             self.authorization_reviewed_at,
@@ -174,6 +191,8 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
         sitemap_urls=_string_tuple(payload, "sitemap_urls", minimum=0),
         feed_urls=_string_tuple(payload, "feed_urls", minimum=0),
         discover_security_txt=_optional_bool(payload, "discover_security_txt", default=False),
+        discover_sitemaps=_optional_bool(payload, "discover_sitemaps", default=False),
+        discover_feeds=_optional_bool(payload, "discover_feeds", default=False),
         source_id=_optional_string(payload, "source_id"),
         allowed_path_prefixes=_string_tuple(
             payload,
@@ -200,6 +219,27 @@ def _parse_target(payload: dict[str, Any]) -> PublicWebTarget:
             default=0,
             minimum=0,
             maximum=20,
+        ),
+        max_sitemap_depth=_optional_bounded_int(
+            limits,
+            "max_sitemap_depth",
+            default=0,
+            minimum=0,
+            maximum=10,
+        ),
+        max_sitemaps=_optional_bounded_int(
+            limits,
+            "max_sitemaps",
+            default=10,
+            minimum=1,
+            maximum=100,
+        ),
+        max_feeds=_optional_bounded_int(
+            limits,
+            "max_feeds",
+            default=5,
+            minimum=1,
+            maximum=50,
         ),
         max_pages=_bounded_int(limits, "max_pages", minimum=1, maximum=1_000),
         max_total_bytes=_bounded_int(

--- a/src/cip/adapters/sources/public_web/registry_values.py
+++ b/src/cip/adapters/sources/public_web/registry_values.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from cip.shared.kernel.time import require_aware_utc
+
+
+def load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ValueError("public web target registry root must be a mapping")
+    return loaded
+
+
+def required_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{key} must be a mapping")
+    return value
+
+
+def required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def optional_string(payload: dict[str, Any], key: str) -> str | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string or null")
+    return optional_text(value)
+
+
+def required_bool(payload: dict[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def optional_bool(payload: dict[str, Any], key: str, *, default: bool) -> bool:
+    value = payload.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def string_tuple(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    minimum: int,
+) -> tuple[str, ...]:
+    value = payload.get(key, [])
+    if not isinstance(value, list) or len(value) < minimum:
+        raise ValueError(f"{key} must contain at least {minimum} item(s)")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{key} items must be non-empty strings")
+        result.append(item)
+    return tuple(result)
+
+
+def bounded_int(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    value = payload.get(key)
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not minimum <= value <= maximum
+    ):
+        raise ValueError(f"{key} must be between {minimum} and {maximum}")
+    return value
+
+
+def optional_bounded_int(
+    payload: dict[str, Any],
+    key: str,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    value = payload.get(key, default)
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not minimum <= value <= maximum
+    ):
+        raise ValueError(f"{key} must be between {minimum} and {maximum}")
+    return value
+
+
+def positive_int(payload: dict[str, Any], key: str) -> int:
+    return bounded_int(payload, key, minimum=1, maximum=2_147_483_647)
+
+
+def optional_datetime(payload: dict[str, Any], key: str) -> datetime | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return require_aware_utc(value, field_name=key)
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be an ISO datetime or null")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an ISO datetime or null") from exc
+    return require_aware_utc(parsed, field_name=key)
+
+
+def optional_time(value: datetime | None, *, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    return require_aware_utc(value, field_name=field_name)
+
+
+def optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/src/cip/modules/collection_orchestration/application/public_web_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/public_web_adapter.py
@@ -11,10 +11,10 @@ from cip.adapters.sources.public_web.client import (
     PublicWebPolicyDeniedError,
     PublicWebResponseError,
 )
+from cip.adapters.sources.public_web.collection_policy import PublicWebCollectionDeniedError
 from cip.adapters.sources.public_web.collector import (
     PageCheckpoint,
     PublicWebCheckpoint,
-    PublicWebCollectionDeniedError,
     collect_public_web_target,
 )
 from cip.adapters.sources.public_web.parsing import PublicWebParseError
@@ -38,17 +38,14 @@ class PublicWebAdapter:
         target: PublicWebTarget,
         *,
         timeout_seconds: float = 30.0,
-        transport: httpx.BaseTransport | None = None,
     ) -> None:
-        if entry.policy.id != target.id:
-            raise ValueError("public web adapter requires matching source and target ids")
-        if timeout_seconds <= 0:
-            raise ValueError("timeout_seconds must be positive")
-        self.source_id = target.id
         self._entry = entry
         self._target = target
         self._timeout_seconds = timeout_seconds
-        self._transport = transport
+
+    @property
+    def target_id(self) -> str:
+        return self._target.id
 
     def collect(
         self,
@@ -58,13 +55,9 @@ class PublicWebAdapter:
         collected_at: datetime,
         retention_until: datetime,
     ) -> AdapterCollectionBatch:
-        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        checkpoint = _parse_checkpoint(checkpoint_payload)
         try:
-            with httpx.Client(
-                timeout=self._timeout_seconds,
-                follow_redirects=False,
-                transport=self._transport,
-            ) as http_client:
+            with httpx.Client(timeout=self._timeout_seconds) as http_client:
                 batch = collect_public_web_target(
                     PublicWebClient(http_client),
                     self._entry,
@@ -74,77 +67,42 @@ class PublicWebAdapter:
                     retention_until=retention_until,
                     checkpoint=checkpoint,
                 )
-        except (PublicWebCollectionDeniedError, PublicWebPolicyDeniedError) as exc:
-            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
-        except PublicWebParseError as exc:
-            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
-        except PublicWebResponseError as exc:
-            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
-        except httpx.HTTPStatusError as exc:
-            status = exc.response.status_code
-            raise AdapterExecutionError(
-                f"public web target returned HTTP {status}",
-                error_code=f"http_{status}",
-                retryable=status == 429 or status >= 500,
-            ) from exc
-        except (httpx.TimeoutException, httpx.TransportError) as exc:
-            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
+        except (
+            httpx.HTTPError,
+            PublicWebCollectionDeniedError,
+            PublicWebParseError,
+            PublicWebPolicyDeniedError,
+            PublicWebResponseError,
+        ) as exc:
+            raise AdapterExecutionError(str(exc)) from exc
         return AdapterCollectionBatch(
             observations=batch.observations,
+            public_footprint_projections=batch.projections,
             checkpoint_payload=_checkpoint_payload(batch.checkpoint),
             not_modified=batch.not_modified,
-            public_footprint_projections=batch.projections,
         )
 
 
-def _checkpoint_from_payload(
-    payload: Mapping[str, object] | None,
-) -> PublicWebCheckpoint | None:
+def _parse_checkpoint(payload: Mapping[str, object] | None) -> PublicWebCheckpoint | None:
     if payload is None:
         return None
     raw_pages = payload.get("pages")
     if not isinstance(raw_pages, dict):
-        raise AdapterExecutionError(
-            "public web checkpoint pages must be a mapping",
-            error_code="invalid_checkpoint",
-            retryable=False,
-        )
+        raise AdapterExecutionError("public-web checkpoint pages must be a mapping")
     pages: dict[str, PageCheckpoint] = {}
-    for raw_url, raw_state in raw_pages.items():
-        if not isinstance(raw_url, str) or not isinstance(raw_state, dict):
-            raise AdapterExecutionError(
-                "public web checkpoint page entries are invalid",
-                error_code="invalid_checkpoint",
-                retryable=False,
-            )
-        content_hash = raw_state.get("content_hash_sha256")
-        version_id = raw_state.get("version_id")
-        canonical_url = raw_state.get("canonical_url")
-        resource_kind = raw_state.get("resource_kind", PublicResourceKind.WEB_PAGE.value)
-        if (
-            not isinstance(content_hash, str)
-            or not isinstance(version_id, str)
-            or not isinstance(canonical_url, str)
-            or not isinstance(resource_kind, str)
-        ):
-            raise AdapterExecutionError(
-                "public web checkpoint page state is invalid",
-                error_code="invalid_checkpoint",
-                retryable=False,
-            )
+    for raw_url, raw_page in raw_pages.items():
+        if not isinstance(raw_url, str) or not isinstance(raw_page, dict):
+            raise AdapterExecutionError("public-web checkpoint page is invalid")
         try:
+            raw_kind = raw_page.get("resource_kind", PublicResourceKind.WEB_PAGE.value)
             pages[raw_url] = PageCheckpoint(
-                content_hash_sha256=content_hash,
-                version_id=UUID(version_id),
-                canonical_url=canonical_url,
-                resource_kind=PublicResourceKind(resource_kind),
+                content_hash_sha256=_required_string(raw_page, "content_hash_sha256"),
+                version_id=UUID(_required_string(raw_page, "version_id")),
+                canonical_url=_required_string(raw_page, "canonical_url"),
+                resource_kind=PublicResourceKind(_required_string_value(raw_kind)),
             )
-        except ValueError as exc:
-            raise AdapterExecutionError(
-                "public web checkpoint page state is invalid",
-                error_code="invalid_checkpoint",
-                retryable=False,
-            ) from exc
+        except (TypeError, ValueError) as exc:
+            raise AdapterExecutionError("public-web checkpoint page is invalid") from exc
     return PublicWebCheckpoint(pages)
 
 
@@ -152,24 +110,24 @@ def _checkpoint_payload(checkpoint: PublicWebCheckpoint) -> dict[str, object]:
     return {
         "pages": {
             url: {
-                "content_hash_sha256": state.content_hash_sha256,
-                "version_id": str(state.version_id),
-                "canonical_url": state.canonical_url,
-                "resource_kind": state.resource_kind.value,
+                "content_hash_sha256": page.content_hash_sha256,
+                "version_id": str(page.version_id),
+                "canonical_url": page.canonical_url,
+                "resource_kind": page.resource_kind.value,
             }
-            for url, state in sorted(checkpoint.pages.items())
+            for url, page in checkpoint.pages.items()
         }
     }
 
 
-def _execution_error(
-    exc: Exception,
-    error_code: str,
-    *,
-    retryable: bool,
-) -> AdapterExecutionError:
-    return AdapterExecutionError(
-        str(exc) or type(exc).__name__,
-        error_code=error_code,
-        retryable=retryable,
-    )
+def _required_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _required_string_value(value: object) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("resource_kind must be a non-empty string")
+    return value

--- a/src/cip/modules/collection_orchestration/application/public_web_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/public_web_adapter.py
@@ -38,14 +38,17 @@ class PublicWebAdapter:
         target: PublicWebTarget,
         *,
         timeout_seconds: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
     ) -> None:
+        if entry.policy.id != target.id:
+            raise ValueError("public web adapter requires matching source and target ids")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self.source_id = target.id
         self._entry = entry
         self._target = target
         self._timeout_seconds = timeout_seconds
-
-    @property
-    def target_id(self) -> str:
-        return self._target.id
+        self._transport = transport
 
     def collect(
         self,
@@ -55,9 +58,13 @@ class PublicWebAdapter:
         collected_at: datetime,
         retention_until: datetime,
     ) -> AdapterCollectionBatch:
-        checkpoint = _parse_checkpoint(checkpoint_payload)
+        checkpoint = _checkpoint_from_payload(checkpoint_payload)
         try:
-            with httpx.Client(timeout=self._timeout_seconds) as http_client:
+            with httpx.Client(
+                timeout=self._timeout_seconds,
+                follow_redirects=False,
+                transport=self._transport,
+            ) as http_client:
                 batch = collect_public_web_target(
                     PublicWebClient(http_client),
                     self._entry,
@@ -67,42 +74,77 @@ class PublicWebAdapter:
                     retention_until=retention_until,
                     checkpoint=checkpoint,
                 )
-        except (
-            httpx.HTTPError,
-            PublicWebCollectionDeniedError,
-            PublicWebParseError,
-            PublicWebPolicyDeniedError,
-            PublicWebResponseError,
-        ) as exc:
-            raise AdapterExecutionError(str(exc)) from exc
+        except (PublicWebCollectionDeniedError, PublicWebPolicyDeniedError) as exc:
+            raise _execution_error(exc, "source_policy_denied", retryable=False) from exc
+        except PublicWebParseError as exc:
+            raise _execution_error(exc, "source_schema_drift", retryable=False) from exc
+        except PublicWebResponseError as exc:
+            raise _execution_error(exc, "unsafe_source_response", retryable=True) from exc
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            raise AdapterExecutionError(
+                f"public web target returned HTTP {status}",
+                error_code=f"http_{status}",
+                retryable=status == 429 or status >= 500,
+            ) from exc
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            raise _execution_error(exc, "source_transport_error", retryable=True) from exc
         return AdapterCollectionBatch(
             observations=batch.observations,
-            public_footprint_projections=batch.projections,
             checkpoint_payload=_checkpoint_payload(batch.checkpoint),
             not_modified=batch.not_modified,
+            public_footprint_projections=batch.projections,
         )
 
 
-def _parse_checkpoint(payload: Mapping[str, object] | None) -> PublicWebCheckpoint | None:
+def _checkpoint_from_payload(
+    payload: Mapping[str, object] | None,
+) -> PublicWebCheckpoint | None:
     if payload is None:
         return None
     raw_pages = payload.get("pages")
     if not isinstance(raw_pages, dict):
-        raise AdapterExecutionError("public-web checkpoint pages must be a mapping")
+        raise AdapterExecutionError(
+            "public web checkpoint pages must be a mapping",
+            error_code="invalid_checkpoint",
+            retryable=False,
+        )
     pages: dict[str, PageCheckpoint] = {}
-    for raw_url, raw_page in raw_pages.items():
-        if not isinstance(raw_url, str) or not isinstance(raw_page, dict):
-            raise AdapterExecutionError("public-web checkpoint page is invalid")
-        try:
-            raw_kind = raw_page.get("resource_kind", PublicResourceKind.WEB_PAGE.value)
-            pages[raw_url] = PageCheckpoint(
-                content_hash_sha256=_required_string(raw_page, "content_hash_sha256"),
-                version_id=UUID(_required_string(raw_page, "version_id")),
-                canonical_url=_required_string(raw_page, "canonical_url"),
-                resource_kind=PublicResourceKind(_required_string_value(raw_kind)),
+    for raw_url, raw_state in raw_pages.items():
+        if not isinstance(raw_url, str) or not isinstance(raw_state, dict):
+            raise AdapterExecutionError(
+                "public web checkpoint page entries are invalid",
+                error_code="invalid_checkpoint",
+                retryable=False,
             )
-        except (TypeError, ValueError) as exc:
-            raise AdapterExecutionError("public-web checkpoint page is invalid") from exc
+        content_hash = raw_state.get("content_hash_sha256")
+        version_id = raw_state.get("version_id")
+        canonical_url = raw_state.get("canonical_url")
+        resource_kind = raw_state.get("resource_kind", PublicResourceKind.WEB_PAGE.value)
+        if (
+            not isinstance(content_hash, str)
+            or not isinstance(version_id, str)
+            or not isinstance(canonical_url, str)
+            or not isinstance(resource_kind, str)
+        ):
+            raise AdapterExecutionError(
+                "public web checkpoint page state is invalid",
+                error_code="invalid_checkpoint",
+                retryable=False,
+            )
+        try:
+            pages[raw_url] = PageCheckpoint(
+                content_hash_sha256=content_hash,
+                version_id=UUID(version_id),
+                canonical_url=canonical_url,
+                resource_kind=PublicResourceKind(resource_kind),
+            )
+        except ValueError as exc:
+            raise AdapterExecutionError(
+                "public web checkpoint page state is invalid",
+                error_code="invalid_checkpoint",
+                retryable=False,
+            ) from exc
     return PublicWebCheckpoint(pages)
 
 
@@ -110,24 +152,24 @@ def _checkpoint_payload(checkpoint: PublicWebCheckpoint) -> dict[str, object]:
     return {
         "pages": {
             url: {
-                "content_hash_sha256": page.content_hash_sha256,
-                "version_id": str(page.version_id),
-                "canonical_url": page.canonical_url,
-                "resource_kind": page.resource_kind.value,
+                "content_hash_sha256": state.content_hash_sha256,
+                "version_id": str(state.version_id),
+                "canonical_url": state.canonical_url,
+                "resource_kind": state.resource_kind.value,
             }
-            for url, page in checkpoint.pages.items()
+            for url, state in sorted(checkpoint.pages.items())
         }
     }
 
 
-def _required_string(payload: Mapping[str, object], key: str) -> str:
-    value = payload.get(key)
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{key} must be a non-empty string")
-    return value
-
-
-def _required_string_value(value: object) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError("resource_kind must be a non-empty string")
-    return value
+def _execution_error(
+    exc: Exception,
+    error_code: str,
+    *,
+    retryable: bool,
+) -> AdapterExecutionError:
+    return AdapterExecutionError(
+        str(exc) or type(exc).__name__,
+        error_code=error_code,
+        retryable=retryable,
+    )

--- a/tests/unit/adapters/public_web/test_structured_discovery.py
+++ b/tests/unit/adapters/public_web/test_structured_discovery.py
@@ -186,8 +186,14 @@ def test_collection_traverses_robots_sitemap_index_and_discovered_feed() -> None
         "https://example.com/from-sitemap",
         "https://example.com/from-feed",
     }
-    assert resources["https://example.com/from-sitemap"].resource.discovery_method is DiscoveryMethod.SITEMAP
-    assert resources["https://example.com/from-feed"].resource.discovery_method is DiscoveryMethod.FEED
+    assert (
+        resources["https://example.com/from-sitemap"].resource.discovery_method
+        is DiscoveryMethod.SITEMAP
+    )
+    assert (
+        resources["https://example.com/from-feed"].resource.discovery_method
+        is DiscoveryMethod.FEED
+    )
     assert resources["https://example.com/from-sitemap"].version.source_locator == (
         "https://example.com/nested.xml"
     )

--- a/tests/unit/adapters/public_web/test_structured_discovery.py
+++ b/tests/unit/adapters/public_web/test_structured_discovery.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.link_discovery import extract_public_feed_links
+from cip.adapters.sources.public_web.parsing import parse_sitemap_document
+from cip.adapters.sources.public_web.provisioning import (
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.public_footprint.domain import DiscoveryMethod
+
+_NOW = datetime(2026, 8, 12, 12, 0, tzinfo=UTC)
+_ORG_ID = UUID("15712d0d-9054-50b4-8a26-e25d9ea1f509")
+
+
+def _target_and_entry():
+    organization = Organization(
+        id=_ORG_ID,
+        canonical_name="Example Research",
+        website_url="https://example.com/",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l03-test",
+            reviewed_at=_NOW,
+            max_link_depth=0,
+            discover_sitemaps=True,
+            discover_feeds=True,
+            max_sitemap_depth=1,
+            max_sitemaps=4,
+            max_feeds=2,
+            max_pages=5,
+            max_total_bytes=200_000,
+            max_resource_bytes=50_000,
+            max_redirects=0,
+        ),
+        first_crawl_at=_NOW,
+    )
+    return replace(provisioned.target, discover_security_txt=False), provisioned.source_entry
+
+
+def test_feed_link_discovery_requires_declared_alternate_type() -> None:
+    body = b"""
+    <html><head>
+      <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+      <link rel="alternate stylesheet" type="application/atom+xml" href="/atom.xml">
+      <link rel="alternate" type="text/html" href="/not-feed">
+      <link rel="stylesheet" type="application/rss+xml" href="/also-not-feed">
+    </head></html>
+    """
+
+    assert extract_public_feed_links(
+        body,
+        base_url="https://example.com/",
+        max_feeds=5,
+    ) == (
+        "https://example.com/feed.xml",
+        "https://example.com/atom.xml",
+    )
+
+
+def test_sitemap_index_parser_bounds_and_filters_children() -> None:
+    target, _ = _target_and_entry()
+    body = b"""
+    <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <sitemap><loc>https://example.com/a.xml</loc></sitemap>
+      <sitemap><loc>https://outside.example/b.xml</loc></sitemap>
+      <sitemap><loc>https://example.com/a.xml#duplicate</loc></sitemap>
+      <sitemap><loc>https://example.com/c.xml</loc></sitemap>
+    </sitemapindex>
+    """
+
+    document = parse_sitemap_document(
+        body,
+        target,
+        max_entries=5,
+        max_child_sitemaps=2,
+    )
+
+    assert document.entries == ()
+    assert document.child_sitemaps == (
+        "https://example.com/a.xml",
+        "https://example.com/c.xml",
+    )
+
+
+def test_collection_traverses_robots_sitemap_index_and_discovered_feed() -> None:
+    target, entry = _target_and_entry()
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        requested.append(url)
+        if url == "https://example.com/robots.txt":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/plain"},
+                text=(
+                    "User-agent: *\nAllow: /\n"
+                    "Sitemap: https://example.com/sitemap-index.xml\n"
+                    "Sitemap: https://outside.example/ignored.xml\n"
+                ),
+                request=request,
+            )
+        if url == "https://example.com/sitemap-index.xml":
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/xml"},
+                text=(
+                    '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+                    "<sitemap><loc>https://example.com/nested.xml</loc></sitemap>"
+                    "</sitemapindex>"
+                ),
+                request=request,
+            )
+        if url == "https://example.com/nested.xml":
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/xml"},
+                text=(
+                    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+                    "<url><loc>https://example.com/from-sitemap</loc></url>"
+                    "</urlset>"
+                ),
+                request=request,
+            )
+        if url == "https://example.com/":
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text=(
+                    "<html><head><title>Root</title>"
+                    '<link rel="alternate" type="application/rss+xml" href="/feed.xml">'
+                    "</head><body>Root</body></html>"
+                ),
+                request=request,
+            )
+        if url == "https://example.com/feed.xml":
+            return httpx.Response(
+                200,
+                headers={"content-type": "application/rss+xml"},
+                text=(
+                    "<rss version=\"2.0\"><channel><title>News</title>"
+                    "<item><title>Feed item</title>"
+                    "<link>https://example.com/from-feed</link></item>"
+                    "</channel></rss>"
+                ),
+                request=request,
+            )
+        if url in {
+            "https://example.com/from-sitemap",
+            "https://example.com/from-feed",
+        }:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text=f"<html><title>{url}</title><body>ok</body></html>",
+                request=request,
+            )
+        raise AssertionError(f"unexpected request: {url}")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http_client:
+        batch = collect_public_web_target(
+            PublicWebClient(http_client),
+            entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=_NOW,
+            retention_until=_NOW + timedelta(days=30),
+        )
+
+    resources = {projection.resource.canonical_url: projection for projection in batch.projections}
+    assert set(resources) == {
+        "https://example.com/",
+        "https://example.com/from-sitemap",
+        "https://example.com/from-feed",
+    }
+    assert resources["https://example.com/from-sitemap"].resource.discovery_method is DiscoveryMethod.SITEMAP
+    assert resources["https://example.com/from-feed"].resource.discovery_method is DiscoveryMethod.FEED
+    assert resources["https://example.com/from-sitemap"].version.source_locator == (
+        "https://example.com/nested.xml"
+    )
+    assert resources["https://example.com/from-feed"].version.source_locator == (
+        "https://example.com/feed.xml"
+    )
+    assert "https://outside.example/ignored.xml" not in requested
+    assert requested.count("https://example.com/nested.xml") == 1
+    assert requested.count("https://example.com/feed.xml") == 1


### PR DESCRIPTION
Implement the next SA16 static-discovery increment on top of merged L02.

Scope in progress:
- robots.txt `Sitemap:` discovery under same-origin/path governance;
- bounded sitemap-index recursion with explicit sitemap count/depth limits;
- automatic RSS/Atom discovery from HTML `<link rel="alternate">` declarations;
- dynamically discovered sitemap/feed URLs remain fail-closed unless the target explicitly enables that discovery mode;
- every discovered structured URL is source-authorized and re-enters PublicWebClient scope/robots/size controls;
- discovery-document bytes count against the target total-byte budget;
- legacy targets keep discovery modes disabled by default.

Still to add before ready: deterministic integration tests, controlled real-network proofs (RFC Editor robots sitemap + Python Insider feed), exact-head CI/live gate, documentation and review-thread audit. No browser/JS/authenticated acquisition is introduced in L03.