### PR TITLE
SA21: own orphaned source activation recovery

### DIFF
--- a/docs/source_activation/SA_21_HANDOFF_REGISTRY.md
+++ b/docs/source_activation/SA_21_HANDOFF_REGISTRY.md
@@ -1,0 +1,45 @@
+# SA-21 — Handoff Registry
+
+## Canonical ownership amendment
+
+This registry makes the post-SA16 ownership correction explicit without changing the historical truth of SA-00 through SA-20 documents.
+
+The Source Activation Master Plan and SA-15→SA-20 roadmap remain historical/normative context for their original waves. Where they leave a useful unresolved capability without a later named owner, this registry and `SA_21_ORPHANED_SOURCE_ACTIVATION_RECOVERY.md` assign that capability to SA-21.
+
+## Handoffs into SA-21
+
+| Historical owner/state | Capability | SA-21 ownership |
+| --- | --- | --- |
+| SA-02 / SA-15 incomplete | Brave Search | final entitlement/onboarding/live promotion |
+| SA-14 / SA-15 incomplete | Mojeek | final entitlement/storage-rights/live promotion |
+| SA-15 incomplete | Marginalia | commercial activation/live proof |
+| SA-14 / SA-15 incomplete | PatentsView / current USPTO ODP | current contract/provider implementation/live proof |
+| SA-15 incomplete | Google automated search route | legitimate automated route or fully integrated equivalent replacement |
+| SA-15 omitted residual | Bing or independent web search provider | provider selection/implementation/live proof |
+| SA-06 manual | official corporate disclosures | concrete provider/first-party acquisition activation |
+| SA-06 manual | official regulatory change notices | concrete provider/regulator acquisition activation |
+| SA-06 manual | official relationship disclosures | concrete provider/first-party acquisition activation |
+| SA-06 manual | public partner directories | concrete provider activation |
+| SA-06 manual | public case studies | concrete provider/first-party acquisition activation |
+| SA-06 manual | public certificate relationship metadata | relationship-specific activation where semantics are explicit |
+| SA-06 / SA-07 blocked | licensed corporate news metadata | concrete licensed provider activation |
+| SA-07 blocked | commercial licensed dataset | concrete provider decomposition/activation or product-owner exclusion |
+| SA-15 ambiguous with SA-18 | current-generation GDELT | provider activation in SA-21; downstream CTI semantics remain SA-18 |
+
+## GDELT single-owner rule
+
+There is no longer a shared provider-activation responsibility.
+
+**SA-21 is the only Source Activation owner for current-generation GDELT provider integration.** It owns provider contract review, endpoint/product generation, schemas, quotas, storage/use terms, Source Governance, adapter/runtime/checkpoints and controlled real-provider live proof.
+
+**SA-18 is a downstream consumer.** It owns only CTI/news evidence semantics after the SA-21 provider path is available: evidence classification, claim state, source independence, chronology and CTI/ransomware/phishing use.
+
+If a future roadmap sentence says that SA-18 uses current GDELT/news evidence, it must be read as a consumption dependency on SA-21 rather than an authorization for a second GDELT adapter.
+
+## Historical issue disposition
+
+Historical SA-15 issue #115 allowed closure when unresolved dependencies were either genuinely resolved or explicitly handed to a later named SA with their concrete dependency preserved. The handoff to SA-21 / issue #158 satisfies that rule. Issue #115 is therefore closed as a completed handoff, while implementation remains open under #158.
+
+## No silent ownership changes
+
+Future decomposition may split SA-21 into micro-lots, but each capability above must retain a named owner until it reaches a truthful terminal outcome under the current Source Activation completeness definition.

