### PR TITLE
SA16-L04: add conditional incremental recrawl

### DIFF
--- a/.github/workflows/sa16-l04-live-validation.yml
+++ b/.github/workflows/sa16-l04-live-validation.yml
@@ -1,0 +1,35 @@
+name: SA-16 L04 Live Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sa16-l04-live-${{ github.event.pull_request.head.sha }}
+  cancel-in-progress: true
+
+jobs:
+  live-incremental-public-web-recrawl:
+    if: github.event.pull_request.head.ref == 'agent/sa16-l04-incremental-recrawl'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact pull-request head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install project
+        run: python -m pip install .
+
+      - name: Controlled real HTTP conditional recrawl validation
+        run: python scripts/live_validate_sa16_l04.py

--- a/docs/source_activation/SA_16_L04_INCREMENTAL_RECRAWL.md
+++ b/docs/source_activation/SA_16_L04_INCREMENTAL_RECRAWL.md
@@ -1,0 +1,152 @@
+# SA-16 L04 — Conditional incremental public-web recrawl
+
+## Status
+
+`FINAL_EXACT_HEAD_REVALIDATION_PENDING`.
+
+L04 extends the merged SA16-L01/L02/L03 public-web path with durable HTTP conditional recrawl. The pre-documentation implementation candidate `e235bcfca4022da7efd17d8b3cde374156ece315` passed complete repository CI and the dedicated real-network SA-16 L04 live workflow. Because this closeout document changes the PR content tree, those runs are candidate evidence only: the documentation head produced by this commit must independently repeat both gates before merge.
+
+L04 does not add browser rendering, authenticated navigation, JavaScript execution, CAPTCHA/MFA automation or a second source-health subsystem.
+
+## Capability
+
+```text
+previous durable checkpoint
+-> exact URL representation metadata
+   -> ETag
+   -> Last-Modified
+   -> content hash / version id
+   -> discovery method / locator / depth
+-> If-None-Match / If-Modified-Since on that exact URL
+-> normal Source Governance / robots / crawl scope / budgets
+-> HTTP response
+   -> 200 changed: normal observation/version path
+   -> 304 unchanged: NOT_MODIFIED, no new RawObservation/content version
+   -> existing error/tombstone handling for other responses
+-> refreshed durable checkpoint
+```
+
+The existing collection checkpoint remains the durable persistence boundary for validators and discovery-resume metadata. L04 deliberately does not introduce a database migration solely for ETag/Last-Modified state.
+
+## Implemented behavior
+
+- `ETag` and `Last-Modified` are persisted per exact canonical fetched URL together with existing representation/version metadata.
+- Conditional headers are sent only when a prior representation exists for the same URL; validators are not transferred to another resource.
+- A real HTTP `304 Not Modified` maps the resource to `ResourceRetrievalState.NOT_MODIFIED`.
+- A 304 does not create a new `RawObservation`, content hash or replacement content version; the existing version identity is reused.
+- Legacy checkpoint payloads without validators, frontier metadata or feed URLs remain readable.
+- The worker's existing SourceHealth/Freshness behavior is reused rather than creating a competing health state.
+
+## Recursive-frontier preservation
+
+A conditional parent response creates a subtle recursive-crawl problem: a `304` has no HTML body, so its child links cannot be rediscovered from the parent during that run.
+
+L04 therefore persists the minimum known page frontier required for deterministic bounded recrawl: URL, depth, discovery method and source locator. Known descendants can be revisited even when the parent is unchanged. Every resumed URL still re-enters the existing `PublicWebClient` path and is subject to source authorization, robots, same-origin/path scope and crawl budgets.
+
+This is resume metadata, not permission expansion: checkpoint contents cannot authorize a URL that the current target/governance rules reject.
+
+## Dynamic-feed preservation
+
+The same issue applies to an RSS/Atom feed declared by HTML. If the declaring page returns `304`, its `<link rel="alternate">` declaration cannot be reparsed, while the feed itself may have new entries.
+
+L04 persists dynamically discovered feed URLs separately and revisits them under the existing structured-discovery governance. A 304 declaring page therefore does not freeze its feed or prevent new feed entries from entering the normal governed candidate path.
+
+## Safety invariants
+
+- Source Governance remains authoritative before acquisition; conditional requests do not bypass authorization.
+- robots, origin/path scope, redirect limits and page/byte/resource budgets remain authoritative.
+- validators are bound to the exact previously fetched URL.
+- checkpoint frontier/feed state does not become an authorization source.
+- `304` means only that the HTTP representation is unchanged relative to the supplied validator; it is not evidence of new content, a commercial signal or independent corroboration.
+- raw-content storage policy is unchanged.
+- no browser, authenticated-session, CAPTCHA/MFA or anti-bot bypass path is introduced.
+
+## Architecture corrections during validation
+
+The first L04 composition made `mapper.py` exceed the repository module-size contract and left a representation helper with too many parameters. The implementation was refactored rather than weakening the architecture gate:
+
+- representation/version construction was extracted into `page_representation.py`;
+- the representation inputs are grouped through a typed context instead of an oversized parameter list;
+- `PreviousPageState` remains an explicit compatible public re-export for existing consumers after the extraction.
+
+The corrected candidate passes the repository architecture/release suite.
+
+## Deterministic validation
+
+The L04 tests exercise the production adapter with deterministic HTTP transports and prove, among other cases:
+
+1. a first parent/child crawl stores distinct ETags and the child's discovery depth/method;
+2. a second crawl can receive `304` for the parent and still recrawl the known child with its own validator;
+3. no new observations are created when the known representations are unchanged;
+4. a dynamically discovered feed is persisted and fetched again even when its declaring HTML later returns `304`;
+5. a newly appearing feed item is still discovered on that second run;
+6. runnable automated test sources satisfy the same documented-terms governance contract as production sources.
+
+## Validation history
+
+### Rejected intermediate head — `a7e599edc51ec0cf4e0d7d9e47a30159ec84a44a`
+
+The dedicated real-network 304 workflow passed, and Ruff/Mypy/architecture/migrations/frontend also passed, but full CI correctly rejected the candidate:
+
+- two incremental-recrawl tests failed before exercising the L04 behavior because their runnable `SourcePolicy` fixture lacked terms/licence evidence;
+- 1503 tests passed and 2 failed;
+- branch-aware total coverage was 89.91%, below the required 90.00%.
+
+The governance rule was not weakened. The fixture was corrected to include documented terms.
+
+### External live-surface failure — `b81515fd444d29af97d676ec26a3cd20225507b5`
+
+After correcting the test fixture, the first new live attempt failed before the ETag resource was fetched because `https://httpbin.org/robots.txt` returned HTTP 503. No production L04 behavior had changed. That failed run is not counted as live proof.
+
+The controlled live surface was moved to HTTPBingo, which provides both `/robots.txt` and an ETag conditional endpoint. The production acquisition path and assertions were left unchanged.
+
+### Validated pre-documentation candidate — `e235bcfca4022da7efd17d8b3cde374156ece315`
+
+Normal CI #2030 (`31680302970`) passed completely:
+
+- dependency consistency: PASS;
+- Python dependency audit: no known vulnerabilities;
+- Ruff: PASS;
+- strict Mypy: PASS on 702 source files;
+- architecture/release contracts: 36 passed;
+- reversible migrations: PASS;
+- backend suite: 1505 passed;
+- branch-aware coverage: 90.01%;
+- frontend dependency audit/typecheck/build: PASS.
+
+SA-16 L04 Live Validation #5 (`31680302980`) also passed on that exact head using the production `PublicWebClient` and collector against the real HTTPBingo conditional endpoint.
+
+These runs prove the implementation candidate but do not substitute for validation of this documentation head.
+
+## Controlled real-network validation contract
+
+`scripts/live_validate_sa16_l04.py` provisions a governed automatic public-web target for `https://httpbingo.org/` and uses `https://httpbingo.org/etag/sa16-l04` as its sole page seed.
+
+The first production-path collection must obtain a real ETag and persist exactly one observation/projection. The second collection supplies the durable checkpoint and must receive the conditional not-modified behavior. The workflow fails unless all of the following hold:
+
+- the second collection is `not_modified`;
+- it creates zero new observations;
+- its projection remains present and maps to `ResourceRetrievalState.NOT_MODIFIED`;
+- the checkpoint retains the same content-version id;
+- the representation hash is unchanged;
+- the workflow checked out the exact pull-request head.
+
+A mock, skipped workflow, prior SHA, or successful deterministic unit test does not satisfy this live gate.
+
+## Exit gate
+
+L04 is complete only when the final documentation PR head has all of the following on that exact content:
+
+1. frontend audit/typecheck/build green;
+2. dependency consistency and Python audit green;
+3. Ruff green;
+4. strict Mypy green;
+5. architecture/release contracts green;
+6. reversible migrations green;
+7. complete backend tests and branch-aware coverage >= 90% green;
+8. the SA-16 L04 real-network conditional-recrawl workflow green;
+9. zero unresolved review threads;
+10. PR mergeability confirmed;
+11. squash-merged Git tree proven identical to the validated final head tree.
+
+Until those conditions hold, this document intentionally keeps L04 at `FINAL_EXACT_HEAD_REVALIDATION_PENDING` rather than claiming completion.