--- a/docs/source_activation/SA_21_MICROLOT_DECOMPOSITION.md
+++ b/docs/source_activation/SA_21_MICROLOT_DECOMPOSITION.md
@@ -1,0 +1,134 @@
+# SA-21 — Initial Microlot Decomposition
+
+## Purpose
+
+This document converts the SA-21 recovery umbrella into independently implementable units without dropping any owned capability.
+
+The decomposition is planning-level. Each microlot must receive its own kickoff, deterministic tests, controlled live proof where legitimate provider access exists, exact-head validation, and closeout before it can be considered complete.
+
+## Search/provider activation microlots
+
+### SA21-L01 — Independent search redundancy
+
+Owns:
+
+- Bing or another approved independent general web-search provider;
+- provider selection and entitlement review;
+- normalized SERP adapter/runtime registration;
+- governed evidence-discovery routing;
+- controlled live proof.
+
+Exit gate: one additional independent general search provider is fully integrated and live-tested, or an explicit product-owner decision records why the capability is excluded.
+
+### SA21-L02 — Brave live completion
+
+Owns final credential/onboarding/live-proof promotion for Brave Search.
+
+Exit gate: legitimate deployment entitlement, secret onboarding, non-empty production-adapter live proof, truthful activation promotion and exact-head CI.
+
+### SA21-L03 — Mojeek live completion
+
+Owns final API entitlement, durable-storage-rights confirmation, onboarding and live-proof promotion.
+
+Exit gate: legitimate provider access and reviewed storage rights are exercised through the production adapter on the exact validated head.
+
+### SA21-L04 — Marginalia commercial activation
+
+Owns commercial entitlement, storage/use rights, Source Governance, approved endpoint scope, secret onboarding and real-provider live proof.
+
+Exit gate: either fully integrated under legitimate commercial rights or explicitly excluded by product-owner decision.
+
+### SA21-L05 — Current USPTO / PatentsView ODP
+
+Owns replacement of the revoked historical PatentsView route with the reviewed current USPTO Open Data Portal contract.
+
+Exit gate: current endpoint/schema/auth/terms are implemented provider-specifically and live-tested; the historical endpoint remains revoked.
+
+### SA21-L06 — Google eligible automated route
+
+Owns one legitimate automated Google route or an explicitly approved fully integrated equivalent replacement.
+
+Exit gate: eligible official API, independently verified provider-authorized browser route, or equivalent canonical replacement is genuinely live; analyst-opened links alone do not satisfy the gate.
+
+### SA21-L07 — Current-generation GDELT provider activation
+
+Owns all provider activation for current-generation GDELT:
+
+- official current contract;
+- endpoint/product generation;
+- schemas/query semantics;
+- quotas/failure behavior;
+- storage/use/retention terms;
+- Source Governance;
+- adapter/runtime/checkpoints;
+- controlled real-provider live proof.
+
+Exit gate: a current provider-specific production path is fully integrated and live-tested, or the capability is explicitly excluded/replaced under the standard terminal outcomes.
+
+Dependency rule: SA-18 may consume GDELT-derived news/CTI evidence only after this microlot establishes the provider path. SA-18 does not own GDELT provider activation.
+
+## Corporate/regulatory/relationship microlots
+
+### SA21-L08 — Corporate and regulatory first-party acquisition
+
+Owns:
+
+- official corporate disclosures;
+- official regulatory change notices.
+
+Work must decompose generic families into concrete first-party/provider-specific acquisition paths and retain analyst review where semantic interpretation is source-specific.
+
+### SA21-L09 — Relationship evidence acquisition
+
+Owns:
+
+- official relationship disclosures;
+- public partner directories;
+- public case studies;
+- public certificate relationship metadata where relationship semantics are explicit.
+
+The microlot must preserve `claimed` versus `contracted/current` truth, chronology and independence. Directory presence, marketing language or certificate issuance alone must not be promoted into current commercial incumbency.
+
+## Licensed-data microlots
+
+### SA21-L10 — Licensed corporate news
+
+Owns concrete licensed corporate-news provider selection, commercial/customer-facing rights, fields, attribution, retention, credentials, quotas, adapter/runtime controls and controlled live proof.
+
+### SA21-L11 — Commercial licensed dataset disposition
+
+Owns decomposition of the historical generic commercial dataset family into concrete useful providers/datasets.
+
+Each selected provider must receive lawful-purpose review, field restrictions, customer-facing rights, retention/deletion rules, adapter/runtime design and live proof. If no concrete useful provider remains justified, the product owner must explicitly exclude the generic family rather than leave it permanently blocked.
+
+## SA21-L12 — Final orphan and ownership audit
+
+After L01-L11 dispositions are complete, generate a machine-derived audit covering all historical Source Activation records and useful OSINT Framework candidates.
+
+Required output fields include:
+
+- canonical capability/provider;
+- historical source/wave;
+- current owner SA/lot;
+- adapter present;
+- authorized deployment path;
+- executable;
+- scheduled/invokable;
+- live tested;
+- remaining prerequisite;
+- terminal disposition;
+- evidence supporting replacement/duplicate/exclusion where applicable.
+
+Exit gate: no useful historical capability remains `manual`, `blocked`, `planned`, adapter-only or otherwise unfinished without an explicit open remediation owner.
+
+## Sequencing
+
+Recommended order:
+
+1. L01 independent search redundancy;
+2. L02-L07 provider-specific search/news recovery based on legitimate prerequisite availability;
+3. L08-L09 corporate/regulatory/relationship provider decomposition;
+4. L10-L11 licensed-provider decisions and activation;
+5. L12 final orphan audit.
+
+Provider prerequisite availability may change the execution order, but it must not remove or silently close any item.

--- a/docs/source_activation/SA_21_ORPHANED_SOURCE_ACTIVATION_RECOVERY.md
+++ b/docs/source_activation/SA_21_ORPHANED_SOURCE_ACTIVATION_RECOVERY.md
@@ -1,0 +1,177 @@
+# SA-21 — Orphaned Source Activation Recovery
+
+## Purpose
+
+SA-21 owns useful Source Activation work that remained unfinished after historical SA closeouts and was not given an explicit future Source Activation owner in SA-17 through SA-20.
+
+This SA exists to eliminate ownership gaps. It does not weaken provider authorization, commercial, security, evidence, or live-validation requirements. A missing key, entitlement, provider permission, stable contract, target, account, or deployment configuration remains unfinished work until resolved, replaced by an equivalent fully integrated canonical source, or explicitly excluded by product-owner decision.
+
+## Scope boundary
+
+SA-21 is a recovery/ownership wave. It owns only the orphaned or ambiguously handed-off capabilities listed below.
+
+It does not reopen capabilities already explicitly owned by SA-17, SA-18, SA-19, or SA-20.
+
+## Search and deferred-provider recovery
+
+SA-21 owns final activation for the following search/deferred-provider capabilities that remain incomplete after SA-15 and have no later explicit Source Activation owner:
+
+1. **Brave Search API**
+   - provision legitimate deployment subscription/token;
+   - complete Provider Onboarding and secret configuration;
+   - run controlled non-empty production-adapter live validation;
+   - promote activation state only on the exact validated final SHA.
+
+2. **Mojeek Web Search**
+   - provision legitimate API access;
+   - confirm durable-result-storage rights for the metadata CIP persists;
+   - complete Provider Onboarding/secret configuration;
+   - run controlled non-empty production-adapter live validation.
+
+3. **Marginalia Search**
+   - obtain legitimate commercial entitlement;
+   - record reviewed commercial-use/storage rights;
+   - configure approved host/path/purpose and Provider Onboarding secret references;
+   - run controlled non-empty production-adapter live validation.
+
+4. **PatentsView / current USPTO Open Data Portal route**
+   - do not revive or relabel the historical revoked `search.patentsview.org` route;
+   - review the current USPTO/ODP endpoint, authentication model, schemas, quotas, terms and retention rules;
+   - implement the current provider-specific adapter/runtime/checkpoint path;
+   - run controlled non-empty exact-head live validation.
+
+5. **Google automated search route**
+   - close through one legitimate provider-approved route only:
+     - eligible official API entitlement; or
+     - explicit independently verified provider-authorized browser automation route; or
+     - approved equivalent canonical replacement whose own capability is fully integrated and live-tested;
+   - analyst-opened Google links do not count as automated provider live proof.
+
+6. **Bing or another approved independent general web-search provider**
+   - select a concrete provider that is genuinely independent of the existing canonical search routes;
+   - document provider terms, storage/retention rights, credentials, quotas and governance;
+   - implement provider-specific normalized SERP adapter/runtime registration;
+   - feed governed evidence-discovery routing;
+   - obtain controlled production-adapter live proof.
+
+## Corporate, regulatory and relationship acquisition recovery
+
+SA-21 also owns the provider-specific activation path for useful SA-06 families that historically remained `manual` and were never assigned a later Source Activation owner.
+
+A family placeholder itself must not become an executable generic endpoint. SA-21 must select concrete providers or first-party acquisition contracts where useful.
+
+7. **Official corporate disclosures**
+   - define concrete first-party/provider-specific discovery and acquisition paths;
+   - retain analyst review where semantics are provider/company-specific;
+   - preserve Lot 18 corporate-change evidence boundaries;
+   - live-validate any executable production acquisition path introduced.
+
+8. **Official regulatory change notices**
+   - identify concrete regulator/provider records for material regulatory-change intelligence outside incident-only CTI scope;
+   - implement provider-specific governed acquisition where useful;
+   - preserve evidence class and chronology;
+   - run controlled live proof for executable providers.
+
+9. **Official relationship disclosures**
+   - define concrete first-party/provider-specific acquisition routes;
+   - preserve `claimed` versus `contracted/current` relationship truth;
+   - live-validate executable production paths.
+
+10. **Public partner directories**
+    - select useful concrete partner-directory providers;
+    - implement governed acquisition and canonical relationship-evidence mapping;
+    - do not infer current commercial contracts from directory presence alone;
+    - run controlled live proof.
+
+11. **Public case studies**
+    - select useful concrete first-party/provider-specific sources;
+    - implement bounded acquisition and chronology/version handling;
+    - preserve historical-versus-current relationship semantics;
+    - run controlled live proof for executable providers.
+
+12. **Public certificate relationship metadata**
+    - define the narrow cases where certificate material has explicit relationship semantics;
+    - keep technical certificate telemetry under SA-17 and relationship interpretation under this SA;
+    - require review and independent evidence where certificate issuance alone is insufficient;
+    - live-validate any executable relationship-specific path.
+
+## Licensed corporate/news and dataset recovery
+
+13. **Licensed corporate news metadata**
+    - select one or more concrete licensed provider(s) where product value justifies it;
+    - establish customer-facing use, storage, redistribution, attribution and retention rights;
+    - implement provider-specific adapter/runtime/secret/quota controls;
+    - run controlled live proof before activation promotion.
+
+14. **Commercial licensed dataset**
+    - decompose the historical generic family into concrete provider-specific datasets only where useful;
+    - document lawful purpose, permitted fields, customer-facing rights, storage/retention, quotas and deletion obligations;
+    - implement and live-test each approved concrete provider;
+    - otherwise explicitly exclude the generic family by product-owner decision rather than leaving it permanently blocked.
+
+## GDELT handoff clarification
+
+15. **GDELT current-generation provider activation** is owned by **SA-21**, not SA-18.
+
+The responsibility split is explicit:
+
+- **SA-21 owns provider activation**: current official contract review, exact endpoint/product generation, schemas, quotas, storage/use terms, Source Governance, adapter/runtime/checkpoints and controlled real-provider live proof.
+- **SA-18 owns CTI/news consumption semantics only after SA-21 activation**: incident/news evidence classification, claim-state handling, source independence, chronology and downstream CTI/ransomware/phishing use.
+
+SA-18 must not implement a separate GDELT provider adapter, relabel a historical GDELT endpoint as current generation, or claim GDELT live integration before SA-21 closes the provider activation path.
+
+The historical SA-15 GDELT dependency is therefore handed forward to SA-21 and should no longer be described as ambiguously shared with SA-18.
+
+## Explicit non-scope
+
+The following remain owned by their already assigned waves and are not SA-21 work:
+
+- SA-17: DNS/CT/RDAP passive infrastructure, Shodan/Censys/SecurityTrails/urlscan/VirusTotal/GreyNoise/AbuseIPDB/Spamhaus/Wappalyzer/BuiltWith/HTTP Archive/licensed passive providers and local OSINT frameworks;
+- SA-18: vulnerability, CERT/vendor advisory, incident, ransomware, phishing, malware/IOC and CTI consumption semantics;
+- SA-19: LinkedIn, Reddit, Discord, BrixHub and professional/community providers;
+- SA-20: document/media expansion, developer ecosystems and residual identity/procurement/ATS live proof.
+
+## Mandatory decomposition
+
+SA-21 is an ownership umbrella and must be decomposed into independently implementable micro-lots before substantive provider coding. Each micro-lot should own one coherent vertical capability and one exact exit gate.
+
+Suggested decomposition:
+
+- SA21-L01: second independent search provider selection + adapter/live proof;
+- SA21-L02: Brave final live promotion;
+- SA21-L03: Mojeek final live promotion;
+- SA21-L04: Marginalia commercial activation;
+- SA21-L05: current USPTO/PatentsView ODP implementation;
+- SA21-L06: Google eligible automated route;
+- SA21-L07: current GDELT provider activation;
+- SA21-L08+: concrete corporate/regulatory/relationship provider activations;
+- final SA21 closeout: licensed corporate news/commercial dataset decisions and machine-derived orphan audit.
+
+The decomposition may change as provider prerequisites are resolved, but no item in this SA may silently disappear.
+
+## Exit gate
+
+SA-21 may close only when all fifteen owned items have exactly one truthful terminal outcome:
+
+1. fully integrated through a real production path and controlled live proof;
+2. replaced by a demonstrably equivalent fully integrated canonical capability;
+3. duplicate of a fully integrated canonical capability; or
+4. explicitly excluded from product scope by product-owner decision.
+
+The following are not terminal completion states for a useful SA-21 item:
+
+- missing API key;
+- missing paid entitlement;
+- missing provider permission;
+- missing deployment account/target;
+- `manual` fallback without an explicit manual-only product decision;
+- `blocked` prerequisite;
+- adapter-only readiness;
+- deterministic/mock CI without provider live proof;
+- an issue or documentation note without an executable owner.
+
+Before closeout, generate a machine-derived orphan audit proving that no useful historical Source Activation capability remains without a named remediation SA/lot.
+
+## Validation requirements
+
+Every implementation micro-lot must satisfy repository standards, including deterministic network-free unit tests, provider contract fixtures, architecture checks, complete backend regression coverage requirements, controlled live validation through production adapters after legitimate authorization, exact-final-SHA validation, and no unresolved review blockers before merge.