--- a/scripts/live_validate_sa16_l04.py
+++ b/scripts/live_validate_sa16_l04.py
@@ -16,22 +16,22 @@ from cip.modules.organizations.domain.entities import Organization
 from cip.modules.public_footprint.domain import ResourceRetrievalState
 
 _ORG_ID = UUID("c26cffc5-02bc-5b72-850d-b20c6c88b4c5")
-_ETAG_URL = "https://httpbin.org/etag/sa16-l04"
+_ETAG_URL = "https://httpbingo.org/etag/sa16-l04"
 
 
 def main() -> None:
     now = datetime.now(UTC)
     organization = Organization(
         id=_ORG_ID,
-        canonical_name="HTTPBin conditional request test surface",
-        website_url="https://httpbin.org/",
+        canonical_name="HTTPBingo conditional request test surface",
+        website_url="https://httpbingo.org/",
         created_at=now,
         updated_at=now,
     )
     provisioned = provision_public_web_target(
         organization,
         AutomaticPublicWebPolicy(
-            authorization_reference="sa16-l04-controlled-httpbin-etag",
+            authorization_reference="sa16-l04-controlled-httpbingo-etag",
             reviewed_at=now,
             allowed_path_prefixes=("/",),
             max_link_depth=0,

--- a/scripts/live_validate_sa16_l04.py
+++ b/scripts/live_validate_sa16_l04.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.client import PublicWebClient
+from cip.adapters.sources.public_web.collector import collect_public_web_target
+from cip.adapters.sources.public_web.provisioning import (
+    AutomaticPublicWebPolicy,
+    provision_public_web_target,
+)
+from cip.modules.organizations.domain.entities import Organization
+from cip.modules.public_footprint.domain import ResourceRetrievalState
+
+_ORG_ID = UUID("c26cffc5-02bc-5b72-850d-b20c6c88b4c5")
+_ETAG_URL = "https://httpbin.org/etag/sa16-l04"
+
+
+def main() -> None:
+    now = datetime.now(UTC)
+    organization = Organization(
+        id=_ORG_ID,
+        canonical_name="HTTPBin conditional request test surface",
+        website_url="https://httpbin.org/",
+        created_at=now,
+        updated_at=now,
+    )
+    provisioned = provision_public_web_target(
+        organization,
+        AutomaticPublicWebPolicy(
+            authorization_reference="sa16-l04-controlled-httpbin-etag",
+            reviewed_at=now,
+            allowed_path_prefixes=("/",),
+            max_link_depth=0,
+            discover_sitemaps=False,
+            discover_feeds=False,
+            max_sitemap_depth=0,
+            max_sitemaps=1,
+            max_feeds=1,
+            max_pages=1,
+            max_total_bytes=200_000,
+            max_resource_bytes=100_000,
+            max_redirects=0,
+        ),
+        first_crawl_at=now,
+    )
+    target = replace(
+        provisioned.target,
+        seed_urls=(_ETAG_URL,),
+        discover_security_txt=False,
+        discover_sitemaps=False,
+        discover_feeds=False,
+    )
+    with httpx.Client(timeout=30.0) as http_client:
+        client = PublicWebClient(http_client)
+        first = collect_public_web_target(
+            client,
+            provisioned.source_entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=now,
+            retention_until=now + timedelta(days=30),
+        )
+        first_state = first.checkpoint.pages[_ETAG_URL]
+        if first_state.etag is None:
+            raise RuntimeError("SA16-L04 live surface did not provide an ETag")
+        if len(first.observations) != 1 or len(first.projections) != 1:
+            raise RuntimeError("SA16-L04 initial live fetch did not persist one representation")
+
+        second = collect_public_web_target(
+            client,
+            provisioned.source_entry,
+            target,
+            collection_job_id=uuid4(),
+            collected_at=now + timedelta(minutes=1),
+            retention_until=now + timedelta(days=30),
+            checkpoint=first.checkpoint,
+        )
+    second_state = second.checkpoint.pages[_ETAG_URL]
+    if not second.not_modified or second.observations:
+        raise RuntimeError("SA16-L04 live recrawl did not resolve to not-modified")
+    if len(second.projections) != 1:
+        raise RuntimeError("SA16-L04 live recrawl lost the resource projection")
+    if second.projections[0].resource.retrieval_state is not ResourceRetrievalState.NOT_MODIFIED:
+        raise RuntimeError("SA16-L04 live recrawl did not map HTTP 304 to NOT_MODIFIED")
+    if second_state.version_id != first_state.version_id:
+        raise RuntimeError("SA16-L04 live 304 created a replacement content version")
+    if second_state.content_hash_sha256 != first_state.content_hash_sha256:
+        raise RuntimeError("SA16-L04 live 304 changed the representation hash")
+    print(
+        "SA-16 L04 live validation passed: "
+        f"etag={first_state.etag!r} observations_first={len(first.observations)} "
+        f"observations_second={len(second.observations)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cip/adapters/sources/public_web/checkpoint.py
+++ b/src/cip/adapters/sources/public_web/checkpoint.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from uuid import UUID
+
+from cip.adapters.sources.public_web.collector import PageCheckpoint, PublicWebCheckpoint
+from cip.modules.public_footprint.domain import DiscoveryMethod, PublicResourceKind
+from cip.modules.public_footprint.domain.url_identity import CanonicalUrl
+
+_MAX_TEXT = 2_000
+_MAX_FEEDS = 100
+
+
+class PublicWebCheckpointError(ValueError):
+    """A durable public-web checkpoint is malformed or unsafe to replay."""
+
+
+def load_checkpoint(payload: Mapping[str, object] | None) -> PublicWebCheckpoint | None:
+    if payload is None:
+        return None
+    raw_pages = payload.get("pages")
+    if not isinstance(raw_pages, dict):
+        raise PublicWebCheckpointError("checkpoint pages must be a mapping")
+    pages: dict[str, PageCheckpoint] = {}
+    for raw_url, raw_state in raw_pages.items():
+        if not isinstance(raw_url, str) or not isinstance(raw_state, dict):
+            raise PublicWebCheckpointError("checkpoint page entries are invalid")
+        pages[CanonicalUrl(raw_url).value] = _page_state(raw_state)
+    return PublicWebCheckpoint(
+        pages=pages,
+        feed_urls=_feed_urls(payload.get("feed_urls", [])),
+    )
+
+
+def dump_checkpoint(checkpoint: PublicWebCheckpoint) -> dict[str, object]:
+    return {
+        "pages": {
+            url: {
+                "content_hash_sha256": state.content_hash_sha256,
+                "version_id": str(state.version_id),
+                "canonical_url": state.canonical_url,
+                "resource_kind": state.resource_kind.value,
+                "etag": state.etag,
+                "last_modified": state.last_modified,
+                "mime_type": state.mime_type,
+                "byte_size": state.byte_size,
+                "discovery_method": (
+                    state.discovery_method.value
+                    if state.discovery_method is not None
+                    else None
+                ),
+                "source_locator": state.source_locator,
+                "depth": state.depth,
+                "security_txt": state.security_txt,
+            }
+            for url, state in sorted(checkpoint.pages.items())
+        },
+        "feed_urls": list(checkpoint.feed_urls),
+    }
+
+
+def _page_state(raw: Mapping[object, object]) -> PageCheckpoint:
+    content_hash = raw.get("content_hash_sha256")
+    version_id = raw.get("version_id")
+    canonical_url = raw.get("canonical_url")
+    resource_kind = raw.get("resource_kind", PublicResourceKind.WEB_PAGE.value)
+    if not all(isinstance(value, str) for value in (
+        content_hash,
+        version_id,
+        canonical_url,
+        resource_kind,
+    )):
+        raise PublicWebCheckpointError("checkpoint page state is invalid")
+    try:
+        return PageCheckpoint(
+            content_hash_sha256=str(content_hash),
+            version_id=UUID(str(version_id)),
+            canonical_url=CanonicalUrl(str(canonical_url)).value,
+            resource_kind=PublicResourceKind(str(resource_kind)),
+            etag=_text(raw, "etag"),
+            last_modified=_text(raw, "last_modified"),
+            mime_type=_text(raw, "mime_type"),
+            byte_size=_non_negative_int(raw, "byte_size"),
+            discovery_method=_discovery_method(raw),
+            source_locator=_text(raw, "source_locator"),
+            depth=_depth(raw),
+            security_txt=_boolean(raw, "security_txt", default=False),
+        )
+    except (TypeError, ValueError) as exc:
+        raise PublicWebCheckpointError("checkpoint page state is invalid") from exc
+
+
+def _feed_urls(raw: object) -> tuple[str, ...]:
+    if not isinstance(raw, list) or len(raw) > _MAX_FEEDS:
+        raise PublicWebCheckpointError("checkpoint feed URLs are invalid")
+    urls: list[str] = []
+    try:
+        for value in raw:
+            if not isinstance(value, str):
+                raise ValueError("feed URL must be text")
+            canonical = CanonicalUrl(value).value
+            if canonical not in urls:
+                urls.append(canonical)
+    except ValueError as exc:
+        raise PublicWebCheckpointError("checkpoint feed URLs are invalid") from exc
+    return tuple(urls)
+
+
+def _text(raw: Mapping[object, object], key: str) -> str | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_TEXT
+        or "\r" in value
+        or "\n" in value
+    ):
+        raise PublicWebCheckpointError(f"checkpoint {key} is invalid")
+    return value
+
+
+def _non_negative_int(raw: Mapping[object, object], key: str) -> int | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise PublicWebCheckpointError(f"checkpoint {key} is invalid")
+    return value
+
+
+def _depth(raw: Mapping[object, object]) -> int | None:
+    value = _non_negative_int(raw, "depth")
+    if value is not None and value > 20:
+        raise PublicWebCheckpointError("checkpoint depth is invalid")
+    return value
+
+
+def _discovery_method(raw: Mapping[object, object]) -> DiscoveryMethod | None:
+    value = raw.get("discovery_method")
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PublicWebCheckpointError("checkpoint discovery_method is invalid")
+    return DiscoveryMethod(value)
+
+
+def _boolean(raw: Mapping[object, object], key: str, *, default: bool) -> bool:
+    value = raw.get(key, default)
+    if not isinstance(value, bool):
+        raise PublicWebCheckpointError(f"checkpoint {key} is invalid")
+    return value

--- a/src/cip/adapters/sources/public_web/client.py
+++ b/src/cip/adapters/sources/public_web/client.py
@@ -26,6 +26,7 @@ _FEED_MIME_TYPES = {
     "application/xml",
     "text/xml",
 }
+_NOT_MODIFIED_MIME_TYPE = "application/x-public-resource-not-modified"
 
 
 class PublicWebResponseError(RuntimeError):
@@ -210,10 +211,13 @@ class PublicWebClient:
         *,
         usage: CrawlUsage,
         depth: int = 0,
+        etag: str | None = None,
+        last_modified: str | None = None,
     ) -> PublicWebFetchResult:
         requested = CanonicalUrl(url).value
         current = requested
         redirects = 0
+        conditional_request = etag is not None or last_modified is not None
         while True:
             decision = target.crawl_scope.evaluate_target(
                 current,
@@ -227,10 +231,11 @@ class PublicWebClient:
                 raise PublicWebPolicyDeniedError("robots.txt denied page collection")
             response = self._client.get(
                 current,
-                headers={
-                    "Accept": "text/html,application/pdf,text/plain;q=0.9,*/*;q=0.1",
-                    "User-Agent": _USER_AGENT,
-                },
+                headers=_page_headers(
+                    include_validators=current == requested,
+                    etag=etag,
+                    last_modified=last_modified,
+                ),
                 follow_redirects=False,
             )
             if response.status_code in _REDIRECT_STATUSES:
@@ -240,6 +245,21 @@ class PublicWebClient:
                 redirects += 1
                 current = CanonicalUrl(urljoin(current, location)).value
                 continue
+            if response.status_code == httpx.codes.NOT_MODIFIED:
+                if not conditional_request or current != requested:
+                    raise PublicWebResponseError(
+                        "unexpected 304 response without an applicable validator"
+                    )
+                return PublicWebFetchResult(
+                    requested_url=requested,
+                    fetched_url=current,
+                    body=b"",
+                    mime_type=_NOT_MODIFIED_MIME_TYPE,
+                    etag=_header(response, "etag") or etag,
+                    last_modified=_header(response, "last-modified") or last_modified,
+                    redirects=redirects,
+                    status_code=response.status_code,
+                )
             if response.status_code in _TOMBSTONE_STATUSES:
                 return PublicWebFetchResult(
                     requested_url=requested,
@@ -271,6 +291,23 @@ class PublicWebClient:
                 redirects=redirects,
                 status_code=response.status_code,
             )
+
+
+def _page_headers(
+    *,
+    include_validators: bool,
+    etag: str | None,
+    last_modified: str | None,
+) -> dict[str, str]:
+    headers = {
+        "Accept": "text/html,application/pdf,text/plain;q=0.9,*/*;q=0.1",
+        "User-Agent": _USER_AGENT,
+    }
+    if include_validators and etag is not None:
+        headers["If-None-Match"] = etag
+    if include_validators and last_modified is not None:
+        headers["If-Modified-Since"] = last_modified
+    return headers
 
 
 def _robots_sitemaps(

--- a/src/cip/adapters/sources/public_web/collector.py
+++ b/src/cip/adapters/sources/public_web/collector.py
@@ -11,6 +11,7 @@ from cip.adapters.sources.public_web.collection_policy import (
 )
 from cip.adapters.sources.public_web.discovery import (
     PublicWebDiscoveryCandidate,
+    append_candidate,
     discover_html_feeds,
     discover_initial_candidates,
     discover_recursive_links,
@@ -23,11 +24,19 @@ from cip.adapters.sources.public_web.mapper import (
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.adapters.sources.public_web.security_txt import parse_security_txt
 from cip.adapters.sources.public_web.security_txt_mapper import map_security_txt
-from cip.modules.public_footprint.domain import PublicFootprintProjection, PublicResourceKind
+from cip.modules.public_footprint.domain import (
+    DiscoveryMethod,
+    PublicFootprintProjection,
+    PublicResourceKind,
+)
 from cip.modules.public_footprint.domain.scope import CrawlUsage
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 from cip.shared.kernel.time import require_aware_utc
+
+_NOT_MODIFIED_STATUS = 304
+_TOMBSTONE_MIME_TYPE = "application/x-public-resource-tombstone"
+_MAX_VALIDATOR_LENGTH = 2_000
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,11 +45,20 @@ class PageCheckpoint:
     version_id: UUID
     canonical_url: str
     resource_kind: PublicResourceKind = PublicResourceKind.WEB_PAGE
+    etag: str | None = None
+    last_modified: str | None = None
+    mime_type: str | None = None
+    byte_size: int | None = None
+    discovery_method: DiscoveryMethod | None = None
+    source_locator: str | None = None
+    depth: int | None = None
+    security_txt: bool = False
 
 
 @dataclass(frozen=True, slots=True)
 class PublicWebCheckpoint:
     pages: dict[str, PageCheckpoint]
+    feed_urls: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,6 +86,8 @@ def collect_public_web_target(
         raise PublicWebCollectionDeniedError("target_authorization_inactive")
     authorize_public_web_url(entry, target.robots_url, now=collected)
     robots = client.fetch_robots(target)
+    previous_pages = checkpoint.pages if checkpoint is not None else {}
+    known_feed_urls = checkpoint.feed_urls if checkpoint is not None else ()
     initial_candidates, discovery_bytes, seen_feeds = discover_initial_candidates(
         client,
         entry,
@@ -75,11 +95,12 @@ def collect_public_web_target(
         robots,
         now=collected,
         initial_bytes=robots.bytes_fetched,
+        known_feed_urls=known_feed_urls,
     )
     candidates = list(initial_candidates)
     seen = {candidate.url for candidate in candidates}
+    _restore_checkpoint_candidates(target, previous_pages, candidates, seen)
     usage = CrawlUsage(bytes_fetched=discovery_bytes)
-    previous_pages = checkpoint.pages if checkpoint is not None else {}
     next_pages = dict(previous_pages)
     observations: list[RawObservation] = []
     projections: list[PublicFootprintProjection] = []
@@ -90,12 +111,16 @@ def collect_public_web_target(
         if usage.pages_fetched >= target.max_pages:
             break
         authorize_public_web_url(entry, candidate.url, now=collected)
+        previous = previous_pages.get(candidate.url)
+        etag, last_modified = _conditional_validators(previous, candidate)
         fetched = client.fetch_page(
             target,
             candidate.url,
             robots,
             usage=usage,
             depth=candidate.depth,
+            etag=etag,
+            last_modified=last_modified,
         )
         usage = CrawlUsage(
             pages_fetched=usage.pages_fetched + 1,
@@ -103,7 +128,6 @@ def collect_public_web_target(
         )
         if candidate.security_txt and fetched.status_code in {404, 410}:
             continue
-        previous = previous_pages.get(candidate.url)
         mapped = _map_candidate(
             target,
             candidate,
@@ -116,12 +140,14 @@ def collect_public_web_target(
         if mapped.observation is not None:
             observations.append(mapped.observation)
         projections.append(mapped.projection)
-        next_pages[candidate.url] = PageCheckpoint(
-            content_hash_sha256=mapped.content_hash_sha256,
-            version_id=_checkpoint_version_id(previous, mapped, fetched),
-            canonical_url=fetched.fetched_url,
-            resource_kind=mapped.projection.resource.kind,
+        next_pages[candidate.url] = _next_page_checkpoint(
+            candidate,
+            previous,
+            mapped,
+            fetched,
         )
+        if fetched.status_code == _NOT_MODIFIED_STATUS:
+            continue
         usage = discover_html_feeds(
             client,
             entry,
@@ -138,9 +164,98 @@ def collect_public_web_target(
     return PublicWebCollectionBatch(
         observations=tuple(observations),
         projections=tuple(projections),
-        checkpoint=PublicWebCheckpoint(next_pages),
+        checkpoint=PublicWebCheckpoint(
+            pages=next_pages,
+            feed_urls=tuple(sorted(seen_feeds)),
+        ),
         not_modified=not observations,
     )
+
+
+def _restore_checkpoint_candidates(
+    target: PublicWebTarget,
+    previous_pages: dict[str, PageCheckpoint],
+    candidates: list[PublicWebDiscoveryCandidate],
+    seen: set[str],
+) -> None:
+    resumable = sorted(
+        previous_pages.items(),
+        key=lambda item: (
+            item[1].depth if item[1].depth is not None else 21,
+            item[0],
+        ),
+    )
+    for url, state in resumable:
+        if state.discovery_method is None or state.depth is None:
+            continue
+        if state.security_txt and not target.discover_security_txt:
+            continue
+        decision = target.crawl_scope.evaluate_target(
+            url,
+            depth=state.depth,
+            redirects=0,
+            usage=CrawlUsage(),
+        )
+        if not decision.allowed:
+            continue
+        append_candidate(
+            candidates,
+            seen,
+            PublicWebDiscoveryCandidate(
+                url=url,
+                discovery_method=state.discovery_method,
+                source_locator=state.source_locator,
+                security_txt=state.security_txt,
+                depth=state.depth,
+            ),
+            max_pages=target.max_pages,
+        )
+
+
+def _conditional_validators(
+    previous: PageCheckpoint | None,
+    candidate: PublicWebDiscoveryCandidate,
+) -> tuple[str | None, str | None]:
+    if (
+        previous is None
+        or candidate.security_txt
+        or previous.canonical_url != candidate.url
+        or previous.mime_type in {None, _TOMBSTONE_MIME_TYPE}
+        or previous.byte_size is None
+    ):
+        return None, None
+    return previous.etag, previous.last_modified
+
+
+def _next_page_checkpoint(
+    candidate: PublicWebDiscoveryCandidate,
+    previous: PageCheckpoint | None,
+    mapped: MappedPublicPage,
+    fetched: PublicWebFetchResult,
+) -> PageCheckpoint:
+    not_modified = fetched.status_code == _NOT_MODIFIED_STATUS
+    mime_type = previous.mime_type if not_modified and previous is not None else fetched.mime_type
+    byte_size = previous.byte_size if not_modified and previous is not None else len(fetched.body)
+    return PageCheckpoint(
+        content_hash_sha256=mapped.content_hash_sha256,
+        version_id=_checkpoint_version_id(previous, mapped, fetched),
+        canonical_url=fetched.fetched_url,
+        resource_kind=mapped.projection.resource.kind,
+        etag=_safe_validator(fetched.etag),
+        last_modified=_safe_validator(fetched.last_modified),
+        mime_type=mime_type,
+        byte_size=byte_size,
+        discovery_method=candidate.discovery_method,
+        source_locator=candidate.source_locator,
+        depth=candidate.depth,
+        security_txt=candidate.security_txt,
+    )
+
+
+def _safe_validator(value: str | None) -> str | None:
+    if value is None or len(value) > _MAX_VALIDATOR_LENGTH or "\r" in value or "\n" in value:
+        return None
+    return value
 
 
 def _map_candidate(
@@ -188,6 +303,8 @@ def _previous_state(previous: PageCheckpoint | None) -> PreviousPageState | None
         version_id=previous.version_id,
         canonical_url=previous.canonical_url,
         resource_kind=previous.resource_kind,
+        mime_type=previous.mime_type,
+        byte_size=previous.byte_size,
     )
 
 

--- a/src/cip/adapters/sources/public_web/discovery.py
+++ b/src/cip/adapters/sources/public_web/discovery.py
@@ -42,6 +42,7 @@ def discover_initial_candidates(
     *,
     now: datetime,
     initial_bytes: int,
+    known_feed_urls: tuple[str, ...] = (),
 ) -> tuple[tuple[PublicWebDiscoveryCandidate, ...], int, set[str]]:
     candidates: list[PublicWebDiscoveryCandidate] = []
     seen: set[str] = set()
@@ -93,6 +94,37 @@ def discover_initial_candidates(
             total_bytes=total_bytes,
             discovered=False,
         )
+    if target.discover_feeds:
+        for feed_url in known_feed_urls:
+            if (
+                feed_url in seen_feeds
+                or len(seen_feeds) >= target.max_feeds
+                or len(candidates) >= target.max_pages
+            ):
+                continue
+            if not same_origin(target.base_url, feed_url):
+                continue
+            decision = target.crawl_scope.evaluate_target(
+                feed_url,
+                depth=0,
+                redirects=0,
+                usage=CrawlUsage(),
+            )
+            if not decision.allowed:
+                continue
+            seen_feeds.add(feed_url)
+            total_bytes = _consume_feed(
+                client,
+                entry,
+                target,
+                robots,
+                feed_url,
+                candidates,
+                seen,
+                now=now,
+                total_bytes=total_bytes,
+                discovered=True,
+            )
     return tuple(candidates), total_bytes, seen_feeds
 
 

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -35,6 +35,8 @@ from cip.modules.public_footprint.domain import (
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import DataCategory
 
+__all__ = ("MappedPublicPage", "PreviousPageState", "map_public_page")
+
 _NOT_MODIFIED_STATUS = 304
 _TECHNOLOGY_TERMS = (
     "amazon web services",

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -315,7 +315,9 @@ def _validate_not_modified(
     if state.canonical_url != result.fetched_url:
         raise PublicWebResponseError("304 response changed the canonical resource URL")
     if state.mime_type is None or state.byte_size is None:
-        raise PublicWebResponseError("304 response requires complete previous representation metadata")
+        raise PublicWebResponseError(
+            "304 response requires complete previous representation metadata"
+        )
 
 
 def _required_previous(previous: PreviousPageState | None) -> PreviousPageState:
@@ -350,7 +352,10 @@ def _resource_kind(
     result: PublicWebFetchResult,
     previous: PreviousPageState | None,
 ) -> PublicResourceKind:
-    if (result.status_code == _NOT_MODIFIED_STATUS or _is_tombstone(result)) and previous is not None:
+    unchanged_or_tombstoned = (
+        result.status_code == _NOT_MODIFIED_STATUS or _is_tombstone(result)
+    )
+    if unchanged_or_tombstoned and previous is not None:
         return previous.resource_kind
     if result.mime_type in {"application/pdf", "text/plain"}:
         return PublicResourceKind.DOCUMENT

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from cip.adapters.sources.public_web.client import PublicWebFetchResult
+from cip.adapters.sources.public_web.client import (
+    PublicWebFetchResult,
+    PublicWebResponseError,
+)
 from cip.adapters.sources.public_web.content_extraction import (
     ExtractedPublicContent,
     extract_public_content,
@@ -29,6 +32,7 @@ from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import DataCategory
 
 _TOMBSTONE_MIME_TYPE = "application/x-public-resource-tombstone"
+_NOT_MODIFIED_STATUS = 304
 _TECHNOLOGY_TERMS = (
     "amazon web services",
     "aws",
@@ -58,6 +62,8 @@ class PreviousPageState:
     version_id: UUID
     canonical_url: str
     resource_kind: PublicResourceKind = PublicResourceKind.WEB_PAGE
+    mime_type: str | None = None
+    byte_size: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,14 +85,25 @@ def map_public_page(
     discovery_source_url: str | None = None,
     allow_claims: bool = True,
 ) -> MappedPublicPage:
+    not_modified = result.status_code == _NOT_MODIFIED_STATUS
+    if not_modified:
+        _validate_not_modified(previous, result)
     tombstoned = _is_tombstone(result)
-    content_hash = _content_hash(result)
-    quarantined = not tombstoned and contains_credential_marker(result.body)
-    unchanged = _is_unchanged(previous, result, content_hash)
-    extracted = extract_public_content(
-        result,
-        quarantined=quarantined,
-        tombstoned=tombstoned,
+    content_hash = _content_hash(result, previous)
+    quarantined = (
+        not tombstoned
+        and not not_modified
+        and contains_credential_marker(result.body)
+    )
+    unchanged = not_modified or _is_unchanged(previous, result, content_hash)
+    extracted = (
+        None
+        if not_modified
+        else extract_public_content(
+            result,
+            quarantined=quarantined,
+            tombstoned=tombstoned,
+        )
     )
     indexable_text = _indexable_text(extracted)
     resource = _resource(
@@ -107,6 +124,7 @@ def map_public_page(
         collected_at=collected_at,
         previous=previous,
         unchanged=unchanged,
+        not_modified=not_modified,
         content_hash=content_hash,
         indexable_text=indexable_text,
         extracted=extracted,
@@ -115,7 +133,7 @@ def map_public_page(
     )
     claims = (
         ()
-        if tombstoned or not allow_claims
+        if tombstoned or not_modified or not allow_claims
         else _claims(target, resource, version, indexable_text)
     )
     projection = PublicFootprintProjection(resource=resource, version=version, claims=claims)
@@ -187,6 +205,7 @@ def _version(
     collected_at: datetime,
     previous: PreviousPageState | None,
     unchanged: bool,
+    not_modified: bool,
     content_hash: str,
     indexable_text: str,
     extracted: ExtractedPublicContent | None,
@@ -198,13 +217,30 @@ def _version(
         if tombstoned
         else extracted.excerpt if extracted is not None else None
     )
+    mime_type = (
+        _required_previous(previous).mime_type
+        if not_modified
+        else result.mime_type
+    )
+    byte_size = (
+        _required_previous(previous).byte_size
+        if not_modified
+        else len(result.body)
+    )
+    assert mime_type is not None
+    assert byte_size is not None
     return PublicResourceVersion(
         resource_key=resource.identity_key,
         source_url=result.fetched_url,
         content_hash_sha256=content_hash,
         fetched_at=collected_at,
-        mime_type=result.mime_type,
-        byte_size=len(result.body),
+        mime_type=mime_type,
+        byte_size=byte_size,
+        id=(
+            _required_previous(previous).version_id
+            if not_modified
+            else uuid4()
+        ),
         title=extracted.title if extracted is not None else None,
         language=extracted.language if extracted is not None else None,
         extracted_text_hash_sha256=(
@@ -260,10 +296,32 @@ def _observation(
     )
 
 
-def _content_hash(result: PublicWebFetchResult) -> str:
+def _content_hash(
+    result: PublicWebFetchResult,
+    previous: PreviousPageState | None,
+) -> str:
+    if result.status_code == _NOT_MODIFIED_STATUS:
+        return _required_previous(previous).content_hash_sha256
     if _is_tombstone(result):
         return sha256(f"http-status:{result.status_code}".encode()).hexdigest()
     return sha256(result.body).hexdigest()
+
+
+def _validate_not_modified(
+    previous: PreviousPageState | None,
+    result: PublicWebFetchResult,
+) -> None:
+    state = _required_previous(previous)
+    if state.canonical_url != result.fetched_url:
+        raise PublicWebResponseError("304 response changed the canonical resource URL")
+    if state.mime_type is None or state.byte_size is None:
+        raise PublicWebResponseError("304 response requires complete previous representation metadata")
+
+
+def _required_previous(previous: PreviousPageState | None) -> PreviousPageState:
+    if previous is None:
+        raise PublicWebResponseError("304 response requires previous page state")
+    return previous
 
 
 def _is_tombstone(result: PublicWebFetchResult) -> bool:
@@ -292,7 +350,7 @@ def _resource_kind(
     result: PublicWebFetchResult,
     previous: PreviousPageState | None,
 ) -> PublicResourceKind:
-    if _is_tombstone(result) and previous is not None:
+    if (result.status_code == _NOT_MODIFIED_STATUS or _is_tombstone(result)) and previous is not None:
         return previous.resource_kind
     if result.mime_type in {"application/pdf", "text/plain"}:
         return PublicResourceKind.DOCUMENT

--- a/src/cip/adapters/sources/public_web/mapper.py
+++ b/src/cip/adapters/sources/public_web/mapper.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from hashlib import sha256
-from uuid import UUID, uuid4
+from uuid import UUID
 
-from cip.adapters.sources.public_web.client import (
-    PublicWebFetchResult,
-    PublicWebResponseError,
-)
+from cip.adapters.sources.public_web.client import PublicWebFetchResult
 from cip.adapters.sources.public_web.content_extraction import (
     ExtractedPublicContent,
     extract_public_content,
+)
+from cip.adapters.sources.public_web.page_representation import (
+    PageVersionContext,
+    PreviousPageState,
+    build_version,
+    content_hash,
+    is_tombstone,
+    resource_kind,
+    validate_not_modified,
 )
 from cip.adapters.sources.public_web.parsing import contains_credential_marker
 from cip.adapters.sources.public_web.registry import PublicWebTarget
@@ -23,7 +28,6 @@ from cip.modules.public_footprint.domain import (
     PublicClaimType,
     PublicFootprintProjection,
     PublicResource,
-    PublicResourceKind,
     PublicResourceVersion,
     ResourceAccessState,
     ResourceRetrievalState,
@@ -31,7 +35,6 @@ from cip.modules.public_footprint.domain import (
 from cip.modules.raw_observations.domain.entities import RawObservation
 from cip.modules.source_governance.domain.models import DataCategory
 
-_TOMBSTONE_MIME_TYPE = "application/x-public-resource-tombstone"
 _NOT_MODIFIED_STATUS = 304
 _TECHNOLOGY_TERMS = (
     "amazon web services",
@@ -57,16 +60,6 @@ _SECURITY_OBJECTIVE_TERMS = (
 
 
 @dataclass(frozen=True, slots=True)
-class PreviousPageState:
-    content_hash_sha256: str
-    version_id: UUID
-    canonical_url: str
-    resource_kind: PublicResourceKind = PublicResourceKind.WEB_PAGE
-    mime_type: str | None = None
-    byte_size: int | None = None
-
-
-@dataclass(frozen=True, slots=True)
 class MappedPublicPage:
     projection: PublicFootprintProjection
     observation: RawObservation | None
@@ -87,15 +80,15 @@ def map_public_page(
 ) -> MappedPublicPage:
     not_modified = result.status_code == _NOT_MODIFIED_STATUS
     if not_modified:
-        _validate_not_modified(previous, result)
-    tombstoned = _is_tombstone(result)
-    content_hash = _content_hash(result, previous)
+        validate_not_modified(previous, result)
+    tombstoned = is_tombstone(result)
+    page_hash = content_hash(result, previous)
     quarantined = (
         not tombstoned
         and not not_modified
         and contains_credential_marker(result.body)
     )
-    unchanged = not_modified or _is_unchanged(previous, result, content_hash)
+    unchanged = not_modified or _is_unchanged(previous, result, page_hash)
     extracted = (
         None
         if not_modified
@@ -118,18 +111,20 @@ def map_public_page(
         discovery_method=discovery_method,
         discovery_source_url=discovery_source_url,
     )
-    version = _version(
+    version = build_version(
         resource,
         result,
-        collected_at=collected_at,
-        previous=previous,
-        unchanged=unchanged,
-        not_modified=not_modified,
-        content_hash=content_hash,
-        indexable_text=indexable_text,
-        extracted=extracted,
-        tombstoned=tombstoned,
-        discovery_source_url=discovery_source_url,
+        PageVersionContext(
+            collected_at=collected_at,
+            previous=previous,
+            unchanged=unchanged,
+            not_modified=not_modified,
+            content_hash=page_hash,
+            indexable_text=indexable_text,
+            extracted=extracted,
+            tombstoned=tombstoned,
+            discovery_source_url=discovery_source_url,
+        ),
     )
     claims = (
         ()
@@ -146,7 +141,7 @@ def map_public_page(
             collection_job_id=collection_job_id,
             collected_at=collected_at,
             retention_until=retention_until,
-            content_hash=content_hash,
+            content_hash=page_hash,
             extracted=extracted,
             tombstoned=tombstoned,
             include_technology_category=allow_claims,
@@ -155,7 +150,7 @@ def map_public_page(
     return MappedPublicPage(
         projection=projection,
         observation=observation,
-        content_hash_sha256=content_hash,
+        content_hash_sha256=page_hash,
     )
 
 
@@ -172,14 +167,13 @@ def _resource(
     discovery_method: DiscoveryMethod,
     discovery_source_url: str | None,
 ) -> PublicResource:
-    kind = _resource_kind(result, previous)
     return PublicResource(
         organization_id=target.organization_id,
         source_id=target.source_id or target.id,
         source_record_key=result.requested_url,
         canonical_url=result.fetched_url,
         source_url=discovery_source_url or result.requested_url,
-        kind=kind,
+        kind=resource_kind(result, previous),
         discovery_method=discovery_method,
         first_discovered_at=collected_at,
         last_seen_at=collected_at,
@@ -195,66 +189,6 @@ def _resource(
             previous=previous,
         ),
         title=extracted.title if extracted is not None else None,
-    )
-
-
-def _version(
-    resource: PublicResource,
-    result: PublicWebFetchResult,
-    *,
-    collected_at: datetime,
-    previous: PreviousPageState | None,
-    unchanged: bool,
-    not_modified: bool,
-    content_hash: str,
-    indexable_text: str,
-    extracted: ExtractedPublicContent | None,
-    tombstoned: bool,
-    discovery_source_url: str | None,
-) -> PublicResourceVersion:
-    excerpt = (
-        f"HTTP {result.status_code} tombstone"
-        if tombstoned
-        else extracted.excerpt if extracted is not None else None
-    )
-    mime_type = (
-        _required_previous(previous).mime_type
-        if not_modified
-        else result.mime_type
-    )
-    byte_size = (
-        _required_previous(previous).byte_size
-        if not_modified
-        else len(result.body)
-    )
-    assert mime_type is not None
-    assert byte_size is not None
-    return PublicResourceVersion(
-        resource_key=resource.identity_key,
-        source_url=result.fetched_url,
-        content_hash_sha256=content_hash,
-        fetched_at=collected_at,
-        mime_type=mime_type,
-        byte_size=byte_size,
-        id=(
-            _required_previous(previous).version_id
-            if not_modified
-            else uuid4()
-        ),
-        title=extracted.title if extracted is not None else None,
-        language=extracted.language if extracted is not None else None,
-        extracted_text_hash_sha256=(
-            sha256(indexable_text.encode()).hexdigest()
-            if indexable_text
-            else None
-        ),
-        excerpt=excerpt,
-        source_locator=discovery_source_url or result.fetched_url,
-        supersedes_version_id=_predecessor_id(
-            previous,
-            result.fetched_url,
-            unchanged=unchanged,
-        ),
     )
 
 
@@ -296,48 +230,14 @@ def _observation(
     )
 
 
-def _content_hash(
-    result: PublicWebFetchResult,
-    previous: PreviousPageState | None,
-) -> str:
-    if result.status_code == _NOT_MODIFIED_STATUS:
-        return _required_previous(previous).content_hash_sha256
-    if _is_tombstone(result):
-        return sha256(f"http-status:{result.status_code}".encode()).hexdigest()
-    return sha256(result.body).hexdigest()
-
-
-def _validate_not_modified(
-    previous: PreviousPageState | None,
-    result: PublicWebFetchResult,
-) -> None:
-    state = _required_previous(previous)
-    if state.canonical_url != result.fetched_url:
-        raise PublicWebResponseError("304 response changed the canonical resource URL")
-    if state.mime_type is None or state.byte_size is None:
-        raise PublicWebResponseError(
-            "304 response requires complete previous representation metadata"
-        )
-
-
-def _required_previous(previous: PreviousPageState | None) -> PreviousPageState:
-    if previous is None:
-        raise PublicWebResponseError("304 response requires previous page state")
-    return previous
-
-
-def _is_tombstone(result: PublicWebFetchResult) -> bool:
-    return result.status_code in {404, 410} and result.mime_type == _TOMBSTONE_MIME_TYPE
-
-
 def _is_unchanged(
     previous: PreviousPageState | None,
     result: PublicWebFetchResult,
-    content_hash: str,
+    page_hash: str,
 ) -> bool:
     return bool(
         previous is not None
-        and previous.content_hash_sha256 == content_hash
+        and previous.content_hash_sha256 == page_hash
         and previous.canonical_url == result.fetched_url
     )
 
@@ -346,31 +246,6 @@ def _indexable_text(extracted: ExtractedPublicContent | None) -> str:
     if extracted is None or extracted.noindex:
         return ""
     return extracted.text
-
-
-def _resource_kind(
-    result: PublicWebFetchResult,
-    previous: PreviousPageState | None,
-) -> PublicResourceKind:
-    unchanged_or_tombstoned = (
-        result.status_code == _NOT_MODIFIED_STATUS or _is_tombstone(result)
-    )
-    if unchanged_or_tombstoned and previous is not None:
-        return previous.resource_kind
-    if result.mime_type in {"application/pdf", "text/plain"}:
-        return PublicResourceKind.DOCUMENT
-    return PublicResourceKind.WEB_PAGE
-
-
-def _predecessor_id(
-    previous: PreviousPageState | None,
-    canonical_url: str,
-    *,
-    unchanged: bool,
-) -> UUID | None:
-    if previous is None or unchanged or previous.canonical_url != canonical_url:
-        return None
-    return previous.version_id
 
 
 def _retrieval_state(

--- a/src/cip/adapters/sources/public_web/page_representation.py
+++ b/src/cip/adapters/sources/public_web/page_representation.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from hashlib import sha256
+from uuid import UUID, uuid4
+
+from cip.adapters.sources.public_web.client import (
+    PublicWebFetchResult,
+    PublicWebResponseError,
+)
+from cip.adapters.sources.public_web.content_extraction import ExtractedPublicContent
+from cip.modules.public_footprint.domain import (
+    PublicResource,
+    PublicResourceKind,
+    PublicResourceVersion,
+)
+
+_TOMBSTONE_MIME_TYPE = "application/x-public-resource-tombstone"
+_NOT_MODIFIED_STATUS = 304
+
+
+@dataclass(frozen=True, slots=True)
+class PreviousPageState:
+    content_hash_sha256: str
+    version_id: UUID
+    canonical_url: str
+    resource_kind: PublicResourceKind = PublicResourceKind.WEB_PAGE
+    mime_type: str | None = None
+    byte_size: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PageVersionContext:
+    collected_at: datetime
+    previous: PreviousPageState | None
+    unchanged: bool
+    not_modified: bool
+    content_hash: str
+    indexable_text: str
+    extracted: ExtractedPublicContent | None
+    tombstoned: bool
+    discovery_source_url: str | None
+
+
+def validate_not_modified(
+    previous: PreviousPageState | None,
+    result: PublicWebFetchResult,
+) -> None:
+    state = required_previous(previous)
+    if state.canonical_url != result.fetched_url:
+        raise PublicWebResponseError("304 response changed the canonical resource URL")
+    if state.mime_type is None or state.byte_size is None:
+        raise PublicWebResponseError(
+            "304 response requires complete previous representation metadata"
+        )
+
+
+def content_hash(
+    result: PublicWebFetchResult,
+    previous: PreviousPageState | None,
+) -> str:
+    if result.status_code == _NOT_MODIFIED_STATUS:
+        return required_previous(previous).content_hash_sha256
+    if is_tombstone(result):
+        return sha256(f"http-status:{result.status_code}".encode()).hexdigest()
+    return sha256(result.body).hexdigest()
+
+
+def resource_kind(
+    result: PublicWebFetchResult,
+    previous: PreviousPageState | None,
+) -> PublicResourceKind:
+    unchanged_or_tombstoned = (
+        result.status_code == _NOT_MODIFIED_STATUS or is_tombstone(result)
+    )
+    if unchanged_or_tombstoned and previous is not None:
+        return previous.resource_kind
+    if result.mime_type in {"application/pdf", "text/plain"}:
+        return PublicResourceKind.DOCUMENT
+    return PublicResourceKind.WEB_PAGE
+
+
+def build_version(
+    resource: PublicResource,
+    result: PublicWebFetchResult,
+    context: PageVersionContext,
+) -> PublicResourceVersion:
+    previous = context.previous
+    excerpt = (
+        f"HTTP {result.status_code} tombstone"
+        if context.tombstoned
+        else context.extracted.excerpt if context.extracted is not None else None
+    )
+    mime_type = (
+        required_previous(previous).mime_type
+        if context.not_modified
+        else result.mime_type
+    )
+    byte_size = (
+        required_previous(previous).byte_size
+        if context.not_modified
+        else len(result.body)
+    )
+    assert mime_type is not None
+    assert byte_size is not None
+    return PublicResourceVersion(
+        resource_key=resource.identity_key,
+        source_url=result.fetched_url,
+        content_hash_sha256=context.content_hash,
+        fetched_at=context.collected_at,
+        mime_type=mime_type,
+        byte_size=byte_size,
+        id=(
+            required_previous(previous).version_id
+            if context.not_modified
+            else uuid4()
+        ),
+        title=(
+            context.extracted.title if context.extracted is not None else None
+        ),
+        language=(
+            context.extracted.language if context.extracted is not None else None
+        ),
+        extracted_text_hash_sha256=(
+            sha256(context.indexable_text.encode()).hexdigest()
+            if context.indexable_text
+            else None
+        ),
+        excerpt=excerpt,
+        source_locator=context.discovery_source_url or result.fetched_url,
+        supersedes_version_id=predecessor_id(
+            previous,
+            result.fetched_url,
+            unchanged=context.unchanged,
+        ),
+    )
+
+
+def is_tombstone(result: PublicWebFetchResult) -> bool:
+    return result.status_code in {404, 410} and result.mime_type == _TOMBSTONE_MIME_TYPE
+
+
+def required_previous(previous: PreviousPageState | None) -> PreviousPageState:
+    if previous is None:
+        raise PublicWebResponseError("304 response requires previous page state")
+    return previous
+
+
+def predecessor_id(
+    previous: PreviousPageState | None,
+    canonical_url: str,
+    *,
+    unchanged: bool,
+) -> UUID | None:
+    if previous is None or unchanged or previous.canonical_url != canonical_url:
+        return None
+    return previous.version_id

--- a/src/cip/modules/collection_orchestration/application/public_web_adapter.py
+++ b/src/cip/modules/collection_orchestration/application/public_web_adapter.py
@@ -6,24 +6,24 @@ from uuid import UUID
 
 import httpx
 
+from cip.adapters.sources.public_web.checkpoint import (
+    PublicWebCheckpointError,
+    dump_checkpoint,
+    load_checkpoint,
+)
 from cip.adapters.sources.public_web.client import (
     PublicWebClient,
     PublicWebPolicyDeniedError,
     PublicWebResponseError,
 )
 from cip.adapters.sources.public_web.collection_policy import PublicWebCollectionDeniedError
-from cip.adapters.sources.public_web.collector import (
-    PageCheckpoint,
-    PublicWebCheckpoint,
-    collect_public_web_target,
-)
+from cip.adapters.sources.public_web.collector import collect_public_web_target
 from cip.adapters.sources.public_web.parsing import PublicWebParseError
 from cip.adapters.sources.public_web.registry import PublicWebTarget
 from cip.modules.collection_orchestration.application.ports import (
     AdapterCollectionBatch,
     AdapterExecutionError,
 )
-from cip.modules.public_footprint.domain import PublicResourceKind
 from cip.modules.source_governance.domain.models import DataCategory
 from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
 
@@ -58,7 +58,10 @@ class PublicWebAdapter:
         collected_at: datetime,
         retention_until: datetime,
     ) -> AdapterCollectionBatch:
-        checkpoint = _checkpoint_from_payload(checkpoint_payload)
+        try:
+            checkpoint = load_checkpoint(checkpoint_payload)
+        except PublicWebCheckpointError as exc:
+            raise _execution_error(exc, "invalid_checkpoint", retryable=False) from exc
         try:
             with httpx.Client(
                 timeout=self._timeout_seconds,
@@ -91,75 +94,10 @@ class PublicWebAdapter:
             raise _execution_error(exc, "source_transport_error", retryable=True) from exc
         return AdapterCollectionBatch(
             observations=batch.observations,
-            checkpoint_payload=_checkpoint_payload(batch.checkpoint),
+            checkpoint_payload=dump_checkpoint(batch.checkpoint),
             not_modified=batch.not_modified,
             public_footprint_projections=batch.projections,
         )
-
-
-def _checkpoint_from_payload(
-    payload: Mapping[str, object] | None,
-) -> PublicWebCheckpoint | None:
-    if payload is None:
-        return None
-    raw_pages = payload.get("pages")
-    if not isinstance(raw_pages, dict):
-        raise AdapterExecutionError(
-            "public web checkpoint pages must be a mapping",
-            error_code="invalid_checkpoint",
-            retryable=False,
-        )
-    pages: dict[str, PageCheckpoint] = {}
-    for raw_url, raw_state in raw_pages.items():
-        if not isinstance(raw_url, str) or not isinstance(raw_state, dict):
-            raise AdapterExecutionError(
-                "public web checkpoint page entries are invalid",
-                error_code="invalid_checkpoint",
-                retryable=False,
-            )
-        content_hash = raw_state.get("content_hash_sha256")
-        version_id = raw_state.get("version_id")
-        canonical_url = raw_state.get("canonical_url")
-        resource_kind = raw_state.get("resource_kind", PublicResourceKind.WEB_PAGE.value)
-        if (
-            not isinstance(content_hash, str)
-            or not isinstance(version_id, str)
-            or not isinstance(canonical_url, str)
-            or not isinstance(resource_kind, str)
-        ):
-            raise AdapterExecutionError(
-                "public web checkpoint page state is invalid",
-                error_code="invalid_checkpoint",
-                retryable=False,
-            )
-        try:
-            pages[raw_url] = PageCheckpoint(
-                content_hash_sha256=content_hash,
-                version_id=UUID(version_id),
-                canonical_url=canonical_url,
-                resource_kind=PublicResourceKind(resource_kind),
-            )
-        except ValueError as exc:
-            raise AdapterExecutionError(
-                "public web checkpoint page state is invalid",
-                error_code="invalid_checkpoint",
-                retryable=False,
-            ) from exc
-    return PublicWebCheckpoint(pages)
-
-
-def _checkpoint_payload(checkpoint: PublicWebCheckpoint) -> dict[str, object]:
-    return {
-        "pages": {
-            url: {
-                "content_hash_sha256": state.content_hash_sha256,
-                "version_id": str(state.version_id),
-                "canonical_url": state.canonical_url,
-                "resource_kind": state.resource_kind.value,
-            }
-            for url, state in sorted(checkpoint.pages.items())
-        }
-    }
 
 
 def _execution_error(

--- a/tests/unit/adapters/public_web/test_incremental_recrawl.py
+++ b/tests/unit/adapters/public_web/test_incremental_recrawl.py
@@ -198,7 +198,7 @@ def _entry() -> SourceRegistryEntry:
             status=SourceStatus.ENABLED,
             source_type=SourceType.STATIC_HTTP,
             owner="Example",
-            terms_url=None,
+            terms_url="https://example.com/terms",
             allowed_data_categories=frozenset(
                 {
                     DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,

--- a/tests/unit/adapters/public_web/test_incremental_recrawl.py
+++ b/tests/unit/adapters/public_web/test_incremental_recrawl.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+import httpx
+
+from cip.adapters.sources.public_web.registry import PublicWebTarget
+from cip.modules.collection_orchestration.application.public_web_adapter import PublicWebAdapter
+from cip.modules.public_footprint.domain import DiscoveryMethod, ResourceRetrievalState
+from cip.modules.source_governance.domain.models import (
+    AuthorizationStatus,
+    DataCategory,
+    SourceAuthorization,
+    SourcePolicy,
+    SourceStatus,
+    SourceType,
+)
+from cip.modules.source_governance.infrastructure.registry import SourceRegistryEntry
+
+_NOW = datetime(2026, 8, 12, 21, 50, tzinfo=UTC)
+_ORG_ID = UUID("44444444-4444-4444-4444-444444444444")
+_SOURCE_ID = "public-web-incremental-test"
+
+
+def test_conditional_recrawl_restores_child_frontier_after_parent_304() -> None:
+    requests: list[tuple[str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        validator = request.headers.get("if-none-match")
+        requests.append((path, validator))
+        if path == "/robots.txt":
+            return _response(request, 200, "text/plain", b"User-agent: *\nAllow: /\n")
+        if path == "/root":
+            if validator == '"root-v1"':
+                return httpx.Response(304, headers={"etag": '"root-v1"'}, request=request)
+            return _response(
+                request,
+                200,
+                "text/html",
+                b'<html><body><a href="/child">child</a></body></html>',
+                etag='"root-v1"',
+            )
+        if path == "/child":
+            if validator == '"child-v1"':
+                return httpx.Response(304, headers={"etag": '"child-v1"'}, request=request)
+            return _response(
+                request,
+                200,
+                "text/html",
+                b"<html><body>child</body></html>",
+                etag='"child-v1"',
+            )
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    adapter = _adapter(handler, discover_feeds=False)
+    first = _collect(adapter, checkpoint=None, when=_NOW)
+    assert len(first.observations) == 2
+    pages = first.checkpoint_payload["pages"]
+    assert isinstance(pages, dict)
+    child = pages["https://example.com/child"]
+    assert isinstance(child, dict)
+    assert child["etag"] == '"child-v1"'
+    assert child["depth"] == 1
+    assert child["discovery_method"] == DiscoveryMethod.LINK.value
+
+    requests.clear()
+    second = _collect(
+        adapter,
+        checkpoint=first.checkpoint_payload,
+        when=_NOW + timedelta(hours=1),
+    )
+    assert second.not_modified is True
+    assert second.observations == ()
+    assert len(second.public_footprint_projections) == 2
+    assert all(
+        projection.resource.retrieval_state is ResourceRetrievalState.NOT_MODIFIED
+        for projection in second.public_footprint_projections
+    )
+    assert ("/root", '"root-v1"') in requests
+    assert ("/child", '"child-v1"') in requests
+
+
+def test_dynamic_feed_refreshes_when_declaring_html_is_304() -> None:
+    feed_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal feed_calls
+        path = request.url.path
+        validator = request.headers.get("if-none-match")
+        if path == "/robots.txt":
+            return _response(request, 200, "text/plain", b"User-agent: *\nAllow: /\n")
+        if path == "/root":
+            if validator == '"root-v1"':
+                return httpx.Response(304, headers={"etag": '"root-v1"'}, request=request)
+            return _response(
+                request,
+                200,
+                "text/html",
+                (
+                    b'<html><head><link rel="alternate" type="application/rss+xml" '
+                    b'href="/feed.xml"></head><body>root</body></html>'
+                ),
+                etag='"root-v1"',
+            )
+        if path == "/feed.xml":
+            feed_calls += 1
+            item = "item-one" if feed_calls == 1 else "item-two"
+            body = (
+                "<rss version=\"2.0\"><channel><title>News</title>"
+                f"<item><title>{item}</title><link>https://example.com/{item}</link></item>"
+                "</channel></rss>"
+            ).encode()
+            return _response(request, 200, "application/rss+xml", body)
+        if path in {"/item-one", "/item-two"}:
+            etag = f'"{path[1:]}-v1"'
+            if validator == etag:
+                return httpx.Response(304, headers={"etag": etag}, request=request)
+            return _response(
+                request,
+                200,
+                "text/html",
+                f"<html><body>{path}</body></html>".encode(),
+                etag=etag,
+            )
+        raise AssertionError(f"unexpected request: {request.url}")
+
+    adapter = _adapter(handler, discover_feeds=True)
+    first = _collect(adapter, checkpoint=None, when=_NOW)
+    assert feed_calls == 1
+    assert first.checkpoint_payload["feed_urls"] == ["https://example.com/feed.xml"]
+
+    second = _collect(
+        adapter,
+        checkpoint=first.checkpoint_payload,
+        when=_NOW + timedelta(hours=1),
+    )
+    assert feed_calls == 2
+    assert any(
+        projection.resource.canonical_url == "https://example.com/item-two"
+        for projection in second.public_footprint_projections
+    )
+    assert len(second.observations) == 1
+
+
+def _adapter(handler: httpx.MockTransportHandler, *, discover_feeds: bool) -> PublicWebAdapter:
+    return PublicWebAdapter(
+        _entry(),
+        _target(discover_feeds=discover_feeds),
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def _collect(
+    adapter: PublicWebAdapter,
+    *,
+    checkpoint: object,
+    when: datetime,
+):
+    assert checkpoint is None or isinstance(checkpoint, dict)
+    return adapter.collect(
+        collection_job_id=uuid4(),
+        checkpoint_payload=checkpoint,
+        collected_at=when,
+        retention_until=when + timedelta(days=30),
+    )
+
+
+def _target(*, discover_feeds: bool) -> PublicWebTarget:
+    return PublicWebTarget(
+        id=_SOURCE_ID,
+        organization_id=_ORG_ID,
+        canonical_name="Example",
+        base_url="https://example.com",
+        sitemap_urls=(),
+        seed_urls=("https://example.com/root",),
+        allowed_path_prefixes=("/",),
+        enabled=True,
+        authorization_reference="approval:test",
+        authorization_reviewed_at=_NOW - timedelta(days=1),
+        authorization_expires_at=_NOW + timedelta(days=30),
+        discover_feeds=discover_feeds,
+        max_link_depth=1,
+        max_pages=6,
+        max_total_bytes=1_000_000,
+        max_resource_bytes=100_000,
+        max_redirects=1,
+    )
+
+
+def _entry() -> SourceRegistryEntry:
+    return SourceRegistryEntry(
+        policy=SourcePolicy(
+            id=_SOURCE_ID,
+            name="Incremental public web test",
+            base_url="https://example.com",
+            status=SourceStatus.ENABLED,
+            source_type=SourceType.STATIC_HTTP,
+            owner="Example",
+            terms_url=None,
+            allowed_data_categories=frozenset(
+                {
+                    DataCategory.OFFICIAL_DOCUMENT_DISCOVERY,
+                    DataCategory.TECHNOLOGY_OBSERVATION,
+                }
+            ),
+            prohibited_data_categories=frozenset(
+                {
+                    DataCategory.CREDENTIAL,
+                    DataCategory.PRIVATE_COMMUNICATION,
+                    DataCategory.PRIVATE_PERSONAL_DATA,
+                    DataCategory.RESTRICTED_CONTENT,
+                    DataCategory.VICTIM_FILE,
+                }
+            ),
+            raw_content_storage=False,
+            human_review_required=False,
+        ),
+        authorization=SourceAuthorization(
+            status=AuthorizationStatus.APPROVED,
+            document_reference="approval:test",
+            reviewed_at=_NOW - timedelta(days=1),
+            expires_at=_NOW + timedelta(days=30),
+            approved_hosts=frozenset({"example.com"}),
+            approved_path_prefixes=("/",),
+            approved_purposes=frozenset({"corporate-public-footprint"}),
+            automated_collection_allowed=True,
+            raw_storage_allowed=False,
+        ),
+        economics={"cost_model": "free"},
+    )
+
+
+def _response(
+    request: httpx.Request,
+    status: int,
+    mime_type: str,
+    body: bytes,
+    *,
+    etag: str | None = None,
+) -> httpx.Response:
+    headers = {"content-type": mime_type}
+    if etag is not None:
+        headers["etag"] = etag
+    return httpx.Response(status, headers=headers, content=body, request=request)


### PR DESCRIPTION
Implement SA16-L04 incremental public-web recrawl on top of merged L03.

Current scope:
- persist ETag/Last-Modified and representation metadata in the durable collection checkpoint;
- send If-None-Match / If-Modified-Since only for the exact previously fetched URL;
- handle real HTTP 304 as NOT_MODIFIED without creating a new raw observation or content version;
- persist and restore recursive page discovery metadata so a 304 parent does not drop known descendants;
- persist dynamically discovered feed URLs so feeds can still refresh when their declaring HTML is 304;
- reuse existing worker SourceHealth/Freshness handling rather than creating a second health system;
- preserve legacy checkpoints without validators/frontier fields.

Still in progress: deterministic tests, controlled real-network 304 proof, exact-head CI/live gates and final documentation. No browser/authenticated acquisition is introduced in L04.