--- a/docs/source_activation/SA_21_STATUS.md
+++ b/docs/source_activation/SA_21_STATUS.md
@@ -1,0 +1,17 @@
+# SA-21 Status
+
+Status: planning/ownership wave created; implementation not started.
+
+Tracking issue: #158.
+
+Planning PR: #159.
+
+Canonical scope:
+
+- `SA_21_ORPHANED_SOURCE_ACTIVATION_RECOVERY.md`
+- `SA_21_HANDOFF_REGISTRY.md`
+- `SA_21_MICROLOT_DECOMPOSITION.md`
+
+Current rule: SA-21 owns provider activation for all listed orphaned capabilities, including current-generation GDELT. SA-18 consumes GDELT only downstream after SA-21 activation.
+
+No provider activation stage is promoted by these planning documents. Substantive implementation remains open under SA21-L01 through L12 and must satisfy exact-head CI/live-proof requirements where applicable.


### PR DESCRIPTION
## What changed

- adds `SA_21_ORPHANED_SOURCE_ACTIVATION_RECOVERY.md` as the explicit owner for the 14 orphaned Source Activation items plus current-generation GDELT;
- adds `SA_21_HANDOFF_REGISTRY.md` to preserve the exact historical-to-SA21 ownership transfer and prevent future ambiguity;
- adds `SA_21_MICROLOT_DECOMPOSITION.md` with an initial L01-L12 implementation decomposition so the recovery wave is actionable rather than only documentary;
- adds `SA_21_STATUS.md` recording that this PR creates planning/ownership only and does not promote provider activation stages;
- assigns a truthful terminal exit rule instead of allowing permanent `manual`, `blocked`, missing-key, missing-entitlement or adapter-only states;
- explicitly gives SA-21 ownership of the previously omitted Bing/independent-search requirement;
- clarifies GDELT ownership with a single-owner rule: SA-21 owns provider activation; SA-18 is downstream CTI/news semantics only after activation;
- creates tracking issue #158 for the complete SA-21 scope;
- records the explicit handoff on historical SA-15 issue #115 and closes #115 because its own exit condition permits closure after transfer to a later named SA.

## Why

The post-SA16 orphan audit found useful capabilities that were unfinished but had no explicit SA17-SA20 remediation owner. That violates the current Source Activation completion principle requiring every useful unresolved capability to retain an implementation owner and activation path.

## Scope

This PR is planning/ownership clarification only. It does not fabricate provider credentials, entitlements, contracts, permissions or live proofs, and it does not promote any provider activation state.

## Follow-up

Implement SA21-L01 through L12 as independently validated microlots. Provider-specific implementation lots retain exact-head CI and controlled provider-live-proof requirements.